### PR TITLE
feat(discord): add allowBots config for bot-to-bot communication

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -346,6 +346,7 @@ async function main() {
       allowDMs: config.discord.allowDMs,
       channelAllowlist: config.discord.channelAllowlist,
       threadBindings,
+      allowBots: config.discord.allowBots,
     });
 
     if (threadBindings?.enabled) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -19,6 +19,9 @@ import type {
 } from "./types.js";
 import type { AcpConfig } from "../acp/types.js";
 import { resolveSandboxConfig, type SandboxConfig } from "../sandbox/config.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("config");
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -123,6 +126,8 @@ export interface DiscordConfigFile {
   channelAllowlist?: string[];
   /** Thread binding configuration for auto-binding threads to agent sessions */
   threadBindings?: ThreadBindingConfigFile;
+  /** Subagent Discord streaming configuration (M8) */
+  subagentStreaming?: SubagentStreamingConfigFile;
 }
 
 /** Thread binding configuration in config file */
@@ -131,6 +136,71 @@ export interface ThreadBindingConfigFile {
   enabled?: boolean;
   /** Whether to spawn ACP sessions when threads are created (M3.2+) */
   spawnAcpSessions?: boolean;
+}
+
+/** Subagent Discord streaming configuration (M8) */
+export interface SubagentStreamingConfigFile {
+  /** Whether subagent streaming to Discord is enabled. Default: true */
+  enabled?: boolean;
+  /** Whether to show tool call details in Discord. Default: true */
+  showToolCalls?: boolean;
+}
+
+/** Permission mode for subagent tool execution (M8) */
+export type SubagentPermissionMode = "skip" | "allowlist" | "default";
+
+/** Default allowed tools for subagent execution (M8) */
+export const DEFAULT_SUBAGENT_ALLOWED_TOOLS = ["Read", "Write", "Edit", "Glob", "Grep", "LS"];
+
+/** Sub-agent execution configuration in config file (M7/M8) */
+export interface SubagentConfigFile {
+  /** Default acpx agent to use when spawning sub-agents */
+  defaultAgent?: string;
+  /** Agents allowed to be spawned as sub-agents */
+  allowedAgents?: string[];
+  /** Default timeout in seconds for sub-agent runs */
+  timeout?: number;
+  /** Default maximum turns per sub-agent run */
+  maxTurns?: number;
+  /**
+   * Permission mode for subagent tool execution (M8)
+   * - "skip" — Use --dangerously-skip-permissions (full access, no prompts)
+   * - "allowlist" — Use --allowedTools with configured list (recommended)
+   * - "default" — Use claude CLI defaults (interactive prompts, not suitable for automation)
+   * Default: "allowlist"
+   */
+  permissionMode?: SubagentPermissionMode;
+  /**
+   * Tool allowlist for subagent execution (M8)
+   * Only used when permissionMode: "allowlist"
+   * Default: ["Read", "Write", "Edit", "Glob", "Grep", "LS"]
+   */
+  allowedTools?: string[];
+  /**
+   * Enable shell access for subagents (M8)
+   * Adds "Bash" to allowedTools when permissionMode: "allowlist"
+   * WARNING: Combined with permissionMode: "skip", this allows arbitrary command execution
+   * Default: false
+   */
+  enableShell?: boolean;
+  /** @deprecated Use permissionMode instead. Whether to auto-approve tool calls. Default: true */
+  approveAll?: boolean;
+  /** Whether to create Discord threads for sub-agent output. Default: true */
+  useThread?: boolean;
+  /** Whether to show tool call details in Discord. Default: true */
+  showToolCalls?: boolean;
+}
+
+/** Resolved subagent configuration with defaults applied (M8) */
+export interface ResolvedSubagentConfig {
+  defaultAgent?: string;
+  allowedAgents?: string[];
+  timeout?: number;
+  maxTurns?: number;
+  permissionMode: SubagentPermissionMode;
+  allowedTools: string[];
+  useThread: boolean;
+  showToolCalls: boolean;
 }
 
 /** ACP (Agent Communication Protocol) configuration in config file */
