### PR TITLE
fix(core): fix proxy model resolution, auth header injection, and model alias fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ref
+.ref/
+
 # Dependencies
 node_modules/
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -16,6 +16,7 @@ export interface ProviderConfigFile {
   baseUrl?: string;
   apiKey?: string;
   model?: string;
+  headers?: Record<string, string>;
 }
 
 /** Agent configuration in config file */

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -14,18 +14,32 @@ const mockAgent = {
   followUp: vi.fn(),
 };
 
+function createDefaultMockModel() {
+  return {
+    id: "claude-sonnet-4-20250514",
+    name: "Claude Sonnet 4",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+    contextWindow: 200000,
+    maxTokens: 64000,
+  };
+}
+
 vi.mock("@mariozechner/pi-agent-core", () => ({
   Agent: vi.fn(() => mockAgent),
 }));
 
 vi.mock("@mariozechner/pi-ai", () => ({
-  getModel: vi.fn().mockReturnValue({
-    provider: "anthropic",
-    modelId: "claude-sonnet-4-20250514",
-  }),
+  getModel: vi.fn().mockImplementation(() => createDefaultMockModel()),
 }));
 
 // Import after mocks
+import { Agent } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
 import { PiMonoCore } from "./pi-mono.js";
 
 // ---------------------------------------------------------------------------
@@ -47,6 +61,7 @@ function resetMocks() {
   mockAgent.abort.mockClear();
   mockAgent.steer.mockClear();
   mockAgent.followUp.mockClear();
+  vi.mocked(getModel).mockReset().mockImplementation((() => createDefaultMockModel()) as unknown as typeof getModel);
 }
 
 // ---------------------------------------------------------------------------
