### PR TITLE
Improve session persistence and recovery

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,7 @@ async function main() {
   // Load config from fixed path
   const configPath = getConfigPath();
   logger.info(`Loading config from ${configPath}`);
-  
+
   const config = await loadConfig(configPath);
   logger.info(`Loaded ${config.agents.length} agent(s)`);
 
@@ -96,21 +96,29 @@ async function main() {
 
     // Create session store per agent (sessions live in workspace)
     const sessionStores = new Map<string, DefaultSessionStore>();
-    
+
     for (const agentFile of config.agents) {
       const sessionsDir = getSessionsDir(agentFile.id);
       sessionStores.set(agentFile.id, new DefaultSessionStore({ dataDir: sessionsDir }));
     }
 
+    await Promise.all([...sessionStores.values()].map((store) => store.init()));
+
     // Use first agent's session store as default
     const defaultAgentId = config.discord.defaultAgentId || config.agents[0]?.id;
-    const defaultSessionStore = sessionStores.get(defaultAgentId) || 
-      new DefaultSessionStore({ dataDir: getSessionsDir(defaultAgentId || "default") });
+    let defaultSessionStore = sessionStores.get(defaultAgentId);
+    if (!defaultSessionStore) {
+      defaultSessionStore = new DefaultSessionStore({
+        dataDir: getSessionsDir(defaultAgentId || "default"),
+      });
+      await defaultSessionStore.init();
+    }
 
     const discord = new DiscordTransport({
       token,
       agentManager,
       sessionStore: defaultSessionStore,
+      sessionStoreForAgent: (agentId) => sessionStores.get(agentId) || defaultSessionStore,
       defaultAgentId,
       agentBindings: config.discord.agentBindings,
       allowDMs: config.discord.allowDMs,

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -301,6 +301,33 @@ describe("prompt() event mapping", () => {
     expect(events).toContainEqual({ type: "turn_start" });
   });
 
+  it("maps prompt history messages to content blocks", async () => {
+    setupEvents([]);
+    const core = new PiMonoCore();
+    const instance = core.createAgent(makeConfig());
+
+    for await (const _ev of instance.prompt([
+      { role: "user", content: "hello", timestamp: 1000 },
+      { role: "assistant", content: "hi there", timestamp: 2000 },
+      { role: "tool_result", content: "tool output", timestamp: 3000 },
+    ])) {
+      void _ev;
+    }
+
+    expect(mockAgent.prompt).toHaveBeenCalledWith([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1000,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "hi there" }],
+        timestamp: 2000,
+      },
+    ]);
+  });
+
   it("maps turn_end", async () => {
     const events = await collectEvents([
       { type: "turn_end", message: {}, toolResults: [] },

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -41,6 +41,7 @@ vi.mock("@mariozechner/pi-ai", () => ({
 import { Agent } from "@mariozechner/pi-agent-core";
 import { getModel } from "@mariozechner/pi-ai";
 import { PiMonoCore } from "./pi-mono.js";
+import { textContent } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -92,24 +93,24 @@ describe("PiMonoCore.createAgent", () => {
   it("steer() delegates to the underlying Agent with mapped message", () => {
     const core = new PiMonoCore();
     const instance = core.createAgent(makeConfig());
-    const msg: Message = { role: "user", content: "hi", timestamp: 5000 };
+    const msg: Message = { role: "user", content: textContent("hi"), timestamp: 5000 };
 
     instance.steer(msg);
 
     expect(mockAgent.steer).toHaveBeenCalledWith(
-      expect.objectContaining({ role: "user", content: "hi", timestamp: 5000 }),
+      expect.objectContaining({ role: "user", content: textContent("hi"), timestamp: 5000 }),
     );
   });
 
   it("followUp() delegates to the underlying Agent with mapped message", () => {
     const core = new PiMonoCore();
     const instance = core.createAgent(makeConfig());
-    const msg: Message = { role: "user", content: "follow up" };
+    const msg: Message = { role: "user", content: textContent("follow up") };
 
     instance.followUp(msg);
 
     expect(mockAgent.followUp).toHaveBeenCalledWith(
-      expect.objectContaining({ role: "user", content: "follow up" }),
+      expect.objectContaining({ role: "user", content: textContent("follow up") }),
     );
   });
 
@@ -307,9 +308,13 @@ describe("prompt() event mapping", () => {
     const instance = core.createAgent(makeConfig());
 
     for await (const _ev of instance.prompt([
-      { role: "user", content: "hello", timestamp: 1000 },
-      { role: "assistant", content: "hi there", timestamp: 2000 },
-      { role: "tool_result", content: "tool output", timestamp: 3000 },
+      { role: "user", content: textContent("hello"), timestamp: 1000 },
+      { role: "assistant", content: textContent("hi there"), timestamp: 2000 },
+      {
+        role: "tool_result",
+        content: [{ type: "tool_result", output: "tool output", toolCallId: "call-1", toolName: "readFile" }],
+        timestamp: 3000,
+      },
     ])) {
       void _ev;
     }
@@ -317,13 +322,20 @@ describe("prompt() event mapping", () => {
     expect(mockAgent.prompt).toHaveBeenCalledWith([
       {
         role: "user",
-        content: [{ type: "text", text: "hello" }],
+        content: textContent("hello"),
         timestamp: 1000,
       },
       {
         role: "assistant",
-        content: [{ type: "text", text: "hi there" }],
+        content: textContent("hi there"),
         timestamp: 2000,
+      },
+      {
+        role: "toolResult",
+        content: "tool output",
+        timestamp: 3000,
+        toolCallId: "call-1",
+        toolName: "readFile",
       },
     ]);
   });
@@ -388,7 +400,13 @@ describe("prompt() event mapping", () => {
         messages: [
           { role: "user", content: "hi", timestamp: 1000 },
           { role: "assistant", content: "hello", timestamp: 2000 },
-          { role: "toolResult", content: "result data", timestamp: 3000 },
+          {
+            role: "toolResult",
+            content: "result data",
+            timestamp: 3000,
+            toolCallId: "call-2",
+            toolName: "readFile",
+          },
         ],
       },
     ]);
@@ -398,8 +416,13 @@ describe("prompt() event mapping", () => {
     expect(agentEnd.type).toBe("agent_end");
     expect(agentEnd.messages).toHaveLength(3);
     expect(agentEnd.messages[0].role).toBe("user");
+    expect(agentEnd.messages[0].content).toEqual(textContent("hi"));
     expect(agentEnd.messages[1].role).toBe("assistant");
+    expect(agentEnd.messages[1].content).toEqual(textContent("hello"));
     expect(agentEnd.messages[2].role).toBe("tool_result");
+    expect(agentEnd.messages[2].content).toEqual([
+      { type: "text", text: "result data" },
+    ]);
   });
 
   it("maps agent_end error metadata from assistant message", async () => {
@@ -478,7 +501,7 @@ describe("Message conversion", () => {
   it("maps user role to user", () => {
     const core = new PiMonoCore();
     const instance = core.createAgent(makeConfig());
-    instance.steer({ role: "user", content: "hi" });
+    instance.steer({ role: "user", content: textContent("hi") });
 
     expect(mockAgent.steer).toHaveBeenCalledWith(
       expect.objectContaining({ role: "user" }),
@@ -488,7 +511,7 @@ describe("Message conversion", () => {
   it("maps assistant role to assistant", () => {
     const core = new PiMonoCore();
     const instance = core.createAgent(makeConfig());
-    instance.steer({ role: "assistant", content: "hey" });
+    instance.steer({ role: "assistant", content: textContent("hey") });
 
     expect(mockAgent.steer).toHaveBeenCalledWith(
       expect.objectContaining({ role: "assistant" }),
@@ -498,10 +521,13 @@ describe("Message conversion", () => {
   it("maps tool_result role to toolResult", () => {
     const core = new PiMonoCore();
     const instance = core.createAgent(makeConfig());
-    instance.steer({ role: "tool_result", content: "output" });
+    instance.steer({
+      role: "tool_result",
+      content: [{ type: "tool_result", output: "output", toolCallId: "call-3", toolName: "runTool" }],
+    });
 
     expect(mockAgent.steer).toHaveBeenCalledWith(
-      expect.objectContaining({ role: "toolResult" }),
+      expect.objectContaining({ role: "toolResult", content: "output", toolCallId: "call-3", toolName: "runTool" }),
     );
   });
 
@@ -511,7 +537,7 @@ describe("Message conversion", () => {
 
     const core = new PiMonoCore();
     const instance = core.createAgent(makeConfig());
-    instance.steer({ role: "user", content: "test" });
+    instance.steer({ role: "user", content: textContent("test") });
 
     expect(mockAgent.steer).toHaveBeenCalledWith(
       expect.objectContaining({ timestamp: now }),

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -12,7 +12,9 @@ import type {
   AgentEvent,
   AgentInstance,
   Message,
+  MessageContentBlock,
 } from "./types.js";
+import { messageContentToPlainText, textContent } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -96,24 +98,25 @@ function toAgentMessage(msg: Message): AgentMessage {
     tool_result: "toolResult",
   };
   const role = roleMap[msg.role] ?? msg.role;
+
+  if (role === "toolResult") {
+    const toolResult = msg.content.find(
+      (block): block is Extract<MessageContentBlock, { type: "tool_result" }> =>
+        block.type === "tool_result",
+    );
+    return {
+      role,
+      content: toolResult?.output ?? messageContentToPlainText(msg.content),
+      timestamp: msg.timestamp ?? Date.now(),
+      ...(toolResult?.toolCallId ? { toolCallId: toolResult.toolCallId } : {}),
+      ...(toolResult?.toolName ? { toolName: toolResult.toolName } : {}),
+      ...(toolResult?.isError !== undefined ? { isError: toolResult.isError } : {}),
+    } as unknown as AgentMessage;
+  }
+
   return {
     role,
     content: msg.content,
-    timestamp: msg.timestamp ?? Date.now(),
-  } as AgentMessage;
-}
-
-function toPromptHistoryAgentMessage(msg: Message): AgentMessage {
-  const roleMap: Record<string, string> = {
-    user: "user",
-    assistant: "assistant",
-    tool_result: "toolResult",
-  };
-  const role = roleMap[msg.role] ?? msg.role;
-
-  return {
-    role,
-    content: [{ type: "text", text: msg.content }],
     timestamp: msg.timestamp ?? Date.now(),
   } as AgentMessage;
 }
@@ -147,12 +150,57 @@ function fromAgentMessage(msg: AgentMessage): Message {
     }
     return {
       role: roleMap[m.role] ?? "assistant",
-      content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+      content: normalizeContentBlocks(m.content),
       timestamp: typeof m.timestamp === "number" ? m.timestamp : Date.now(),
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
     };
   }
-  return { role: "assistant", content: String(msg), timestamp: Date.now() };
+  return { role: "assistant", content: textContent(String(msg)), timestamp: Date.now() };
+}
+
+function normalizeContentBlocks(content: unknown): MessageContentBlock[] {
+  if (typeof content === "string") {
+    return textContent(content);
+  }
+
+  if (Array.isArray(content)) {
+    const blocks: MessageContentBlock[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+
+      const typed = block as {
+        type?: unknown;
+        text?: unknown;
+        output?: unknown;
+        isError?: unknown;
+        toolCallId?: unknown;
+        toolName?: unknown;
+      };
+
+      if (typed.type === "text" && typeof typed.text === "string") {
+        blocks.push({ type: "text", text: typed.text });
+        continue;
+      }
+
+      if (typed.type === "tool_result" && typeof typed.output === "string") {
+        blocks.push({
+          type: "tool_result",
+          output: typed.output,
+          ...(typeof typed.isError === "boolean" ? { isError: typed.isError } : {}),
+          ...(typeof typed.toolCallId === "string" ? { toolCallId: typed.toolCallId } : {}),
+          ...(typeof typed.toolName === "string" ? { toolName: typed.toolName } : {}),
+        });
+      }
+    }
+
+    if (blocks.length > 0) {
+      return blocks;
+    }
+  }
+
+  return textContent(JSON.stringify(content));
 }
 
 function getAgentEndMetadata(messages: Message[]): {
@@ -215,11 +263,7 @@ class PiMonoInstance implements AgentInstance {
     const done = (
       typeof input === "string"
         ? this.agent.prompt(input)
-        : this.agent.prompt(
-            input
-              .filter((message) => message.role === "user" || message.role === "assistant")
-              .map(toPromptHistoryAgentMessage),
-          )
+        : this.agent.prompt(input.map(toAgentMessage))
     ).then(() => {
       events.push(null); // sentinel
       resolve?.();

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -103,6 +103,21 @@ function toAgentMessage(msg: Message): AgentMessage {
   } as AgentMessage;
 }
 
+function toPromptHistoryAgentMessage(msg: Message): AgentMessage {
+  const roleMap: Record<string, string> = {
+    user: "user",
+    assistant: "assistant",
+    tool_result: "toolResult",
+  };
+  const role = roleMap[msg.role] ?? msg.role;
+
+  return {
+    role,
+    content: [{ type: "text", text: msg.content }],
+    timestamp: msg.timestamp ?? Date.now(),
+  } as AgentMessage;
+}
+
 /**
  * Convert a pi-agent-core AgentMessage to our Message.
  * Role mapping: pi-agent-core `toolResult` → our `tool_result`
@@ -200,7 +215,11 @@ class PiMonoInstance implements AgentInstance {
     const done = (
       typeof input === "string"
         ? this.agent.prompt(input)
-        : this.agent.prompt(input.map(toAgentMessage))
+        : this.agent.prompt(
+            input
+              .filter((message) => message.role === "user" || message.role === "assistant")
+              .map(toPromptHistoryAgentMessage),
+          )
     ).then(() => {
       events.push(null); // sentinel
       resolve?.();

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -46,6 +46,30 @@ describe("DefaultSessionStore", () => {
       expect(session.metadata?.channelId).toBe("123456");
     });
 
+    it("stores session key in metadata", async () => {
+      const session = await store.create("agent-1", {
+        key: "discord:bot1:channel:123:agent-1",
+        transport: "discord",
+        channelId: "123",
+      });
+
+      expect(session.metadata?.key).toBe("discord:bot1:channel:123:agent-1");
+    });
+
+    it("throws if key already exists", async () => {
+      await store.create("agent-1", {
+        key: "duplicate-key",
+        transport: "discord",
+      });
+
+      await expect(
+        store.create("agent-2", {
+          key: "duplicate-key",
+          transport: "discord",
+        })
+      ).rejects.toThrow("Session with key already exists: duplicate-key");
+    });
+
     it("persists session to disk", async () => {
       const session = await store.create("agent-1");
 
@@ -86,6 +110,39 @@ describe("DefaultSessionStore", () => {
     });
   });
 
+  describe("findByKey", () => {
+    it("finds session by key", async () => {
+      const session = await store.create("agent-1", {
+        key: "discord:bot1:channel:123:agent-1",
+        transport: "discord",
+      });
+
+      const found = await store.findByKey("discord:bot1:channel:123:agent-1");
+      expect(found).toBeDefined();
+      expect(found?.id).toBe(session.id);
+    });
+
+    it("returns undefined for non-existent key", async () => {
+      const result = await store.findByKey("non-existent-key");
+      expect(result).toBeUndefined();
+    });
+
+    it("restores key index after restart", async () => {
+      const session = await store.create("agent-1", {
+        key: "discord:bot1:channel:456:agent-1",
+        transport: "discord",
+      });
+
+      // Create a new store instance (simulates restart)
+      const newStore = new DefaultSessionStore({ dataDir: tempDir });
+      await newStore.init();
+
+      const found = await newStore.findByKey("discord:bot1:channel:456:agent-1");
+      expect(found).toBeDefined();
+      expect(found?.id).toBe(session.id);
+    });
+  });
+
   describe("addMessage / getMessages", () => {
     it("stores and retrieves messages", async () => {
       const session = await store.create("agent-1");
@@ -122,7 +179,6 @@ describe("DefaultSessionStore", () => {
       // New store instance
       const newStore = new DefaultSessionStore({ dataDir: tempDir });
       await newStore.init();
-      await newStore.get(session.id); // Load session
 
       const messages = await newStore.getMessages(session.id);
       expect(messages).toHaveLength(1);
@@ -147,6 +203,18 @@ describe("DefaultSessionStore", () => {
 
       const result = await store.get(session.id);
       expect(result).toBeUndefined();
+    });
+
+    it("removes session from key index", async () => {
+      const session = await store.create("agent-1", {
+        key: "test-key",
+        transport: "discord",
+      });
+
+      await store.delete(session.id);
+
+      const found = await store.findByKey("test-key");
+      expect(found).toBeUndefined();
     });
 
     it("removes session files from disk", async () => {

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -73,9 +73,10 @@ describe("DefaultSessionStore", () => {
     it("persists session to disk", async () => {
       const session = await store.create("agent-1");
 
-      const metaFile = path.join(tempDir, session.id, "session.json");
-      const content = await fs.readFile(metaFile, "utf-8");
-      const meta = JSON.parse(content);
+      const indexFile = path.join(tempDir, "sessions.json");
+      const content = await fs.readFile(indexFile, "utf-8");
+      const index = JSON.parse(content);
+      const meta = index.sessions[session.id];
 
       expect(meta.id).toBe(session.id);
       expect(meta.agentId).toBe("agent-1");
@@ -164,7 +165,7 @@ describe("DefaultSessionStore", () => {
 
       await store.addMessage(session.id, { role: "user", content: "Test" });
 
-      const messagesFile = path.join(tempDir, session.id, "messages.jsonl");
+      const messagesFile = path.join(tempDir, `${session.id}.jsonl`);
       const content = await fs.readFile(messagesFile, "utf-8");
       const lines = content.trim().split("\n");
 
@@ -219,15 +220,65 @@ describe("DefaultSessionStore", () => {
 
     it("removes session files from disk", async () => {
       const session = await store.create("agent-1");
-      const sessionDir = path.join(tempDir, session.id);
+      await store.addMessage(session.id, { role: "user", content: "persist me" });
+      const transcriptFile = path.join(tempDir, `${session.id}.jsonl`);
 
       await store.delete(session.id);
 
-      await expect(fs.access(sessionDir)).rejects.toThrow();
+      await expect(fs.access(transcriptFile)).rejects.toThrow();
+    });
+
+    it("updates the persisted index after deleting a session", async () => {
+      const session = await store.create("agent-1", {
+        key: "delete-key",
+        transport: "discord",
+      });
+
+      await store.delete(session.id);
+
+      const indexFile = path.join(tempDir, "sessions.json");
+      const content = await fs.readFile(indexFile, "utf-8");
+      const index = JSON.parse(content);
+
+      expect(index.sessions[session.id]).toBeUndefined();
+      expect(index.keyIndex["delete-key"]).toBeUndefined();
     });
 
     it("does not throw for non-existent session", async () => {
       await expect(store.delete("non-existent")).resolves.not.toThrow();
+    });
+  });
+
+  describe("legacy migration", () => {
+    it("loads and migrates legacy per-session directories", async () => {
+      const sessionId = "123e4567-e89b-12d3-a456-426614174000";
+      const legacyDir = path.join(tempDir, sessionId);
+      await fs.mkdir(legacyDir, { recursive: true });
+      await fs.writeFile(
+        path.join(legacyDir, "session.json"),
+        JSON.stringify({
+          id: sessionId,
+          agentId: "agent-1",
+          metadata: { key: "legacy-key", transport: "discord", channelId: "123" },
+          createdAt: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+        }),
+      );
+      await fs.writeFile(
+        path.join(legacyDir, "messages.jsonl"),
+        `${JSON.stringify({ role: "user", content: "legacy message" })}\n`,
+      );
+
+      const newStore = new DefaultSessionStore({ dataDir: tempDir });
+      await newStore.init();
+
+      const found = await newStore.findByKey("legacy-key");
+      const messages = await newStore.getMessages(sessionId);
+
+      expect(found?.id).toBe(sessionId);
+      expect(messages).toEqual([{ role: "user", content: "legacy message" }]);
+      await expect(fs.access(path.join(tempDir, "sessions.json"))).resolves.not.toThrow();
+      await expect(fs.access(path.join(tempDir, `${sessionId}.jsonl`))).resolves.not.toThrow();
+      await expect(fs.access(legacyDir)).rejects.toThrow();
     });
   });
 });

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import os from "node:os";
 import { DefaultSessionStore } from "./session-store.js";
 import type { Message } from "./types.js";
+import { textContent } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Test setup
@@ -148,34 +149,36 @@ describe("DefaultSessionStore", () => {
     it("stores and retrieves messages", async () => {
       const session = await store.create("agent-1");
 
-      const msg1: Message = { role: "user", content: "Hello" };
-      const msg2: Message = { role: "assistant", content: "Hi there!" };
+      const msg1: Message = { role: "user", content: textContent("Hello") };
+      const msg2: Message = { role: "assistant", content: textContent("Hi there!") };
 
       await store.addMessage(session.id, msg1);
       await store.addMessage(session.id, msg2);
 
       const messages = await store.getMessages(session.id);
       expect(messages).toHaveLength(2);
-      expect(messages[0].content).toBe("Hello");
-      expect(messages[1].content).toBe("Hi there!");
+      expect(messages[0].content).toEqual(textContent("Hello"));
+      expect(messages[1].content).toEqual(textContent("Hi there!"));
     });
 
     it("persists messages to JSONL file", async () => {
       const session = await store.create("agent-1");
 
-      await store.addMessage(session.id, { role: "user", content: "Test" });
+      await store.addMessage(session.id, { role: "user", content: textContent("Test") });
 
       const messagesFile = path.join(tempDir, `${session.id}.jsonl`);
       const content = await fs.readFile(messagesFile, "utf-8");
       const lines = content.trim().split("\n");
+      const record = JSON.parse(lines[0]);
 
       expect(lines).toHaveLength(1);
-      expect(JSON.parse(lines[0]).content).toBe("Test");
+      expect(record.type).toBe("message");
+      expect(record.message.content).toEqual(textContent("Test"));
     });
 
     it("loads messages from disk", async () => {
       const session = await store.create("agent-1");
-      await store.addMessage(session.id, { role: "user", content: "Persisted" });
+      await store.addMessage(session.id, { role: "user", content: textContent("Persisted") });
 
       // New store instance
       const newStore = new DefaultSessionStore({ dataDir: tempDir });
@@ -183,12 +186,12 @@ describe("DefaultSessionStore", () => {
 
       const messages = await newStore.getMessages(session.id);
       expect(messages).toHaveLength(1);
-      expect(messages[0].content).toBe("Persisted");
+      expect(messages[0].content).toEqual(textContent("Persisted"));
     });
 
     it("throws if session not found", async () => {
       await expect(
-        store.addMessage("non-existent", { role: "user", content: "Hi" }),
+        store.addMessage("non-existent", { role: "user", content: textContent("Hi") }),
       ).rejects.toThrow('Session "non-existent" not found');
 
       await expect(store.getMessages("non-existent")).rejects.toThrow(
@@ -220,7 +223,7 @@ describe("DefaultSessionStore", () => {
 
     it("removes session files from disk", async () => {
       const session = await store.create("agent-1");
-      await store.addMessage(session.id, { role: "user", content: "persist me" });
+      await store.addMessage(session.id, { role: "user", content: textContent("persist me") });
       const transcriptFile = path.join(tempDir, `${session.id}.jsonl`);
 
       await store.delete(session.id);
@@ -249,36 +252,4 @@ describe("DefaultSessionStore", () => {
     });
   });
 
-  describe("legacy migration", () => {
-    it("loads and migrates legacy per-session directories", async () => {
-      const sessionId = "123e4567-e89b-12d3-a456-426614174000";
-      const legacyDir = path.join(tempDir, sessionId);
-      await fs.mkdir(legacyDir, { recursive: true });
-      await fs.writeFile(
-        path.join(legacyDir, "session.json"),
-        JSON.stringify({
-          id: sessionId,
-          agentId: "agent-1",
-          metadata: { key: "legacy-key", transport: "discord", channelId: "123" },
-          createdAt: new Date("2026-01-01T00:00:00.000Z").toISOString(),
-        }),
-      );
-      await fs.writeFile(
-        path.join(legacyDir, "messages.jsonl"),
-        `${JSON.stringify({ role: "user", content: "legacy message" })}\n`,
-      );
-
-      const newStore = new DefaultSessionStore({ dataDir: tempDir });
-      await newStore.init();
-
-      const found = await newStore.findByKey("legacy-key");
-      const messages = await newStore.getMessages(sessionId);
-
-      expect(found?.id).toBe(sessionId);
-      expect(messages).toEqual([{ role: "user", content: "legacy message" }]);
-      await expect(fs.access(path.join(tempDir, "sessions.json"))).resolves.not.toThrow();
-      await expect(fs.access(path.join(tempDir, `${sessionId}.jsonl`))).resolves.not.toThrow();
-      await expect(fs.access(legacyDir)).rejects.toThrow();
-    });
-  });
 });

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -11,6 +11,9 @@ import type {
   SessionStore,
   SessionStoreConfig,
 } from "./types.js";
+import { createLogger } from "./logger.js";
+
+const logger = createLogger("session-store");
 
 interface StoredSession extends Session {
   messages: Message[];
@@ -24,6 +27,7 @@ interface StoredSession extends Session {
  */
 export class DefaultSessionStore implements SessionStore {
   private sessions = new Map<string, StoredSession>();
+  private keyIndex = new Map<string, string>(); // key -> sessionId
   private config: Required<SessionStoreConfig>;
 
   constructor(config: SessionStoreConfig) {
@@ -35,14 +39,20 @@ export class DefaultSessionStore implements SessionStore {
   }
 
   /**
-   * Initialize the store — create data directory if needed.
+   * Initialize the store — create data directory and load existing sessions.
    * Call this before using the store.
    */
   async init(): Promise<void> {
     await fs.mkdir(this.config.dataDir, { recursive: true });
+    await this.loadAllSessions();
   }
 
   async create(agentId: string, metadata?: SessionMetadata): Promise<Session> {
+    // Check key uniqueness
+    if (metadata?.key && this.keyIndex.has(metadata.key)) {
+      throw new Error(`Session with key already exists: ${metadata.key}`);
+    }
+
     const id = randomUUID();
     const session: StoredSession = {
       id,
@@ -53,6 +63,11 @@ export class DefaultSessionStore implements SessionStore {
     };
 
     this.sessions.set(id, session);
+    
+    // Index by key if provided
+    if (metadata?.key) {
+      this.keyIndex.set(metadata.key, id);
+    }
 
     // Persist session metadata
     await this.persistSession(session);
@@ -63,15 +78,17 @@ export class DefaultSessionStore implements SessionStore {
   async get(sessionId: string): Promise<Session | undefined> {
     const stored = this.sessions.get(sessionId);
     if (!stored) {
-      // Try loading from disk
-      const loaded = await this.loadSession(sessionId);
-      if (loaded) {
-        this.sessions.set(sessionId, loaded);
-        return this.toSession(loaded);
-      }
       return undefined;
     }
     return this.toSession(stored);
+  }
+
+  async findByKey(key: string): Promise<Session | undefined> {
+    const sessionId = this.keyIndex.get(key);
+    if (!sessionId) {
+      return undefined;
+    }
+    return this.get(sessionId);
   }
 
   async addMessage(sessionId: string, message: Message): Promise<void> {
@@ -96,6 +113,10 @@ export class DefaultSessionStore implements SessionStore {
   }
 
   async delete(sessionId: string): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (session?.metadata?.key) {
+      this.keyIndex.delete(session.metadata.key);
+    }
     this.sessions.delete(sessionId);
 
     // Remove persisted files
@@ -174,6 +195,36 @@ export class DefaultSessionStore implements SessionStore {
       };
     } catch {
       return undefined;
+    }
+  }
+
+  /**
+   * Load all sessions from disk on startup.
+   */
+  private async loadAllSessions(): Promise<void> {
+    let entries;
+    try {
+      entries = await fs.readdir(this.config.dataDir, { withFileTypes: true });
+    } catch {
+      // Directory doesn't exist yet
+      return;
+    }
+    
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const sessionId = entry.name;
+        try {
+          const session = await this.loadSession(sessionId);
+          if (session) {
+            this.sessions.set(sessionId, session);
+            if (session.metadata?.key) {
+              this.keyIndex.set(session.metadata.key, sessionId);
+            }
+          }
+        } catch (error) {
+          logger.warn(`Failed to load session ${sessionId}: ${error}`);
+        }
+      }
     }
   }
 

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -16,7 +16,20 @@ import { createLogger } from "./logger.js";
 const logger = createLogger("session-store");
 
 interface StoredSession extends Session {
-  messages: Message[];
+  messages?: Message[];
+  messagesLoaded: boolean;
+}
+
+interface PersistedSessionRecord {
+  id: string;
+  agentId: string;
+  metadata?: SessionMetadata;
+  lastActiveAt: string;
+}
+
+interface PersistedSessionIndex {
+  sessions: Record<string, PersistedSessionRecord>;
+  keyIndex?: Record<string, string>;
 }
 
 /**
@@ -60,17 +73,17 @@ export class DefaultSessionStore implements SessionStore {
       metadata,
       lastActiveAt: new Date(),
       messages: [],
+      messagesLoaded: true,
     };
 
     this.sessions.set(id, session);
-    
+
     // Index by key if provided
     if (metadata?.key) {
       this.keyIndex.set(metadata.key, id);
     }
 
-    // Persist session metadata
-    await this.persistSession(session);
+    await this.persistIndex();
 
     return this.toSession(session);
   }
@@ -97,11 +110,14 @@ export class DefaultSessionStore implements SessionStore {
       throw new Error(`Session "${sessionId}" not found`);
     }
 
-    session.messages.push(message);
+    await this.ensureMessagesLoaded(session);
+
+    session.messages!.push(message);
     session.lastActiveAt = new Date();
 
     // Append message to JSONL file
     await this.appendMessage(sessionId, message);
+    await this.persistIndex();
   }
 
   async getMessages(sessionId: string): Promise<Message[]> {
@@ -109,7 +125,8 @@ export class DefaultSessionStore implements SessionStore {
     if (!session) {
       throw new Error(`Session "${sessionId}" not found`);
     }
-    return [...session.messages];
+    await this.ensureMessagesLoaded(session);
+    return [...session.messages!];
   }
 
   async delete(sessionId: string): Promise<void> {
@@ -119,10 +136,12 @@ export class DefaultSessionStore implements SessionStore {
     }
     this.sessions.delete(sessionId);
 
+    await this.persistIndex();
+
     // Remove persisted files
-    const sessionDir = path.join(this.config.dataDir, sessionId);
     try {
-      await fs.rm(sessionDir, { recursive: true, force: true });
+      await fs.rm(this.transcriptFile(sessionId), { force: true });
+      await fs.rm(this.legacySessionDir(sessionId), { recursive: true, force: true });
     } catch {
       // Ignore if doesn't exist
     }
@@ -132,99 +151,205 @@ export class DefaultSessionStore implements SessionStore {
   // Persistence helpers
   // -------------------------------------------------------------------------
 
-  private sessionDir(sessionId: string): string {
+  private indexFile(): string {
+    return path.join(this.config.dataDir, "sessions.json");
+  }
+
+  private transcriptFile(sessionId: string): string {
+    return path.join(this.config.dataDir, `${sessionId}.jsonl`);
+  }
+
+  private legacySessionDir(sessionId: string): string {
     return path.join(this.config.dataDir, sessionId);
   }
 
-  private async persistSession(session: StoredSession): Promise<void> {
-    const dir = this.sessionDir(session.id);
-    await fs.mkdir(dir, { recursive: true });
+  private legacyMetaFile(sessionId: string): string {
+    return path.join(this.legacySessionDir(sessionId), "session.json");
+  }
 
-    const meta = {
-      id: session.id,
-      agentId: session.agentId,
-      metadata: session.metadata,
-      createdAt: session.lastActiveAt.toISOString(),
+  private legacyMessagesFile(sessionId: string): string {
+    return path.join(this.legacySessionDir(sessionId), "messages.jsonl");
+  }
+
+  private async persistIndex(): Promise<void> {
+    const index: PersistedSessionIndex = {
+      sessions: Object.fromEntries(
+        [...this.sessions.values()].map((session) => [
+          session.id,
+          {
+            id: session.id,
+            agentId: session.agentId,
+            ...(session.metadata ? { metadata: session.metadata } : {}),
+            lastActiveAt: session.lastActiveAt.toISOString(),
+          },
+        ]),
+      ),
+      keyIndex: Object.fromEntries(this.keyIndex),
     };
 
     await fs.writeFile(
-      path.join(dir, "session.json"),
-      JSON.stringify(meta, null, 2),
+      this.indexFile(),
+      JSON.stringify(index, null, 2),
     );
   }
 
   private async appendMessage(sessionId: string, message: Message): Promise<void> {
-    const file = path.join(this.sessionDir(sessionId), "messages.jsonl");
+    const file = this.transcriptFile(sessionId);
     const line = JSON.stringify(message) + "\n";
     await fs.appendFile(file, line);
   }
 
-  private async loadSession(sessionId: string): Promise<StoredSession | undefined> {
-    const dir = this.sessionDir(sessionId);
+  private async ensureMessagesLoaded(session: StoredSession): Promise<void> {
+    if (session.messagesLoaded) {
+      return;
+    }
 
-    try {
-      const metaFile = path.join(dir, "session.json");
-      const metaContent = await fs.readFile(metaFile, "utf-8");
-      const meta = JSON.parse(metaContent) as {
-        id: string;
-        agentId: string;
-        metadata?: SessionMetadata;
-        createdAt: string;
-      };
+    session.messages = await this.loadMessages(session.id);
+    session.messagesLoaded = true;
+  }
 
-      // Load messages
-      const messages: Message[] = [];
-      const messagesFile = path.join(dir, "messages.jsonl");
+  private async loadMessages(sessionId: string): Promise<Message[]> {
+    const candidates = [this.transcriptFile(sessionId), this.legacyMessagesFile(sessionId)];
+    for (const file of candidates) {
       try {
-        const content = await fs.readFile(messagesFile, "utf-8");
+        const content = await fs.readFile(file, "utf-8");
+        const messages: Message[] = [];
         for (const line of content.split("\n")) {
           if (line.trim()) {
             messages.push(JSON.parse(line) as Message);
           }
         }
+        return messages;
       } catch {
-        // No messages file yet
+        // Try next candidate.
       }
+    }
 
-      return {
+    return [];
+  }
+
+  private toStoredSession(meta: PersistedSessionRecord): StoredSession {
+    return {
+      id: meta.id,
+      agentId: meta.agentId,
+      metadata: meta.metadata,
+      lastActiveAt: new Date(meta.lastActiveAt),
+      messagesLoaded: false,
+    };
+  }
+
+  private async loadLegacySession(sessionId: string): Promise<StoredSession | undefined> {
+    const metaFile = this.legacyMetaFile(sessionId);
+
+    try {
+      const metaContent = await fs.readFile(metaFile, "utf-8");
+      const meta = JSON.parse(metaContent) as {
+        id: string;
+        agentId: string;
+        metadata?: SessionMetadata;
+        createdAt?: string;
+        lastActiveAt?: string;
+      };
+
+      return this.toStoredSession({
         id: meta.id,
         agentId: meta.agentId,
         metadata: meta.metadata,
-        lastActiveAt: new Date(meta.createdAt),
-        messages,
-      };
+        lastActiveAt: meta.lastActiveAt ?? meta.createdAt ?? new Date().toISOString(),
+      });
     } catch {
       return undefined;
     }
+  }
+
+  private async loadIndexFile(): Promise<void> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.indexFile(), "utf-8");
+    } catch {
+      return;
+    }
+
+    const index = JSON.parse(raw) as PersistedSessionIndex;
+    const sessions = index.sessions ?? {};
+    for (const meta of Object.values(sessions)) {
+      const session = this.toStoredSession(meta);
+      this.sessions.set(session.id, session);
+      if (session.metadata?.key) {
+        this.keyIndex.set(session.metadata.key, session.id);
+      }
+    }
+
+    for (const [key, sessionId] of Object.entries(index.keyIndex ?? {})) {
+      if (this.sessions.has(sessionId)) {
+        this.keyIndex.set(key, sessionId);
+      }
+    }
+  }
+
+  private async migrateLegacySessions(): Promise<boolean> {
+    let entries;
+    try {
+      entries = await fs.readdir(this.config.dataDir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+
+    let migrated = false;
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const sessionId = entry.name;
+      try {
+        const session = await this.loadLegacySession(sessionId);
+        if (!session) {
+          continue;
+        }
+
+        if (!this.sessions.has(sessionId)) {
+          this.sessions.set(sessionId, session);
+          if (session.metadata?.key) {
+            this.keyIndex.set(session.metadata.key, sessionId);
+          }
+        }
+
+        const newTranscriptFile = this.transcriptFile(sessionId);
+        const legacyMessagesFile = this.legacyMessagesFile(sessionId);
+        try {
+          await fs.access(newTranscriptFile);
+        } catch {
+          try {
+            await fs.rename(legacyMessagesFile, newTranscriptFile);
+          } catch {
+            // Keep legacy transcript in place if migration fails.
+          }
+        }
+
+        await fs.rm(this.legacySessionDir(sessionId), { recursive: true, force: true });
+        migrated = true;
+      } catch (error) {
+        logger.warn(`Failed to migrate legacy session ${sessionId}: ${error}`);
+      }
+    }
+
+    return migrated;
   }
 
   /**
    * Load all sessions from disk on startup.
    */
   private async loadAllSessions(): Promise<void> {
-    let entries;
-    try {
-      entries = await fs.readdir(this.config.dataDir, { withFileTypes: true });
-    } catch {
-      // Directory doesn't exist yet
-      return;
-    }
-    
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const sessionId = entry.name;
-        try {
-          const session = await this.loadSession(sessionId);
-          if (session) {
-            this.sessions.set(sessionId, session);
-            if (session.metadata?.key) {
-              this.keyIndex.set(session.metadata.key, sessionId);
-            }
-          }
-        } catch (error) {
-          logger.warn(`Failed to load session ${sessionId}: ${error}`);
-        }
-      }
+    this.sessions.clear();
+    this.keyIndex.clear();
+
+    await this.loadIndexFile();
+
+    const migrated = await this.migrateLegacySessions();
+    if (migrated) {
+      await this.persistIndex();
     }
   }
 

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -11,9 +11,6 @@ import type {
   SessionStore,
   SessionStoreConfig,
 } from "./types.js";
-import { createLogger } from "./logger.js";
-
-const logger = createLogger("session-store");
 
 interface StoredSession extends Session {
   messages?: Message[];

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -32,6 +32,12 @@ interface PersistedSessionIndex {
   keyIndex?: Record<string, string>;
 }
 
+interface PersistedTranscriptRecord {
+  type: "message";
+  timestamp: number;
+  message: Message;
+}
+
 /**
  * DefaultSessionStore — in-memory session storage with file persistence.
  *
@@ -141,7 +147,6 @@ export class DefaultSessionStore implements SessionStore {
     // Remove persisted files
     try {
       await fs.rm(this.transcriptFile(sessionId), { force: true });
-      await fs.rm(this.legacySessionDir(sessionId), { recursive: true, force: true });
     } catch {
       // Ignore if doesn't exist
     }
@@ -157,18 +162,6 @@ export class DefaultSessionStore implements SessionStore {
 
   private transcriptFile(sessionId: string): string {
     return path.join(this.config.dataDir, `${sessionId}.jsonl`);
-  }
-
-  private legacySessionDir(sessionId: string): string {
-    return path.join(this.config.dataDir, sessionId);
-  }
-
-  private legacyMetaFile(sessionId: string): string {
-    return path.join(this.legacySessionDir(sessionId), "session.json");
-  }
-
-  private legacyMessagesFile(sessionId: string): string {
-    return path.join(this.legacySessionDir(sessionId), "messages.jsonl");
   }
 
   private async persistIndex(): Promise<void> {
@@ -195,7 +188,12 @@ export class DefaultSessionStore implements SessionStore {
 
   private async appendMessage(sessionId: string, message: Message): Promise<void> {
     const file = this.transcriptFile(sessionId);
-    const line = JSON.stringify(message) + "\n";
+    const record: PersistedTranscriptRecord = {
+      type: "message",
+      timestamp: message.timestamp ?? Date.now(),
+      message,
+    };
+    const line = JSON.stringify(record) + "\n";
     await fs.appendFile(file, line);
   }
 
@@ -209,23 +207,26 @@ export class DefaultSessionStore implements SessionStore {
   }
 
   private async loadMessages(sessionId: string): Promise<Message[]> {
-    const candidates = [this.transcriptFile(sessionId), this.legacyMessagesFile(sessionId)];
-    for (const file of candidates) {
-      try {
-        const content = await fs.readFile(file, "utf-8");
-        const messages: Message[] = [];
-        for (const line of content.split("\n")) {
-          if (line.trim()) {
-            messages.push(JSON.parse(line) as Message);
-          }
+    try {
+      const content = await fs.readFile(this.transcriptFile(sessionId), "utf-8");
+      const messages: Message[] = [];
+      for (const line of content.split("\n")) {
+        if (!line.trim()) {
+          continue;
         }
-        return messages;
-      } catch {
-        // Try next candidate.
+        const record = JSON.parse(line) as PersistedTranscriptRecord;
+        if (record.type !== "message") {
+          continue;
+        }
+        messages.push({
+          ...record.message,
+          timestamp: record.timestamp,
+        });
       }
+      return messages;
+    } catch {
+      return [];
     }
-
-    return [];
   }
 
   private toStoredSession(meta: PersistedSessionRecord): StoredSession {
@@ -236,30 +237,6 @@ export class DefaultSessionStore implements SessionStore {
       lastActiveAt: new Date(meta.lastActiveAt),
       messagesLoaded: false,
     };
-  }
-
-  private async loadLegacySession(sessionId: string): Promise<StoredSession | undefined> {
-    const metaFile = this.legacyMetaFile(sessionId);
-
-    try {
-      const metaContent = await fs.readFile(metaFile, "utf-8");
-      const meta = JSON.parse(metaContent) as {
-        id: string;
-        agentId: string;
-        metadata?: SessionMetadata;
-        createdAt?: string;
-        lastActiveAt?: string;
-      };
-
-      return this.toStoredSession({
-        id: meta.id,
-        agentId: meta.agentId,
-        metadata: meta.metadata,
-        lastActiveAt: meta.lastActiveAt ?? meta.createdAt ?? new Date().toISOString(),
-      });
-    } catch {
-      return undefined;
-    }
   }
 
   private async loadIndexFile(): Promise<void> {
@@ -287,56 +264,6 @@ export class DefaultSessionStore implements SessionStore {
     }
   }
 
-  private async migrateLegacySessions(): Promise<boolean> {
-    let entries;
-    try {
-      entries = await fs.readdir(this.config.dataDir, { withFileTypes: true });
-    } catch {
-      return false;
-    }
-
-    let migrated = false;
-
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-
-      const sessionId = entry.name;
-      try {
-        const session = await this.loadLegacySession(sessionId);
-        if (!session) {
-          continue;
-        }
-
-        if (!this.sessions.has(sessionId)) {
-          this.sessions.set(sessionId, session);
-          if (session.metadata?.key) {
-            this.keyIndex.set(session.metadata.key, sessionId);
-          }
-        }
-
-        const newTranscriptFile = this.transcriptFile(sessionId);
-        const legacyMessagesFile = this.legacyMessagesFile(sessionId);
-        try {
-          await fs.access(newTranscriptFile);
-        } catch {
-          try {
-            await fs.rename(legacyMessagesFile, newTranscriptFile);
-          } catch {
-            // Keep legacy transcript in place if migration fails.
-          }
-        }
-
-        await fs.rm(this.legacySessionDir(sessionId), { recursive: true, force: true });
-        migrated = true;
-      } catch (error) {
-        logger.warn(`Failed to migrate legacy session ${sessionId}: ${error}`);
-      }
-    }
-
-    return migrated;
-  }
 
   /**
    * Load all sessions from disk on startup.
@@ -346,11 +273,6 @@ export class DefaultSessionStore implements SessionStore {
     this.keyIndex.clear();
 
     await this.loadIndexFile();
-
-    const migrated = await this.migrateLegacySessions();
-    if (migrated) {
-      await this.persistIndex();
-    }
   }
 
   private toSession(stored: StoredSession): Session {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -106,6 +106,7 @@ export interface Session {
 }
 
 export interface SessionMetadata {
+  key?: string;                        // Unique key for session lookup (e.g., discord:{botId}:channel:{id}:{agentId})
   transport: 'discord' | 'feishu' | 'web';
   channelId?: string;
   threadId?: string;
@@ -120,6 +121,7 @@ export interface SessionStoreConfig {
 export interface SessionStore {
   create(agentId: string, metadata?: SessionMetadata): Promise<Session>;
   get(sessionId: string): Promise<Session | undefined>;
+  findByKey(key: string): Promise<Session | undefined>;
   addMessage(sessionId: string, message: Message): Promise<void>;
   getMessages(sessionId: string): Promise<Message[]>;
   delete(sessionId: string): Promise<void>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,9 +5,39 @@
 // Messages
 // ---------------------------------------------------------------------------
 
+export interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+
+export interface ToolResultContentBlock {
+  type: 'tool_result';
+  output: string;
+  isError?: boolean;
+  toolCallId?: string;
+  toolName?: string;
+}
+
+export type MessageContentBlock = TextContentBlock | ToolResultContentBlock;
+
+export function textContent(text: string): MessageContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+export function messageContentToPlainText(content: MessageContentBlock[]): string {
+  return content
+    .map((block) => {
+      if (block.type === 'text') {
+        return block.text;
+      }
+      return block.output;
+    })
+    .join("\n");
+}
+
 export interface Message {
   role: 'user' | 'assistant' | 'tool_result';
-  content: string;
+  content: MessageContentBlock[];
   timestamp?: number;
   metadata?: Record<string, unknown>;
 }

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DiscordTransport } from "./discord.js";
 import type { AgentManager, SessionStore, AgentInstance } from "../core/types.js";
+import { textContent } from "../core/types.js";
 
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -203,7 +204,7 @@ describe("DiscordTransport", () => {
         "session-123",
         expect.objectContaining({
           role: "assistant",
-          content: "❌ No API provider registered for api: undefined",
+          content: textContent("❌ No API provider registered for api: undefined"),
           metadata: { isError: true },
         }),
       );
@@ -221,8 +222,8 @@ describe("DiscordTransport", () => {
         lastActiveAt: new Date(),
       });
       sessionStore.getMessages = vi.fn().mockResolvedValue([
-        { role: "assistant", content: "Previous reply" },
-        { role: "user", content: "hello again" },
+        { role: "assistant", content: textContent("Previous reply") },
+        { role: "user", content: textContent("hello again") },
       ]);
 
       const channel: MockChannel = {
@@ -251,11 +252,11 @@ describe("DiscordTransport", () => {
       expect(sessionStore.addMessage).toHaveBeenNthCalledWith(
         1,
         "session-123",
-        expect.objectContaining({ role: "user", content: "hello again" }),
+        expect.objectContaining({ role: "user", content: textContent("hello again") }),
       );
       expect(promptSpy).toHaveBeenCalledWith([
-        { role: "assistant", content: "Previous reply" },
-        { role: "user", content: "hello again" },
+        { role: "assistant", content: textContent("Previous reply") },
+        { role: "user", content: textContent("hello again") },
       ]);
     });
   });

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -11,6 +11,17 @@ type MockChannel = {
   send: ReturnType<typeof vi.fn>;
 };
 
+type MockIncomingMessage = {
+  author: { bot: boolean; username: string; id: string };
+  content: string;
+  createdTimestamp: number;
+  guild: { id: string };
+  channelId: string;
+  channel: MockChannel;
+  mentions: { has: ReturnType<typeof vi.fn> };
+  thread?: undefined;
+};
+
 // ---------------------------------------------------------------------------
 // Mock discord.js
 // ---------------------------------------------------------------------------
@@ -177,9 +188,10 @@ describe("DiscordTransport", () => {
             input: string,
             channel: MockChannel,
             sessionId: string,
+            sessionStore: SessionStore,
           ) => Promise<void>;
         }
-      ).runAgentAndRespond(erroringAgent, "hello", channel, "session-123");
+      ).runAgentAndRespond(erroringAgent, "hello", channel, "session-123", sessionStore);
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Agent ended with error: No API provider registered for api: undefined"),
@@ -195,6 +207,56 @@ describe("DiscordTransport", () => {
           metadata: { isError: true },
         }),
       );
+    });
+  });
+
+  describe("session recovery", () => {
+    it("rehydrates prior messages when an existing session is found", async () => {
+      const agent = agentManager.get("default")!;
+      const promptSpy = vi.spyOn(agent, "prompt");
+
+      sessionStore.findByKey = vi.fn().mockResolvedValue({
+        id: "session-123",
+        agentId: "default",
+        lastActiveAt: new Date(),
+      });
+      sessionStore.getMessages = vi.fn().mockResolvedValue([
+        { role: "assistant", content: "Previous reply" },
+        { role: "user", content: "hello again" },
+      ]);
+
+      const channel: MockChannel = {
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+      };
+
+      const msg: MockIncomingMessage = {
+        author: { bot: false, username: "tester", id: "user-1" },
+        content: "<@123456> hello again",
+        createdTimestamp: Date.now(),
+        guild: { id: "guild-1" },
+        channelId: "channel-1",
+        channel,
+        mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        thread: undefined,
+      };
+
+      await (
+        transport as unknown as {
+          handleMessage: (message: MockIncomingMessage) => Promise<void>;
+        }
+      ).handleMessage(msg);
+
+      expect(sessionStore.findByKey).toHaveBeenCalledWith("discord:bot-123:channel:channel-1:default");
+      expect(sessionStore.addMessage).toHaveBeenNthCalledWith(
+        1,
+        "session-123",
+        expect.objectContaining({ role: "user", content: "hello again" }),
+      );
+      expect(promptSpy).toHaveBeenCalledWith([
+        { role: "assistant", content: "Previous reply" },
+        { role: "user", content: "hello again" },
+      ]);
     });
   });
 });

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -73,6 +73,7 @@ function createMockSessionStore(): SessionStore {
       lastActiveAt: new Date(),
     }),
     get: vi.fn(),
+    findByKey: vi.fn().mockResolvedValue(undefined),
     addMessage: vi.fn(),
     getMessages: vi.fn().mockResolvedValue([]),
     delete: vi.fn(),

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -29,6 +29,7 @@ export interface DiscordTransportConfig {
   token: string;
   agentManager: AgentManager;
   sessionStore: SessionStore;
+  sessionStoreForAgent?: (agentId: string) => SessionStore;
   /** Default agent ID to use when no @mention routing */
   defaultAgentId?: string;
   /** Map of Discord bot user ID → agent ID for multi-agent routing */
@@ -105,9 +106,11 @@ export class DiscordTransport implements Transport {
       return;
     }
 
+    const sessionStore = this.getSessionStore(agentId);
+
     // Get or create session
     const sessionKey = this.getSessionKey(msg, agentId);
-    const session = await this.findOrCreateSession(sessionKey, agentId, msg);
+    const session = await this.findOrCreateSession(sessionStore, sessionKey, agentId, msg);
 
     // Extract message content (strip @mentions)
     const content = this.extractContent(msg);
@@ -123,10 +126,18 @@ export class DiscordTransport implements Transport {
         username: msg.author.username,
       },
     };
-    await this.config.sessionStore.addMessage(session.id, userMessage);
+    await sessionStore.addMessage(session.id, userMessage);
+
+    const promptInput = await sessionStore.getMessages(session.id);
 
     // Run agent and stream response
-    await this.runAgentAndRespond(agent, content, msg.channel as SendableChannel, session.id);
+    await this.runAgentAndRespond(
+      agent,
+      promptInput,
+      msg.channel as SendableChannel,
+      session.id,
+      sessionStore,
+    );
   }
 
   private shouldRespond(msg: DiscordMessage): boolean {
@@ -164,6 +175,10 @@ export class DiscordTransport implements Transport {
     return this.config.defaultAgentId ?? "default";
   }
 
+  private getSessionStore(agentId: string): SessionStore {
+    return this.config.sessionStoreForAgent?.(agentId) ?? this.config.sessionStore;
+  }
+
   private getSessionKey(msg: DiscordMessage, agentId: string): string {
     const botId = this.client.user?.id ?? "unknown";
 
@@ -177,18 +192,19 @@ export class DiscordTransport implements Transport {
   }
 
   private async findOrCreateSession(
+    sessionStore: SessionStore,
     sessionKey: string,
     agentId: string,
     msg: DiscordMessage,
   ) {
     // Try to find existing session by key
-    const existing = await this.config.sessionStore.findByKey(sessionKey);
+    const existing = await sessionStore.findByKey(sessionKey);
     if (existing) {
       return existing;
     }
 
     // Create new session with key
-    const session = await this.config.sessionStore.create(agentId, {
+    const session = await sessionStore.create(agentId, {
       key: sessionKey,
       transport: "discord",
       channelId: msg.channelId,
@@ -203,9 +219,10 @@ export class DiscordTransport implements Transport {
 
   private async runAgentAndRespond(
     agent: AgentInstance,
-    input: string,
+    input: string | Message[],
     channel: SendableChannel,
     sessionId: string,
+    sessionStore: SessionStore,
   ): Promise<void> {
     // Start typing indicator
     const typing = this.startTyping(channel);
@@ -233,7 +250,7 @@ export class DiscordTransport implements Transport {
         } else if (event.type === "agent_end") {
           // Store final assistant message
           if (responseText) {
-            await this.config.sessionStore.addMessage(sessionId, {
+            await sessionStore.addMessage(sessionId, {
               role: "assistant",
               content: responseText,
               timestamp: Date.now(),
@@ -253,7 +270,7 @@ export class DiscordTransport implements Transport {
         await this.updateOrSendMessage(channel, sentMessage, responseText);
       }
       if (finalErrorMessage) {
-        await this.config.sessionStore.addMessage(sessionId, {
+        await sessionStore.addMessage(sessionId, {
           role: "assistant",
           content: finalErrorMessage,
           timestamp: Date.now(),

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -182,8 +182,14 @@ export class DiscordTransport implements Transport {
     msg: DiscordMessage,
   ) {
     // Try to find existing session by key
-    // For now, create new session each time (TODO: session lookup by key)
+    const existing = await this.config.sessionStore.findByKey(sessionKey);
+    if (existing) {
+      return existing;
+    }
+
+    // Create new session with key
     const session = await this.config.sessionStore.create(agentId, {
+      key: sessionKey,
       transport: "discord",
       channelId: msg.channelId,
       threadId: msg.thread?.id,

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -18,6 +18,7 @@ import type {
   SessionStore,
   Transport,
 } from "../core/types.js";
+import { textContent } from "../core/types.js";
 import { loggers } from "../core/logger.js";
 
 const log = loggers.discord;
@@ -119,7 +120,7 @@ export class DiscordTransport implements Transport {
     // Add user message to session
     const userMessage: Message = {
       role: "user",
-      content,
+      content: textContent(content),
       timestamp: msg.createdTimestamp,
       metadata: {
         userId: msg.author.id,
@@ -252,7 +253,7 @@ export class DiscordTransport implements Transport {
           if (responseText) {
             await sessionStore.addMessage(sessionId, {
               role: "assistant",
-              content: responseText,
+              content: textContent(responseText),
               timestamp: Date.now(),
             });
           }
@@ -272,7 +273,7 @@ export class DiscordTransport implements Transport {
       if (finalErrorMessage) {
         await sessionStore.addMessage(sessionId, {
           role: "assistant",
-          content: finalErrorMessage,
+          content: textContent(finalErrorMessage),
           timestamp: Date.now(),
           metadata: { isError: true },
         });


### PR DESCRIPTION
## Summary
- add key-based session reuse for Discord conversations
- initialize and route per-agent session stores so recovery works across restarts
- rehydrate prior session history into prompt input with Pi Mono compatibility fixes
- switch session persistence toward an OpenClaw-style sessions index plus transcript files
- add tests for recovery, persistence, and legacy migration behavior

## Testing
- pnpm vitest run src/core/pi-mono.test.ts src/transports/discord.test.ts src/core/session-store.test.ts