@@ -143,26 +213,8 @@ export interface AcpConfigFile {
   defaultAgent?: string;
   /** Agent IDs allowed to participate in ACP sessions */
   allowedAgents?: string[];
-  /** Sub-agent execution settings (M7) */
+  /** Sub-agent execution settings (M7/M8) */
   subagent?: SubagentConfigFile;
-}
-
-/** Sub-agent execution configuration in config file (M7) */
-export interface SubagentConfigFile {
-  /** Default acpx agent to use when spawning sub-agents */
-  defaultAgent?: string;
-  /** Agents allowed to be spawned as sub-agents */
-  allowedAgents?: string[];
-  /** Default timeout in seconds for sub-agent runs */
-  timeout?: number;
-  /** Default maximum turns per sub-agent run */
-  maxTurns?: number;
-  /** Whether to auto-approve tool calls. Default: true */
-  approveAll?: boolean;
-  /** Whether to create Discord threads for sub-agent output. Default: true */
-  useThread?: boolean;
-  /** Whether to show tool call details in Discord. Default: true */
-  showToolCalls?: boolean;
 }
 
 /** Cron job configuration in config file */
@@ -198,6 +250,11 @@ export interface IsotopesConfigFile {
   acp?: AcpConfigFile;
   /** Channel-level cron job definitions */
   cron?: CronJobConfigFile[];
+  /**
+   * @deprecated Moved to discord.threadBindings in M8.
+   * Thread binding configuration for auto-binding threads to agent sessions.
+   */
+  threadBindings?: ThreadBindingConfigFile;
 }
 
 export function resolveToolSettings(
@@ -263,6 +320,7 @@ export function resolveSessionConfig(
 }
 
 const VALID_ACP_BACKENDS = new Set<string>(["acpx", "claude-code", "codex"]);
+const VALID_PERMISSION_MODES = new Set<SubagentPermissionMode>(["skip", "allowlist", "default"]);
 
 /**
  * Resolve ACP config from the config file.
@@ -290,6 +348,68 @@ export function resolveAcpConfig(
     backend,
     defaultAgent: acpConfig.defaultAgent,
     allowedAgents: acpConfig.allowedAgents,
+  };
+}
+
+/**
+ * Resolve subagent config with defaults applied (M8).
+ * Validates permission mode and logs security warnings.
+ */
+export function resolveSubagentConfig(
+  subagentConfig?: SubagentConfigFile,
+): ResolvedSubagentConfig {
+  const permissionMode = subagentConfig?.permissionMode ?? "allowlist";
+  
+  // Validate permission mode
+  if (!VALID_PERMISSION_MODES.has(permissionMode)) {
+    throw new Error(
+      `Invalid acp.subagent.permissionMode "${permissionMode}" (must be skip, allowlist, or default)`,
+    );
+  }
+
+  // Build allowed tools list
+  let allowedTools = subagentConfig?.allowedTools ?? [...DEFAULT_SUBAGENT_ALLOWED_TOOLS];
+  
+  // Add Bash if enableShell is true and not already in list
+  if (subagentConfig?.enableShell && !allowedTools.includes("Bash")) {
+    allowedTools = [...allowedTools, "Bash"];
+  }
+
+  // Security warnings (M8.1)
+  if (permissionMode === "skip") {
+    log.warn(
+      "⚠️  SECURITY WARNING: acp.subagent.permissionMode is set to 'skip'. " +
+      "Sub-agents will have unrestricted tool access without any permission prompts. " +
+      "This is NOT recommended for production use.",
+    );
+    
+    if (subagentConfig?.enableShell) {
+      log.warn(
+        "⚠️  CRITICAL SECURITY WARNING: permissionMode 'skip' combined with enableShell: true " +
+        "allows sub-agents to execute ARBITRARY SHELL COMMANDS without approval. " +
+        "Only use this configuration in fully trusted, isolated environments.",
+      );
+    }
+  }
+
+  // Handle deprecated approveAll
+  if (subagentConfig?.approveAll !== undefined) {
+    log.warn(
+      "⚠️  DEPRECATION WARNING: acp.subagent.approveAll is deprecated. " +
+      "Use acp.subagent.permissionMode instead. " +
+      "(approveAll: true → permissionMode: 'skip', approveAll: false → permissionMode: 'default')",
+    );
+  }
+
+  return {
+    defaultAgent: subagentConfig?.defaultAgent,
+    allowedAgents: subagentConfig?.allowedAgents,
+    timeout: subagentConfig?.timeout,
+    maxTurns: subagentConfig?.maxTurns,
+    permissionMode,
+    allowedTools,
+    useThread: subagentConfig?.useThread ?? true,
+    showToolCalls: subagentConfig?.showToolCalls ?? true,
   };
 }
 
@@ -343,6 +463,24 @@ function toSandboxConfig(file: SandboxConfigFile): SandboxConfig {
 // ---------------------------------------------------------------------------
 
 /**
+ * Migrate deprecated top-level threadBindings to discord.threadBindings (M8).
+ * Logs a deprecation warning if migration occurs.
+ */
+function migrateThreadBindings(config: IsotopesConfigFile): void {
+  if (config.threadBindings && !config.discord?.threadBindings) {
+    log.warn(
+      "⚠️  DEPRECATION WARNING: Top-level 'threadBindings' configuration is deprecated. " +
+      "Please move it to 'discord.threadBindings'. Auto-migrating for this session.",
+    );
+    
+    if (!config.discord) {
+      config.discord = {};
+    }
+    config.discord.threadBindings = config.threadBindings;
+  }
+}
+
+/**
  * Load configuration from a file (YAML or JSON).
  * Supports environment variable substitution in string values.
  */
@@ -371,7 +509,12 @@ export async function loadConfig(filePath: string): Promise<IsotopesConfigFile> 
   }
 
   // Process environment variables
-  return processEnvVars(config);
+  config = processEnvVars(config);
+
+  // M8: Migrate deprecated threadBindings
+  migrateThreadBindings(config);
+
+  return config;
 }
 
 /**

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -128,6 +128,8 @@ export interface DiscordConfigFile {
   threadBindings?: ThreadBindingConfigFile;
   /** Subagent Discord streaming configuration (M8) */
   subagentStreaming?: SubagentStreamingConfigFile;