@@ -95,6 +110,155 @@ describe("PiMonoCore.createAgent", () => {
 
     expect(mockAgent.followUp).toHaveBeenCalledWith(
       expect.objectContaining({ role: "user", content: "follow up" }),
+    );
+  });
+
+  it("preserves api metadata when overriding baseUrl for proxy providers", () => {
+    const proxiedModel = Object.create(null, {
+      id: { value: "claude-opus-4.5", enumerable: true },
+      name: { value: "Claude Opus 4.5", enumerable: true },
+      api: { value: "anthropic-messages", enumerable: false },
+      provider: { value: "anthropic", enumerable: false },
+      baseUrl: { value: "https://api.anthropic.com", enumerable: true },
+      reasoning: { value: true, enumerable: true },
+      input: { value: ["text", "image"], enumerable: true },
+      cost: {
+        value: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        enumerable: true,
+      },
+      contextWindow: { value: 200000, enumerable: true },
+      maxTokens: { value: 64000, enumerable: true },
+    });
+
+    vi.mocked(getModel).mockReturnValueOnce(proxiedModel);
+
+    const core = new PiMonoCore();
+    core.createAgent(
+      makeConfig({
+        provider: {
+          type: "anthropic-proxy",
+          baseUrl: "https://copilot-portal.azurewebsites.net",
+          model: "claude-opus-4.5",
+        },
+      }),
+    );
+
+    expect(vi.mocked(Agent)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialState: expect.objectContaining({
+          model: expect.objectContaining({
+            id: "claude-opus-4.5",
+            api: "anthropic-messages",
+            provider: "anthropic",
+            baseUrl: "https://copilot-portal.azurewebsites.net",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("injects Authorization header for anthropic proxy providers", () => {
+    const core = new PiMonoCore();
+    core.createAgent(
+      makeConfig({
+        provider: {
+          type: "anthropic-proxy",
+          baseUrl: "https://copilot-portal.azurewebsites.net",
+          model: "claude-opus-4.5",
+          apiKey: "proxy-token",
+        },
+      }),
+    );
+
+    expect(vi.mocked(Agent)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialState: expect.objectContaining({
+          model: expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: "Bearer proxy-token",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("merges configured proxy headers with existing model headers", () => {
+    vi.mocked(getModel).mockImplementationOnce((() => ({
+      ...createDefaultMockModel(),
+      headers: { "X-Model-Header": "base" },
+    })) as unknown as typeof getModel);
+
+    const core = new PiMonoCore();
+    core.createAgent(
+      makeConfig({
+        provider: {
+          type: "anthropic-proxy",
+          baseUrl: "https://copilot-portal.azurewebsites.net",
+          model: "claude-opus-4.5",
+          apiKey: "proxy-token",
+          headers: { "X-Proxy-Header": "override" },
+        },
+      }),
+    );
+
+    expect(vi.mocked(Agent)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialState: expect.objectContaining({
+          model: expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: "Bearer proxy-token",
+              "X-Model-Header": "base",
+              "X-Proxy-Header": "override",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("falls back to canonical anthropic model metadata for dotted proxy model ids", () => {
+    vi.mocked(getModel).mockImplementation(((provider: string, modelId: string) => {
+      if (provider === "anthropic" && modelId === "claude-opus-4-5") {
+        return {
+          id: "claude-opus-4-5",
+          name: "Claude Opus 4.5 (latest)",
+          api: "anthropic-messages",
+          provider: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+          contextWindow: 200000,
+          maxTokens: 64000,
+        };
+      }
+
+      return undefined;
+    }) as typeof getModel);
+
+    const core = new PiMonoCore();
+    core.createAgent(
+      makeConfig({
+        provider: {
+          type: "anthropic-proxy",
+          baseUrl: "https://copilot-portal.azurewebsites.net",
+          model: "claude-opus-4.5",
+        },
+      }),
+    );
+
+    expect(vi.mocked(Agent)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialState: expect.objectContaining({
+          model: expect.objectContaining({
+            id: "claude-opus-4.5",
+            api: "anthropic-messages",
+            provider: "anthropic",
+            baseUrl: "https://copilot-portal.azurewebsites.net",
+          }),
+        }),
+      }),
     );
   });
 });

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -21,20 +21,67 @@ import type {
 // Default model — used when no provider config is specified
 const DEFAULT_MODEL = "claude-opus-4.5";
 
+function cloneModel<TApi extends Api>(
+  model: Model<TApi>,
+  overrides: Partial<Pick<Model<TApi>, "id" | "name" | "baseUrl" | "headers">>,
+): Model<TApi> {
+  return {
+    id: overrides.id ?? model.id,
+    name: overrides.name ?? model.name,
+    api: model.api,
+    provider: model.provider,
+    baseUrl: overrides.baseUrl ?? model.baseUrl,
+    reasoning: model.reasoning,
+    input: [...model.input],
+    cost: { ...model.cost },
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens,
+    ...((model.headers || overrides.headers)
+      ? { headers: { ...(model.headers ?? {}), ...(overrides.headers ?? {}) } }
+      : {}),
+    ...(model.compat ? { compat: model.compat } : {}),
+  };
+}
+
+function resolveKnownModel(
+  provider: Parameters<typeof getModel>[0],
+  modelId: string,
+): Model<Api> {
+  const model = getModel(provider, modelId as Parameters<typeof getModel>[1]) as Model<Api> | undefined;
+  if (model) return model;
+
+  // For Anthropic, try dashed variant (e.g. claude-opus-4.5 → claude-opus-4-5)
+  if (provider === "anthropic") {
+    const dashed = modelId.replace(/(claude-(?:opus|sonnet|haiku)-\d)\.(\d)/g, "$1-$2");
+    if (dashed !== modelId) {
+      const aliased = getModel(provider, dashed as Parameters<typeof getModel>[1]) as Model<Api> | undefined;
+      if (aliased) return aliased;
+    }
+  }
+
+  throw new Error(`Unknown ${provider} model: ${modelId}`);
+}
+
 /** Resolve a pi-ai Model from our ProviderConfig. */
 function resolveModel(config: AgentConfig): Model<Api> {
   const p = config.provider;
-  if (!p) {
-    // sensible default
-    return getModel("anthropic", DEFAULT_MODEL as Parameters<typeof getModel>[1]) as Model<Api>;
+  const provider = (p?.type.replace(/-proxy$/, "") ?? "anthropic") as Parameters<typeof getModel>[0];
+  const modelId = p?.model ?? DEFAULT_MODEL;
+  const model = resolveKnownModel(provider, modelId);
+
+  // Build proxy headers (Authorization injection for anthropic-proxy)
+  const proxyHeaders = { ...(p?.headers ?? {}) };
+  if (p?.type === "anthropic-proxy" && p.apiKey) {
+    proxyHeaders.Authorization ??= `Bearer ${p.apiKey}`;
   }
-  const provider = p.type.replace(/-proxy$/, "") as Parameters<typeof getModel>[0];
-  const modelId = (p.model ?? DEFAULT_MODEL) as Parameters<typeof getModel>[1];
-  const model = getModel(provider, modelId) as Model<Api>;
-  if (p.baseUrl) {
-    // Override baseUrl for proxy setups
-    return { ...model, baseUrl: p.baseUrl };
+  const headers = Object.keys(proxyHeaders).length > 0
+    ? { ...(model.headers ?? {}), ...proxyHeaders }
+    : undefined;
+
+  if (p?.baseUrl || headers) {
+    return cloneModel(model, { id: modelId, baseUrl: p?.baseUrl, headers });
   }
+
   return model;
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,6 +48,7 @@ export interface ProviderConfig {
   baseUrl?: string;
   apiKey?: string;
   model?: string;
+  headers?: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix three bugs in `pi-mono.ts` that prevented Anthropic proxy providers from working correctly.

## Bug Fixes

### 1. Non-enumerable model metadata lost during spread copy
`getModel()` from pi-ai returns model objects where `api` and `provider` fields are non-enumerable. The original code used object spread (`{ ...model, baseUrl }`) which silently dropped these fields, causing `No API provider registered for api: undefined` errors.

**Fix:** Added `cloneModel()` that explicitly copies all fields including non-enumerable ones.

### 2. Missing Authorization header for proxy endpoints
The Anthropic SDK natively sends `x-api-key` for authentication, but proxy endpoints expect `Authorization: Bearer <token>`. This caused `401 Missing or malformed Authorization header` errors.

**Fix:** For `anthropic-proxy` provider type, automatically inject `Authorization: Bearer <apiKey>` via `model.headers`, which pi-ai merges into the SDK's `defaultHeaders`.

### 3. Model alias resolution for dotted IDs
Config values like `claude-opus-4.5` failed because pi-ai's model registry uses dashed IDs (`claude-opus-4-5`).

**Fix:** `resolveKnownModel()` tries the original ID first, then falls back to a dashed variant for Anthropic models.

## Other Changes
- Added optional `headers` field to `ProviderConfig` / `ProviderConfigFile` for custom proxy header overrides
- Added `.ref/` to `.gitignore`