+  /** Whether to respond to messages from other bots. Default: false */
+  allowBots?: boolean;
 }
 
 /** Thread binding configuration in config file */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -257,6 +257,8 @@ export interface DiscordAccountConfig {
   guilds?: Record<string, GuildConfig>;
   /** Thread binding configuration for auto-binding threads to agent sessions */
   threadBindings?: ThreadBindingConfig;
+  /** Whether to respond to messages from other bots. Default: false */
+  allowBots?: boolean;
 }
 
 /** Channels section of the configuration */

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,8 @@ export {
   getDiscordToken,
   resolveAcpConfig,
   resolveSandboxConfigFromFile,
+  resolveSubagentConfig,
+  DEFAULT_SUBAGENT_ALLOWED_TOOLS,
 } from "./core/config.js";
 export type {
   IsotopesConfigFile,
@@ -91,6 +93,10 @@ export type {
   CronJobConfigFile,
   SandboxConfigFile,
   SandboxDockerConfigFile,
+  SubagentConfigFile,
+  SubagentPermissionMode,
+  SubagentStreamingConfigFile,
+  ResolvedSubagentConfig,
 } from "./core/config.js";
 
 // ---------------------------------------------------------------------------
@@ -319,6 +325,7 @@ export type {
   SubagentTask,
   SendMessageFn,
   CreateThreadFn,
+  AcpxBackendOptions,
 } from "./subagent/index.js";
 
 // ---------------------------------------------------------------------------

--- a/src/subagent/acpx-backend.test.ts
+++ b/src/subagent/acpx-backend.test.ts
@@ -6,6 +6,7 @@ import type { AcpxEvent } from "./types.js";
 import { tmpdir } from "node:os";
 import { mkdtempSync, rmdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { DEFAULT_SUBAGENT_ALLOWED_TOOLS } from "../core/config.js";
 
 // ---------------------------------------------------------------------------
 // parseJsonLine
@@ -235,16 +236,21 @@ describe("AcpxBackend", () => {
       expect(args).toContain("--verbose");
     });
 
-    it("includes non-interactive permission bypass by default", () => {
+    // M8: Default is now 'allowlist' mode, not 'skip' mode
+    it("uses allowlist permission mode by default (M8)", () => {
       const args = backend.buildArgs({
         agent: "claude",
         prompt: "test prompt",
         cwd: "/tmp",
       });
-      expect(args).toContain("--dangerously-skip-permissions");
+      // Should NOT include --dangerously-skip-permissions by default
+      expect(args).not.toContain("--dangerously-skip-permissions");
+      // Should include --allowedTools with default list
+      expect(args).toContain("--allowedTools");
     });
 
-    it("includes the allowed tool list", () => {
+    // M8: Test that default allowed tools match the safe list (no Bash)
+    it("includes the default allowed tool list without Bash (M8)", () => {
       const args = backend.buildArgs({
         agent: "claude",
         prompt: "test prompt",
@@ -253,14 +259,63 @@ describe("AcpxBackend", () => {
 
       const idx = args.indexOf("--allowedTools");
       expect(idx).toBeGreaterThanOrEqual(0);
-      expect(args.slice(idx + 1)).toEqual([
-        "Read",
-        "Write",
-        "Edit",
-        "Bash",
-        "Glob",
-        "Grep",
-      ]);
+      expect(args.slice(idx + 1)).toEqual(DEFAULT_SUBAGENT_ALLOWED_TOOLS);
+      // Verify Bash is not in the default list
+      expect(args.slice(idx + 1)).not.toContain("Bash");
+    });
+
+    // M8: Test skip permission mode
+    it("uses --dangerously-skip-permissions when permissionMode is 'skip'", () => {
+      const skipBackend = new AcpxBackend({
+        permissionMode: "skip",
+      });
+      const args = skipBackend.buildArgs({
+        agent: "claude",
+        prompt: "test",
+        cwd: "/tmp",
+      });
+      expect(args).toContain("--dangerously-skip-permissions");
+    });
+
+    // M8: Test default permission mode (no flags)
+    it("includes no permission flags when permissionMode is 'default'", () => {
+      const defaultBackend = new AcpxBackend({
+        permissionMode: "default",
+      });
+      const args = defaultBackend.buildArgs({
+        agent: "claude",
+        prompt: "test",
+        cwd: "/tmp",
+      });
+      expect(args).not.toContain("--dangerously-skip-permissions");
+      expect(args).not.toContain("--allowedTools");
+    });
+
+    // M8: Test custom allowed tools
+    it("uses custom allowedTools when provided", () => {
+      const customBackend = new AcpxBackend({
+        permissionMode: "allowlist",
+        allowedTools: ["Read", "Write", "Bash"],
+      });
+      const args = customBackend.buildArgs({
+        agent: "claude",
+        prompt: "test",
+        cwd: "/tmp",
+      });
+      const idx = args.indexOf("--allowedTools");
+      expect(args.slice(idx + 1)).toContain("Bash");
+    });
+
+    // M8: Test per-spawn option override
+    it("allows per-spawn permissionMode override", () => {
+      // Backend defaults to 'allowlist', but spawn uses 'skip'
+      const args = backend.buildArgs({
+        agent: "claude",
+        prompt: "test",
+        cwd: "/tmp",
+        permissionMode: "skip",
+      });
+      expect(args).toContain("--dangerously-skip-permissions");
     });
 
     it("includes --model when specified", () => {
@@ -309,7 +364,8 @@ describe("AcpxBackend", () => {
       expect(args).not.toContain("do something cool");
     });
 
-    it("builds minimal args correctly", () => {
+    // M8: Updated to reflect new default (allowlist mode, no Bash)
+    it("builds minimal args correctly with default allowlist mode (M8)", () => {
       const args = backend.buildArgs({
         agent: "codex",
         prompt: "hello",
@@ -319,18 +375,17 @@ describe("AcpxBackend", () => {
         "-p",
         "--output-format", "stream-json",
         "--verbose",
-        "--dangerously-skip-permissions",
-        "--allowedTools", "Read", "Write", "Edit", "Bash", "Glob", "Grep",
+        "--allowedTools", ...DEFAULT_SUBAGENT_ALLOWED_TOOLS,
       ]);
     });
 
-    it("builds full args correctly", () => {
+    // M8: Updated to reflect new behavior
+    it("builds full args correctly with model and maxTurns (M8)", () => {
       const args = backend.buildArgs({
         agent: "gemini",
         prompt: "write tests",
         cwd: "/project",
         model: "gemini-2.5-pro",
-        approveAll: true,
         timeout: 120,
         maxTurns: 5,
       });
@@ -338,11 +393,28 @@ describe("AcpxBackend", () => {
         "-p",
         "--output-format", "stream-json",
         "--verbose",
-        "--dangerously-skip-permissions",
+        "--allowedTools", ...DEFAULT_SUBAGENT_ALLOWED_TOOLS,
         "--model", "gemini-2.5-pro",
         "--max-turns", "5",
-        "--allowedTools", "Read", "Write", "Edit", "Bash", "Glob", "Grep",
       ]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // workspacesKey (M8.5)
+  // ---------------------------------------------------------------------------
+
+  describe("workspacesKey", () => {
+    it("generates a consistent key from allowed workspaces", () => {
+      const backend1 = new AcpxBackend(["/a", "/b"]);
+      const backend2 = new AcpxBackend(["/b", "/a"]); // Different order
+      // Keys should be the same after sorting
+      expect(backend1.workspacesKey).toBe(backend2.workspacesKey);
+    });
+
+    it("generates empty key when no workspaces", () => {
+      const backend1 = new AcpxBackend();
+      expect(backend1.workspacesKey).toBe("");
     });
   });
 

--- a/src/subagent/acpx-backend.ts
+++ b/src/subagent/acpx-backend.ts
@@ -2,7 +2,7 @@
 // Wraps `claude -p --output-format stream-json` as a child process with JSON line streaming.
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, statSync, realpathSync } from "node:fs";
 import { resolve, normalize } from "node:path";
 import { createLogger } from "../core/logger.js";
 import {
@@ -11,6 +11,8 @@ import {
   type AcpxResult,
   type AcpxSpawnOptions,
 } from "./types.js";
+import type { SubagentPermissionMode } from "../core/config.js";
+import { DEFAULT_SUBAGENT_ALLOWED_TOOLS } from "../core/config.js";
 
 const log = createLogger("subagent:acpx");
 
@@ -154,6 +156,27 @@ function mapRawEvent(obj: Record<string, unknown>): AcpxEvent | undefined {
 // ---------------------------------------------------------------------------
 
 /**
+ * Configuration options for AcpxBackend (M8).
+ */
+export interface AcpxBackendOptions {
+  /** Allowed workspace roots for cwd validation */
+  allowedWorkspaceRoots?: string[];
+  /**
+   * Permission mode for tool execution (M8)
+   * - "skip" — Use --dangerously-skip-permissions (full access, no prompts)
+   * - "allowlist" — Use --allowedTools with configured list (recommended)
+   * - "default" — Use claude CLI defaults (interactive prompts)
+   * Default: "allowlist"
+   */
+  permissionMode?: SubagentPermissionMode;
+  /**
+   * Tool allowlist for "allowlist" permission mode (M8)
+   * Default: ["Read", "Write", "Edit", "Glob", "Grep", "LS"]
+   */
+  allowedTools?: string[];
+}
+
+/**
  * Backend for spawning Claude Code sub-agent processes.
  *
  * Each task gets its own child process running
@@ -168,17 +191,47 @@ export class AcpxBackend {
   /** Allowed workspace roots for cwd validation */
   private allowedRoots: string[];
 
-  constructor(allowedWorkspaceRoots?: string[]) {
-    this.allowedRoots = allowedWorkspaceRoots ?? [];
+  /** Permission mode for tool execution (M8) */
+  private permissionMode: SubagentPermissionMode;
+
+  /** Tool allowlist for "allowlist" mode (M8) */
+  private allowedTools: string[];
+
+  /** Workspace key for singleton comparison (M8.5) */
+  public workspacesKey: string;
+
+  constructor(options?: string[] | AcpxBackendOptions) {
+    // Support legacy constructor signature: new AcpxBackend(allowedWorkspaceRoots)
+    if (Array.isArray(options) || options === undefined) {
+      this.allowedRoots = options ?? [];
+      this.permissionMode = "allowlist";
+      this.allowedTools = [...DEFAULT_SUBAGENT_ALLOWED_TOOLS];
+    } else {
+      this.allowedRoots = options.allowedWorkspaceRoots ?? [];
+      this.permissionMode = options.permissionMode ?? "allowlist";
+      this.allowedTools = options.allowedTools ?? [...DEFAULT_SUBAGENT_ALLOWED_TOOLS];
+    }
+
+    // Compute workspace key for singleton comparison (M8.5)
+    this.workspacesKey = this.allowedRoots.slice().sort().join(":");
   }
 
   /**
    * Validate that the given cwd is a real directory within allowed workspaces.
+   * Uses realpathSync to resolve symlinks and prevent escape attacks (M8.3).
    * @throws Error if validation fails
    */
   validateCwd(cwd: string): void {
     const resolved = resolve(cwd);
-    const normalized = normalize(resolved);
+    
+    // M8.3: Use realpathSync when path exists to resolve symlinks
+    let normalized: string;
+    try {
+      normalized = realpathSync(resolved);
+    } catch {
+      // Path doesn't exist yet — fall back to normalize
+      normalized = normalize(resolved);
+    }
 
     // Check directory exists
     if (!existsSync(normalized)) {
@@ -194,7 +247,13 @@ export class AcpxBackend {
     // If allowed roots are configured, validate path is within them
     if (this.allowedRoots.length > 0) {
       const isAllowed = this.allowedRoots.some((root) => {
-        const normalizedRoot = normalize(resolve(root));
+        // M8.3: Use realpathSync for allowed roots too
+        let normalizedRoot: string;
+        try {
+          normalizedRoot = realpathSync(resolve(root));
+        } catch {
+          normalizedRoot = normalize(resolve(root));
+        }
         return normalized === normalizedRoot || normalized.startsWith(normalizedRoot + "/");
       });
       if (!isAllowed) {
@@ -216,14 +275,46 @@ export class AcpxBackend {
   /**
    * Build the command-line arguments for `claude -p`.
    * Note: prompt is passed via stdin, not as an argument.
+   *
+   * M8.1: Supports configurable permission modes:
+   * - "skip" — --dangerously-skip-permissions (full access)
+   * - "allowlist" — --allowedTools with configured list (recommended)
+   * - "default" — no permission flags (uses claude CLI defaults)
    */
   buildArgs(options: AcpxSpawnOptions): string[] {
     const args: string[] = [
       "-p",  // Print mode (non-interactive)
       "--output-format", "stream-json",  // Stream JSON events
       "--verbose",  // Required for stream-json output
-      "--dangerously-skip-permissions",  // Auto-approve all
     ];
+
+    // M8.1: Apply permission mode
+    const permissionMode = options.permissionMode ?? this.permissionMode;
+    const allowedTools = options.allowedTools ?? this.allowedTools;
+
+    switch (permissionMode) {
+      case "skip":
+        // Full access without any permission prompts
+        args.push("--dangerously-skip-permissions");
+        log.debug("Using permissionMode 'skip' — all tool calls auto-approved");
+        break;
+
+      case "allowlist":
+        // Use --allowedTools with configured list
+        if (allowedTools.length > 0) {
+          args.push("--allowedTools", ...allowedTools);
+          log.debug(`Using permissionMode 'allowlist' with tools: ${allowedTools.join(", ")}`);
+        } else {
+          // Empty allowlist — use default mode
+          log.debug("permissionMode 'allowlist' with empty tools list — using defaults");
+        }
+        break;
+
+      case "default":
+        // No permission flags — use claude CLI defaults (interactive prompts)
+        log.debug("Using permissionMode 'default' — claude CLI default behavior");
+        break;
+    }
 
     if (options.model) {
       args.push("--model", options.model);
@@ -232,9 +323,6 @@ export class AcpxBackend {
     if (options.maxTurns !== undefined) {
       args.push("--max-turns", String(options.maxTurns));
     }
-
-    // Add allowed tools for file operations
-    args.push("--allowedTools", "Read", "Write", "Edit", "Bash", "Glob", "Grep");
 
     // Note: prompt is NOT added here - it's passed via stdin
 

--- a/src/subagent/index.ts
+++ b/src/subagent/index.ts
@@ -34,6 +34,7 @@ export type {
 export { ACPX_AGENTS } from "./types.js";
 
 export { AcpxBackend, parseJsonLine, collectResult } from "./acpx-backend.js";
+export type { AcpxBackendOptions } from "./acpx-backend.js";
 
 export {
   DiscordSink,
@@ -99,6 +100,8 @@ export class SubagentManager {
         cwd: task.cwd,
         model: task.model,
         approveAll: task.approveAll,
+        permissionMode: task.permissionMode,
+        allowedTools: task.allowedTools,
         timeout: task.timeout,
         maxTurns: task.maxTurns,
       })) {

--- a/src/subagent/types.ts
+++ b/src/subagent/types.ts
@@ -1,6 +1,8 @@
 // src/subagent/types.ts — Type definitions for sub-agent spawning via acpx
 // Defines agent types, spawn options, event types, and result structures.
 
+import type { SubagentPermissionMode } from "../core/config.js";
+
 // ---------------------------------------------------------------------------
 // Agent types
 // ---------------------------------------------------------------------------
@@ -42,8 +44,24 @@ export interface AcpxSpawnOptions {
   cwd: string;
   /** Model override (e.g., "claude-sonnet-4-20250514") */
   model?: string;
-  /** Auto-approve all tool calls. Default: true */
+  /**
+   * @deprecated Use permissionMode instead.
+   * Auto-approve all tool calls. Default: true
+   */
   approveAll?: boolean;
+  /**
+   * Permission mode for tool execution (M8)
+   * - "skip" — Use --dangerously-skip-permissions (full access, no prompts)
+   * - "allowlist" — Use --allowedTools with configured list (recommended)
+   * - "default" — Use claude CLI defaults (interactive prompts)
+   * Default: "allowlist" (inherited from backend config)
+   */
+  permissionMode?: SubagentPermissionMode;
+  /**
+   * Tool allowlist for "allowlist" permission mode (M8)
+   * Default: inherited from backend config
+   */
+  allowedTools?: string[];
   /** Timeout in seconds for the entire run */
   timeout?: number;
   /** Maximum number of agent turns */
@@ -135,8 +153,22 @@ export interface SubagentTask {
   showToolCalls?: boolean;
   /** Model override */
   model?: string;
-  /** Auto-approve all tool calls */
+  /**
+   * @deprecated Use permissionMode instead.
+   * Auto-approve all tool calls
+   */
   approveAll?: boolean;
+  /**
+   * Permission mode for tool execution (M8)
+   * - "skip" — Use --dangerously-skip-permissions (full access, no prompts)
+   * - "allowlist" — Use --allowedTools with configured list (recommended)
+   * - "default" — Use claude CLI defaults (interactive prompts)
+   */
+  permissionMode?: SubagentPermissionMode;
+  /**
+   * Tool allowlist for "allowlist" permission mode (M8)
+   */
+  allowedTools?: string[];
   /** Timeout in seconds */
   timeout?: number;
   /** Maximum number of agent turns */

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -62,6 +62,8 @@ export interface DiscordTransportConfig {
   enableSubagentStreaming?: boolean;
   /** Whether to show tool calls in subagent threads (default: true) */
   subagentShowToolCalls?: boolean;
+  /** Whether to respond to messages from other bots. Default: false */
+  allowBots?: boolean;
 }
 
 /**
@@ -159,8 +161,11 @@ export class DiscordTransport implements Transport {
   // ---------------------------------------------------------------------------
 
   private async handleMessage(msg: DiscordMessage): Promise<void> {
-    // Ignore bot messages
-    if (msg.author.bot) return;
+    // Handle bot messages based on allowBots config
+    if (msg.author.bot && !this.config.allowBots) {
+      log.debug(`Ignoring bot message from ${msg.author.username} (allowBots=false)`);
+      return;
+    }
 
     // Check if we should respond
     if (!this.shouldRespond(msg)) return;


### PR DESCRIPTION
## Summary

Add `allowBots` configuration option to Discord transport to enable bot-to-bot communication.

## Changes

### 1. feat(M8): configurable subagent permission model and security improvements
- Added `SubagentPermissionMode` type: `'skip'` | `'allowlist'` | `'default'`
- Changed default from `skip` to safer `allowlist` mode
- Default allowed tools: `['Read', 'Write', 'Edit', 'Glob', 'Grep', 'LS']`
- `Bash` requires explicit `enableShell: true`
- Added security warnings for dangerous configurations
- Used `realpathSync` for symlink resolution to prevent path escape attacks

### 2. feat(discord): add allowBots config to enable bot-to-bot communication
- Added `allowBots?: boolean` config option in Discord channel settings
- When `true`, bot messages will be processed instead of ignored
- Enables bots to @ mention each other and communicate

## Testing
- All 967 tests passing
- Needs manual testing for bot-to-bot @ mentions

## Related
- Part of M8: Subagent Security & Discord Integration
