### PR TITLE
feat(skills): M9 Skills System

### DIFF
--- a/src/skills/discovery.test.ts
+++ b/src/skills/discovery.test.ts
@@ -1,0 +1,259 @@
+// src/skills/discovery.test.ts — Unit tests for skill discovery
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  discoverSkills,
+  getGlobalSkillsPath,
+  getWorkspaceSkillsPath,
+  expandTilde,
+} from "./discovery.js";
+
+describe("Skill Discovery", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "isotopes-skills-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("discoverSkills", () => {
+    it("discovers skills with SKILL.md files", async () => {
+      // Create a skill directory with SKILL.md
+      const skillDir = path.join(tempDir, "my-skill");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillDir, "SKILL.md"),
+        "---\nname: my-skill\ndescription: A test skill\n---\n\n# My Skill",
+      );
+
+      const skills = await discoverSkills({ globalPath: tempDir });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].directory).toBe(skillDir);
+      expect(skills[0].skillPath).toBe(path.join(skillDir, "SKILL.md"));
+    });
+
+    it("returns empty array for empty directory", async () => {
+      const skills = await discoverSkills({ globalPath: tempDir });
+
+      expect(skills).toEqual([]);
+    });
+
+    it("returns empty array for non-existent directory", async () => {
+      const nonExistent = path.join(tempDir, "does-not-exist");
+
+      const skills = await discoverSkills({ globalPath: nonExistent });
+
+      expect(skills).toEqual([]);
+    });
+
+    it("discovers nested skills recursively", async () => {
+      // Create nested skill structure
+      const level1 = path.join(tempDir, "level1");
+      const level2 = path.join(level1, "level2");
+      const level3 = path.join(level2, "level3");
+
+      await fs.mkdir(level3, { recursive: true });
+
+      // Skill at level 1
+      await fs.writeFile(path.join(level1, "SKILL.md"), "# Level 1 Skill");
+
+      // Skill at level 3
+      await fs.writeFile(path.join(level3, "SKILL.md"), "# Level 3 Skill");
+
+      const skills = await discoverSkills({ globalPath: tempDir });
+
+      expect(skills).toHaveLength(2);
+      const directories = skills.map((s) => s.directory);
+      expect(directories).toContain(level1);
+      expect(directories).toContain(level3);
+    });
+
+    it("ignores node_modules and .git directories", async () => {
+      // Create skill in node_modules (should be ignored)
+      const nodeModulesSkill = path.join(tempDir, "node_modules", "some-skill");
+      await fs.mkdir(nodeModulesSkill, { recursive: true });
+      await fs.writeFile(path.join(nodeModulesSkill, "SKILL.md"), "# Ignored");
+
+      // Create skill in .git (should be ignored)
+      const gitSkill = path.join(tempDir, ".git", "hooks");
+      await fs.mkdir(gitSkill, { recursive: true });
+      await fs.writeFile(path.join(gitSkill, "SKILL.md"), "# Ignored");
+
+      // Create valid skill
+      const validSkill = path.join(tempDir, "valid-skill");
+      await fs.mkdir(validSkill, { recursive: true });
+      await fs.writeFile(path.join(validSkill, "SKILL.md"), "# Valid");
+
+      const skills = await discoverSkills({ globalPath: tempDir });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].directory).toBe(validSkill);
+    });
+
+    it("ignores directories without SKILL.md", async () => {
+      // Create directory without SKILL.md
+      const noSkillDir = path.join(tempDir, "not-a-skill");
+      await fs.mkdir(noSkillDir, { recursive: true });
+      await fs.writeFile(path.join(noSkillDir, "README.md"), "# Not a skill");
+
+      // Create directory with SKILL.md
+      const skillDir = path.join(tempDir, "actual-skill");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Skill");
+
+      const skills = await discoverSkills({ globalPath: tempDir });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].directory).toBe(skillDir);
+    });
+
+    it("scans workspace skills directory", async () => {
+      // Create workspace structure
+      const workspacePath = path.join(tempDir, "workspace");
+      const workspaceSkillsDir = path.join(workspacePath, "skills");
+      const skillDir = path.join(workspaceSkillsDir, "workspace-skill");
+
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Workspace Skill");
+
+      const skills = await discoverSkills({
+        globalPath: path.join(tempDir, "empty"), // Non-existent, should be skipped
+        workspacePath,
+      });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].directory).toBe(skillDir);
+    });
+
+    it("scans additional paths", async () => {
+      const additionalDir = path.join(tempDir, "custom-skills");
+      const skillDir = path.join(additionalDir, "custom-skill");
+
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Custom Skill");
+
+      const skills = await discoverSkills({
+        globalPath: path.join(tempDir, "empty"),
+        additionalPaths: [additionalDir],
+      });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].directory).toBe(skillDir);
+    });
+
+    it("deduplicates skills by directory", async () => {
+      // Create a skill
+      const skillDir = path.join(tempDir, "shared-skill");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Shared Skill");
+
+      // Scan the same path twice via additionalPaths
+      const skills = await discoverSkills({
+        globalPath: tempDir,
+        additionalPaths: [tempDir],
+      });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].directory).toBe(skillDir);
+    });
+
+    it("discovers skills from multiple paths in order", async () => {
+      // Create global skill
+      const globalDir = path.join(tempDir, "global");
+      const globalSkill = path.join(globalDir, "global-skill");
+      await fs.mkdir(globalSkill, { recursive: true });
+      await fs.writeFile(path.join(globalSkill, "SKILL.md"), "# Global");
+
+      // Create workspace skill
+      const workspaceDir = path.join(tempDir, "workspace");
+      const workspaceSkillsDir = path.join(workspaceDir, "skills");
+      const workspaceSkill = path.join(workspaceSkillsDir, "workspace-skill");
+      await fs.mkdir(workspaceSkill, { recursive: true });
+      await fs.writeFile(path.join(workspaceSkill, "SKILL.md"), "# Workspace");
+
+      // Create additional skill
+      const additionalDir = path.join(tempDir, "additional");
+      const additionalSkill = path.join(additionalDir, "additional-skill");
+      await fs.mkdir(additionalSkill, { recursive: true });
+      await fs.writeFile(path.join(additionalSkill, "SKILL.md"), "# Additional");
+
+      const skills = await discoverSkills({
+        globalPath: globalDir,
+        workspacePath: workspaceDir,
+        additionalPaths: [additionalDir],
+      });
+
+      expect(skills).toHaveLength(3);
+      // Verify order: global, workspace, additional
+      expect(skills[0].directory).toBe(globalSkill);
+      expect(skills[1].directory).toBe(workspaceSkill);
+      expect(skills[2].directory).toBe(additionalSkill);
+    });
+
+    it("handles mixed existing and non-existing paths", async () => {
+      // Create one valid skill
+      const validDir = path.join(tempDir, "valid");
+      const skillDir = path.join(validDir, "my-skill");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Valid Skill");
+
+      const skills = await discoverSkills({
+        globalPath: path.join(tempDir, "nonexistent1"),
+        workspacePath: path.join(tempDir, "nonexistent2"),
+        additionalPaths: [validDir, path.join(tempDir, "nonexistent3")],
+      });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].directory).toBe(skillDir);
+    });
+
+    it("discovers skill at root of scanned directory", async () => {
+      // SKILL.md directly in the scanned path
+      await fs.writeFile(path.join(tempDir, "SKILL.md"), "# Root Skill");
+
+      const skills = await discoverSkills({ globalPath: tempDir });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].directory).toBe(tempDir);
+    });
+  });
+
+  describe("getGlobalSkillsPath", () => {
+    it("returns path under isotopes home", () => {
+      const result = getGlobalSkillsPath();
+      expect(result).toContain("skills");
+      expect(result).toContain(".isotopes");
+    });
+  });
+
+  describe("getWorkspaceSkillsPath", () => {
+    it("returns skills subdirectory of workspace", () => {
+      const result = getWorkspaceSkillsPath("/path/to/workspace");
+      expect(result).toBe("/path/to/workspace/skills");
+    });
+  });
+
+  describe("expandTilde", () => {
+    it("expands ~ to home directory", () => {
+      const result = expandTilde("~/test/path");
+      expect(result).toBe(path.join(os.homedir(), "test/path"));
+    });
+
+    it("leaves absolute paths unchanged", () => {
+      const result = expandTilde("/absolute/path");
+      expect(result).toBe("/absolute/path");
+    });
+
+    it("leaves relative paths unchanged", () => {
+      const result = expandTilde("relative/path");
+      expect(result).toBe("relative/path");
+    });
+  });
+});

--- a/src/skills/discovery.ts
+++ b/src/skills/discovery.ts
@@ -1,0 +1,173 @@
+// src/skills/discovery.ts — Skill discovery module
+// Scans directories to find SKILL.md files for the skills system.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { getIsotopesHome } from "../core/paths.js";
+
+// Directories to skip during recursive scanning
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".svn",
+  ".hg",
+  "__pycache__",
+  ".cache",
+  "dist",
+  "build",
+  ".next",
+  ".nuxt",
+]);
+
+const SKILL_FILE = "SKILL.md";
+
+export interface DiscoveryOptions {
+  /** Global skills path (default: ~/.isotopes/skills) */
+  globalPath?: string;
+  /** Workspace path to scan for skills in {workspace}/skills/ */
+  workspacePath?: string;
+  /** Additional paths to scan for skills */
+  additionalPaths?: string[];
+}
+
+export interface DiscoveredSkill {
+  /** Absolute path to the SKILL.md file */
+  skillPath: string;
+  /** Absolute path to the skill directory */
+  directory: string;
+}
+
+/**
+ * Get the default global skills directory.
+ */
+export function getGlobalSkillsPath(): string {
+  return path.join(getIsotopesHome(), "skills");
+}
+
+/**
+ * Get the workspace skills directory for a given workspace.
+ */
+export function getWorkspaceSkillsPath(workspacePath: string): string {
+  return path.join(workspacePath, "skills");
+}
+
+/**
+ * Discover skills from configured paths.
+ * Scans directories recursively for SKILL.md files.
+ *
+ * Discovery order (per PRD):
+ * 1. Global: ~/.isotopes/skills/
+ * 2. Workspace: {workspace}/skills/
+ * 3. Additional paths (if provided)
+ */
+export async function discoverSkills(
+  options: DiscoveryOptions = {},
+): Promise<DiscoveredSkill[]> {
+  const {
+    globalPath = getGlobalSkillsPath(),
+    workspacePath,
+    additionalPaths = [],
+  } = options;
+
+  const pathsToScan: string[] = [];
+
+  // Add paths in discovery order
+  pathsToScan.push(globalPath);
+
+  if (workspacePath) {
+    pathsToScan.push(getWorkspaceSkillsPath(workspacePath));
+  }
+
+  pathsToScan.push(...additionalPaths);
+
+  // Scan all paths and collect skills
+  const allSkills: DiscoveredSkill[] = [];
+  const seenDirectories = new Set<string>();
+
+  for (const scanPath of pathsToScan) {
+    const skills = await scanDirectory(scanPath);
+    for (const skill of skills) {
+      // Deduplicate by directory path
+      if (!seenDirectories.has(skill.directory)) {
+        seenDirectories.add(skill.directory);
+        allSkills.push(skill);
+      }
+    }
+  }
+
+  return allSkills;
+}
+
+interface DirEntry {
+  name: string;
+  isFile(): boolean;
+  isDirectory(): boolean;
+}
+
+/**
+ * Recursively scan a directory for SKILL.md files.
+ * Returns empty array if directory doesn't exist.
+ */
+async function scanDirectory(dirPath: string): Promise<DiscoveredSkill[]> {
+  const skills: DiscoveredSkill[] = [];
+
+  // Check if directory exists
+  try {
+    const stats = await fs.stat(dirPath);
+    if (!stats.isDirectory()) {
+      return skills;
+    }
+  } catch {
+    // Directory doesn't exist, silently skip
+    return skills;
+  }
+
+  // Read directory contents
+  let entries: DirEntry[];
+  try {
+    entries = (await fs.readdir(dirPath, { withFileTypes: true })) as DirEntry[];
+  } catch {
+    return skills;
+  }
+
+  // Check if this directory contains SKILL.md
+  const hasSkillFile = entries.some(
+    (entry) => entry.isFile() && entry.name === SKILL_FILE,
+  );
+
+  if (hasSkillFile) {
+    skills.push({
+      skillPath: path.join(dirPath, SKILL_FILE),
+      directory: dirPath,
+    });
+  }
+
+  // Recursively scan subdirectories
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    // Skip ignored directories
+    if (IGNORED_DIRS.has(entry.name)) {
+      continue;
+    }
+
+    const subDirPath = path.join(dirPath, entry.name);
+    const subSkills = await scanDirectory(subDirPath);
+    skills.push(...subSkills);
+  }
+
+  return skills;
+}
+
+/**
+ * Expand ~ to home directory in a path.
+ */
+export function expandTilde(p: string): string {
+  if (p.startsWith("~/")) {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -1,0 +1,7 @@
+// src/skills/index.ts — Public API for the skills system
+// Re-exports all types and functions from skills modules.
+
+export * from "./discovery.js";
+export * from "./parser.js";
+export * from "./prompt.js";
+export * from "./skill-loader.js";

--- a/src/skills/parser.test.ts
+++ b/src/skills/parser.test.ts
@@ -1,0 +1,360 @@
+// src/skills/parser.test.ts — Unit tests for SKILL.md parser
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  parseSkillFile,
+  parseFrontmatter,
+  validateSkillName,
+} from "./parser.js";
+
+describe("Skill Parser", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "isotopes-parser-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("validateSkillName", () => {
+    it("accepts valid names", () => {
+      expect(validateSkillName("my-skill")).toEqual({ valid: true });
+      expect(validateSkillName("web-search")).toEqual({ valid: true });
+      expect(validateSkillName("github-issues")).toEqual({ valid: true });
+      expect(validateSkillName("pdf-tools")).toEqual({ valid: true });
+      expect(validateSkillName("a")).toEqual({ valid: true });
+      expect(validateSkillName("skill123")).toEqual({ valid: true });
+      expect(validateSkillName("a1b2c3")).toEqual({ valid: true });
+    });
+
+    it("rejects empty name", () => {
+      const result = validateSkillName("");
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain("empty");
+    });
+
+    it("rejects name exceeding 64 characters", () => {
+      const longName = "a".repeat(65);
+      const result = validateSkillName(longName);
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain("64");
+    });
+
+    it("rejects uppercase letters", () => {
+      const result = validateSkillName("MySkill");
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain("lowercase");
+    });
+
+    it("rejects leading hyphen", () => {
+      const result = validateSkillName("-skill");
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects trailing hyphen", () => {
+      const result = validateSkillName("skill-");
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects consecutive hyphens", () => {
+      const result = validateSkillName("my--skill");
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects underscores", () => {
+      const result = validateSkillName("my_skill");
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects spaces", () => {
+      const result = validateSkillName("my skill");
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects non-string input", () => {
+      const result = validateSkillName(123 as unknown as string);
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain("string");
+    });
+  });
+
+  describe("parseFrontmatter", () => {
+    it("parses valid frontmatter", () => {
+      const content = `---
+name: my-skill
+description: A test skill for doing things
+---
+
+# My Skill
+
+Instructions here.`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(true);
+      expect(result.metadata).toBeDefined();
+      expect(result.metadata?.name).toBe("my-skill");
+      expect(result.metadata?.description).toBe("A test skill for doing things");
+      expect(result.metadata?.raw).toEqual({
+        name: "my-skill",
+        description: "A test skill for doing things",
+      });
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it("preserves extra frontmatter fields in raw", () => {
+      const content = `---
+name: my-skill
+description: A test skill
+version: 1.0.0
+author: Test Author
+---
+
+# Content`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(true);
+      expect(result.metadata?.raw).toEqual({
+        name: "my-skill",
+        description: "A test skill",
+        version: "1.0.0",
+        author: "Test Author",
+      });
+    });
+
+    it("returns error for missing frontmatter", () => {
+      const content = `# My Skill
+
+No frontmatter here.`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("No frontmatter found");
+    });
+
+    it("returns error for missing name", () => {
+      const content = `---
+description: A skill without a name
+---
+
+# Content`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Missing required field: name");
+    });
+
+    it("returns error for missing description", () => {
+      const content = `---
+name: my-skill
+---
+
+# Content`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Missing required field: description");
+    });
+
+    it("returns error for invalid YAML", () => {
+      const content = `---
+name: [invalid yaml
+description: broken
+---
+
+# Content`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to parse YAML");
+    });
+
+    it("returns error for non-string name", () => {
+      const content = `---
+name: 123
+description: A skill
+---`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("'name' must be a string");
+    });
+
+    it("returns error for non-string description", () => {
+      const content = `---
+name: my-skill
+description:
+  - list item
+---`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("'description' must be a string");
+    });
+
+    it("returns warning for invalid name format", () => {
+      const content = `---
+name: My-Invalid-Name
+description: A skill with bad name format
+---`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(true);
+      expect(result.metadata?.name).toBe("My-Invalid-Name");
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings?.[0]).toContain("Invalid name format");
+    });
+
+    it("returns warning for description exceeding 1024 chars", () => {
+      const longDescription = "x".repeat(1025);
+      const content = `---
+name: my-skill
+description: ${longDescription}
+---`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings?.[0]).toContain("exceeds 1024 characters");
+    });
+
+    it("handles Windows line endings (CRLF)", () => {
+      const content = "---\r\nname: my-skill\r\ndescription: A skill\r\n---\r\n\r\n# Content";
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(true);
+      expect(result.metadata?.name).toBe("my-skill");
+    });
+
+    it("returns error for empty frontmatter", () => {
+      const content = `---
+---
+
+# Content`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(false);
+      // null parsed from empty YAML
+      expect(result.error).toContain("No frontmatter found");
+    });
+
+    it("handles multiline description", () => {
+      const content = `---
+name: my-skill
+description: |
+  This is a multiline description.
+  It spans multiple lines.
+---`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.success).toBe(true);
+      expect(result.metadata?.description).toContain("multiline description");
+      expect(result.metadata?.description).toContain("multiple lines");
+    });
+  });
+
+  describe("parseSkillFile", () => {
+    it("parses valid SKILL.md file", async () => {
+      const skillPath = path.join(tempDir, "SKILL.md");
+      await fs.writeFile(
+        skillPath,
+        `---
+name: test-skill
+description: A test skill for unit testing
+---
+
+# Test Skill
+
+Instructions here.`,
+      );
+
+      const result = await parseSkillFile(skillPath);
+
+      expect(result.success).toBe(true);
+      expect(result.metadata?.name).toBe("test-skill");
+      expect(result.metadata?.description).toBe("A test skill for unit testing");
+    });
+
+    it("returns error for non-existent file", async () => {
+      const skillPath = path.join(tempDir, "nonexistent", "SKILL.md");
+
+      const result = await parseSkillFile(skillPath);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("File not found");
+    });
+
+    it("returns error for empty file", async () => {
+      const skillPath = path.join(tempDir, "SKILL.md");
+      await fs.writeFile(skillPath, "");
+
+      const result = await parseSkillFile(skillPath);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("empty");
+    });
+
+    it("returns error for whitespace-only file", async () => {
+      const skillPath = path.join(tempDir, "SKILL.md");
+      await fs.writeFile(skillPath, "   \n\n   \t  ");
+
+      const result = await parseSkillFile(skillPath);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("empty");
+    });
+
+    it("propagates frontmatter parsing errors", async () => {
+      const skillPath = path.join(tempDir, "SKILL.md");
+      await fs.writeFile(
+        skillPath,
+        `---
+name: my-skill
+---
+
+Missing description field.`,
+      );
+
+      const result = await parseSkillFile(skillPath);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Missing required field: description");
+    });
+
+    it("propagates warnings from frontmatter parsing", async () => {
+      const skillPath = path.join(tempDir, "SKILL.md");
+      await fs.writeFile(
+        skillPath,
+        `---
+name: INVALID-NAME
+description: Valid description
+---
+
+# Content`,
+      );
+
+      const result = await parseSkillFile(skillPath);
+
+      expect(result.success).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings?.[0]).toContain("Invalid name format");
+    });
+  });
+});

--- a/src/skills/parser.ts
+++ b/src/skills/parser.ts
@@ -1,0 +1,204 @@
+// src/skills/parser.ts — SKILL.md frontmatter parser and validator
+// Parses YAML frontmatter from skill files and validates required fields.
+
+import fs from "node:fs/promises";
+import YAML from "yaml";
+
+export interface SkillMetadata {
+  name: string;
+  description: string;
+  /** Preserve original frontmatter for future extensions */
+  raw?: Record<string, unknown>;
+}
+
+export interface ParseResult {
+  success: boolean;
+  metadata?: SkillMetadata;
+  error?: string;
+  warnings?: string[];
+}
+
+// Regex to extract YAML frontmatter between --- delimiters
+const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+// Name validation: lowercase a-z, 0-9, hyphens, 1-64 chars
+// No leading/trailing hyphens, no consecutive hyphens
+const NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const NAME_MIN_LENGTH = 1;
+const NAME_MAX_LENGTH = 64;
+const DESCRIPTION_MAX_LENGTH = 1024;
+
+/**
+ * Validate a skill name according to the spec.
+ * Returns validation result with optional message.
+ */
+export function validateSkillName(name: string): {
+  valid: boolean;
+  message?: string;
+} {
+  if (typeof name !== "string") {
+    return { valid: false, message: "Name must be a string" };
+  }
+
+  if (name.length < NAME_MIN_LENGTH) {
+    return { valid: false, message: "Name cannot be empty" };
+  }
+
+  if (name.length > NAME_MAX_LENGTH) {
+    return {
+      valid: false,
+      message: `Name exceeds ${NAME_MAX_LENGTH} characters`,
+    };
+  }
+
+  if (!NAME_PATTERN.test(name)) {
+    return {
+      valid: false,
+      message:
+        "Name must be lowercase letters, numbers, and hyphens only. No leading/trailing hyphens or consecutive hyphens.",
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Parse frontmatter from SKILL.md content.
+ * Extracts YAML between --- delimiters and validates required fields.
+ */
+export function parseFrontmatter(content: string): ParseResult {
+  const warnings: string[] = [];
+
+  // Check for frontmatter
+  const match = FRONTMATTER_REGEX.exec(content);
+  if (!match) {
+    return {
+      success: false,
+      error: "No frontmatter found. SKILL.md must start with --- delimited YAML.",
+    };
+  }
+
+  const yamlContent = match[1];
+
+  // Parse YAML
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = YAML.parse(yamlContent) as Record<string, unknown>;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      error: `Failed to parse YAML frontmatter: ${message}`,
+    };
+  }
+
+  // Handle empty or non-object frontmatter
+  if (!parsed || typeof parsed !== "object") {
+    return {
+      success: false,
+      error: "Frontmatter must be a YAML object",
+    };
+  }
+
+  // Validate required fields
+  const { name, description } = parsed;
+
+  // Check name
+  if (name === undefined || name === null) {
+    return {
+      success: false,
+      error: "Missing required field: name",
+    };
+  }
+
+  if (typeof name !== "string") {
+    return {
+      success: false,
+      error: "Field 'name' must be a string",
+    };
+  }
+
+  // Validate name format (warnings, not errors per PRD)
+  const nameValidation = validateSkillName(name);
+  if (!nameValidation.valid && nameValidation.message) {
+    warnings.push(`Invalid name format: ${nameValidation.message}`);
+  }
+
+  // Check description
+  if (description === undefined || description === null) {
+    return {
+      success: false,
+      error: "Missing required field: description",
+    };
+  }
+
+  if (typeof description !== "string") {
+    return {
+      success: false,
+      error: "Field 'description' must be a string",
+    };
+  }
+
+  // Validate description length (warning, not error)
+  if (description.length > DESCRIPTION_MAX_LENGTH) {
+    warnings.push(
+      `Description exceeds ${DESCRIPTION_MAX_LENGTH} characters (${description.length} chars)`,
+    );
+  }
+
+  const result: ParseResult = {
+    success: true,
+    metadata: {
+      name: String(name),
+      description: String(description),
+      raw: parsed,
+    },
+  };
+
+  if (warnings.length > 0) {
+    result.warnings = warnings;
+  }
+
+  return result;
+}
+
+/**
+ * Read and parse a SKILL.md file.
+ * Returns parsed metadata or error information.
+ */
+export async function parseSkillFile(skillPath: string): Promise<ParseResult> {
+  // Read file
+  let content: string;
+  try {
+    content = await fs.readFile(skillPath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return {
+        success: false,
+        error: `File not found: ${skillPath}`,
+      };
+    }
+    if (code === "EACCES") {
+      return {
+        success: false,
+        error: `Permission denied: ${skillPath}`,
+      };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      error: `Failed to read file: ${message}`,
+    };
+  }
+
+  // Handle empty file
+  if (!content.trim()) {
+    return {
+      success: false,
+      error: "File is empty",
+    };
+  }
+
+  return parseFrontmatter(content);
+}

--- a/src/skills/prompt.test.ts
+++ b/src/skills/prompt.test.ts
@@ -1,0 +1,265 @@
+// src/skills/prompt.test.ts — Unit tests for skill prompt generation
+
+import { describe, it, expect } from "vitest";
+import {
+  generateSkillsPrompt,
+  generateXmlBlock,
+  generateInstructions,
+  type LoadedSkill,
+} from "./prompt.js";
+
+describe("Skill Prompt Generator", () => {
+  const sampleSkill: LoadedSkill = {
+    name: "web-search",
+    description: "Search the web using DuckDuckGo.",
+    location: "~/.isotopes/skills/web-search/SKILL.md",
+    directory: "~/.isotopes/skills/web-search",
+  };
+
+  const anotherSkill: LoadedSkill = {
+    name: "github-issues",
+    description: "Create, list, and manage GitHub issues.",
+    location: "/home/user/workspace/skills/github-issues/SKILL.md",
+    directory: "/home/user/workspace/skills/github-issues",
+  };
+
+  describe("generateXmlBlock", () => {
+    it("generates XML for a single skill", () => {
+      const result = generateXmlBlock([sampleSkill]);
+
+      expect(result).toContain("<available_skills>");
+      expect(result).toContain("</available_skills>");
+      expect(result).toContain("<name>web-search</name>");
+      expect(result).toContain(
+        "<description>Search the web using DuckDuckGo.</description>",
+      );
+      expect(result).toContain(
+        "<location>~/.isotopes/skills/web-search/SKILL.md</location>",
+      );
+    });
+
+    it("generates XML for multiple skills", () => {
+      const result = generateXmlBlock([sampleSkill, anotherSkill]);
+
+      expect(result).toContain("<name>web-search</name>");
+      expect(result).toContain("<name>github-issues</name>");
+      expect(result).toContain(
+        "<description>Create, list, and manage GitHub issues.</description>",
+      );
+    });
+
+    it("returns empty string for empty skills array", () => {
+      const result = generateXmlBlock([]);
+      expect(result).toBe("");
+    });
+
+    it("escapes XML special characters in name", () => {
+      const skill: LoadedSkill = {
+        name: "test<>&skill",
+        description: "A normal description",
+        location: "/path/to/SKILL.md",
+        directory: "/path/to",
+      };
+
+      const result = generateXmlBlock([skill]);
+
+      expect(result).toContain("<name>test&lt;&gt;&amp;skill</name>");
+      expect(result).not.toContain("<name>test<>&skill</name>");
+    });
+
+    it("escapes XML special characters in description", () => {
+      const skill: LoadedSkill = {
+        name: "test-skill",
+        description: 'Use <code> & "quotes" for \'emphasis\'',
+        location: "/path/to/SKILL.md",
+        directory: "/path/to",
+      };
+
+      const result = generateXmlBlock([skill]);
+
+      expect(result).toContain(
+        "<description>Use &lt;code&gt; &amp; &quot;quotes&quot; for &apos;emphasis&apos;</description>",
+      );
+    });
+
+    it("escapes XML special characters in location", () => {
+      const skill: LoadedSkill = {
+        name: "test-skill",
+        description: "Test",
+        location: "/path/with<special>&chars/SKILL.md",
+        directory: "/path/with<special>&chars",
+      };
+
+      const result = generateXmlBlock([skill]);
+
+      expect(result).toContain(
+        "<location>/path/with&lt;special&gt;&amp;chars/SKILL.md</location>",
+      );
+    });
+
+    it("formats XML with proper indentation", () => {
+      const result = generateXmlBlock([sampleSkill]);
+
+      // Check structure
+      const lines = result.split("\n");
+      expect(lines[0]).toBe("<available_skills>");
+      expect(lines[1]).toBe("  <skill>");
+      expect(lines[2]).toMatch(/^\s{4}<name>/);
+      expect(lines[lines.length - 1]).toBe("</available_skills>");
+    });
+  });
+
+  describe("generateInstructions", () => {
+    it("returns the instruction block", () => {
+      const result = generateInstructions();
+
+      expect(result).toContain("## Skills");
+      expect(result).toContain("scan <available_skills> descriptions");
+      expect(result).toContain("read its SKILL.md at <location>");
+      expect(result).toContain("resolve them against the skill directory");
+    });
+
+    it("contains all three decision rules", () => {
+      const result = generateInstructions();
+
+      expect(result).toContain("exactly one skill clearly applies");
+      expect(result).toContain("multiple could apply");
+      expect(result).toContain("none apply");
+    });
+  });
+
+  describe("generateSkillsPrompt", () => {
+    it("returns empty string for empty skills array", () => {
+      const result = generateSkillsPrompt([]);
+      expect(result).toBe("");
+    });
+
+    it("returns empty string for empty array even with includeInstructions true", () => {
+      const result = generateSkillsPrompt([], { includeInstructions: true });
+      expect(result).toBe("");
+    });
+
+    it("includes instructions by default", () => {
+      const result = generateSkillsPrompt([sampleSkill]);
+
+      expect(result).toContain("## Skills");
+      expect(result).toContain("<available_skills>");
+    });
+
+    it("excludes instructions when includeInstructions is false", () => {
+      const result = generateSkillsPrompt([sampleSkill], {
+        includeInstructions: false,
+      });
+
+      expect(result).not.toContain("## Skills");
+      expect(result).toContain("<available_skills>");
+    });
+
+    it("uses XML format by default", () => {
+      const result = generateSkillsPrompt([sampleSkill]);
+
+      expect(result).toContain("<available_skills>");
+      expect(result).toContain("<skill>");
+    });
+
+    it("supports markdown format", () => {
+      const result = generateSkillsPrompt([sampleSkill], { format: "markdown" });
+
+      expect(result).toContain("## Available Skills");
+      expect(result).toContain("### web-search");
+      expect(result).toContain("**Location:**");
+      expect(result).not.toMatch(/<available_skills>\n {2}<skill>/);
+    });
+
+    it("supports JSON format", () => {
+      const result = generateSkillsPrompt([sampleSkill], { format: "json" });
+
+      expect(result).toContain('"available_skills"');
+      expect(result).toContain('"name": "web-search"');
+      expect(result).not.toMatch(/<available_skills>\n {2}<skill>/);
+    });
+
+    it("separates instructions and skills block with blank line", () => {
+      const result = generateSkillsPrompt([sampleSkill]);
+
+      // Instructions end, then blank line, then XML
+      expect(result).toMatch(/skill directory\.\n\n<available_skills>/);
+    });
+
+    it("handles all special characters in combined output", () => {
+      const specialSkill: LoadedSkill = {
+        name: "special-skill",
+        description: 'Handles <tags>, &ampersands, "quotes", and \'apostrophes\'',
+        location: "/path/to/SKILL.md",
+        directory: "/path/to",
+      };
+
+      const result = generateSkillsPrompt([specialSkill]);
+
+      expect(result).toContain("&lt;tags&gt;");
+      expect(result).toContain("&amp;ampersands");
+      expect(result).toContain("&quot;quotes&quot;");
+      expect(result).toContain("&apos;apostrophes&apos;");
+    });
+
+    it("preserves skill order in output", () => {
+      const skills: LoadedSkill[] = [
+        { ...sampleSkill, name: "aaa-first" },
+        { ...sampleSkill, name: "mmm-middle" },
+        { ...sampleSkill, name: "zzz-last" },
+      ];
+
+      const result = generateSkillsPrompt(skills);
+
+      const firstIndex = result.indexOf("aaa-first");
+      const middleIndex = result.indexOf("mmm-middle");
+      const lastIndex = result.indexOf("zzz-last");
+
+      expect(firstIndex).toBeLessThan(middleIndex);
+      expect(middleIndex).toBeLessThan(lastIndex);
+    });
+  });
+
+  describe("markdown format", () => {
+    it("generates markdown with proper structure", () => {
+      const result = generateSkillsPrompt([sampleSkill, anotherSkill], {
+        format: "markdown",
+        includeInstructions: false,
+      });
+
+      expect(result).toContain("## Available Skills");
+      expect(result).toContain("### web-search");
+      expect(result).toContain("### github-issues");
+      expect(result).toContain(
+        "**Location:** `~/.isotopes/skills/web-search/SKILL.md`",
+      );
+    });
+  });
+
+  describe("JSON format", () => {
+    it("generates valid JSON", () => {
+      const result = generateSkillsPrompt([sampleSkill], {
+        format: "json",
+        includeInstructions: false,
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.available_skills).toHaveLength(1);
+      expect(parsed.available_skills[0].name).toBe("web-search");
+    });
+
+    it("includes all skill fields in JSON", () => {
+      const result = generateSkillsPrompt([sampleSkill], {
+        format: "json",
+        includeInstructions: false,
+      });
+
+      const parsed = JSON.parse(result);
+      const skill = parsed.available_skills[0];
+
+      expect(skill.name).toBe("web-search");
+      expect(skill.description).toBe("Search the web using DuckDuckGo.");
+      expect(skill.location).toBe("~/.isotopes/skills/web-search/SKILL.md");
+    });
+  });
+});

--- a/src/skills/prompt.ts
+++ b/src/skills/prompt.ts
@@ -1,0 +1,129 @@
+// src/skills/prompt.ts — Generate skills system prompt block
+// Produces XML-formatted skill descriptions for agent system prompts.
+
+import type { SkillMetadata } from "./parser.js";
+
+export interface LoadedSkill extends SkillMetadata {
+  /** Absolute path to SKILL.md */
+  location: string;
+  /** Skill directory for relative path resolution */
+  directory: string;
+}
+
+export interface PromptGeneratorOptions {
+  /** Output format. Default: "xml" */
+  format?: "xml" | "markdown" | "json";
+  /** Include instruction block before skills. Default: true */
+  includeInstructions?: boolean;
+}
+
+/**
+ * Escape XML special characters.
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Generate the instruction block that precedes skills.
+ */
+export function generateInstructions(): string {
+  return `## Skills
+
+Before replying, scan <available_skills> descriptions.
+- If exactly one skill clearly applies: read its SKILL.md at <location>, then follow it.
+- If multiple could apply: choose the most specific one, then read/follow.
+- If none apply: proceed without loading any skill.
+
+When a skill references relative paths, resolve them against the skill directory.`;
+}
+
+/**
+ * Generate XML block containing skill information.
+ */
+export function generateXmlBlock(skills: LoadedSkill[]): string {
+  if (skills.length === 0) {
+    return "";
+  }
+
+  const skillEntries = skills
+    .map(
+      (skill) => `  <skill>
+    <name>${escapeXml(skill.name)}</name>
+    <description>${escapeXml(skill.description)}</description>
+    <location>${escapeXml(skill.location)}</location>
+  </skill>`,
+    )
+    .join("\n");
+
+  return `<available_skills>
+${skillEntries}
+</available_skills>`;
+}
+
+/**
+ * Generate complete skills prompt block.
+ * Returns empty string if no skills are provided.
+ */
+export function generateSkillsPrompt(
+  skills: LoadedSkill[],
+  options?: PromptGeneratorOptions,
+): string {
+  const { format = "xml", includeInstructions = true } = options ?? {};
+
+  if (skills.length === 0) {
+    return "";
+  }
+
+  const parts: string[] = [];
+
+  if (includeInstructions) {
+    parts.push(generateInstructions());
+  }
+
+  switch (format) {
+    case "xml":
+      parts.push(generateXmlBlock(skills));
+      break;
+    case "markdown":
+      parts.push(generateMarkdownBlock(skills));
+      break;
+    case "json":
+      parts.push(generateJsonBlock(skills));
+      break;
+  }
+
+  return parts.join("\n\n");
+}
+
+/**
+ * Generate markdown-formatted skill list.
+ */
+function generateMarkdownBlock(skills: LoadedSkill[]): string {
+  const entries = skills
+    .map(
+      (skill) =>
+        `### ${skill.name}\n\n${skill.description}\n\n**Location:** \`${skill.location}\``,
+    )
+    .join("\n\n");
+
+  return `## Available Skills\n\n${entries}`;
+}
+
+/**
+ * Generate JSON-formatted skill list.
+ */
+function generateJsonBlock(skills: LoadedSkill[]): string {
+  const data = skills.map((skill) => ({
+    name: skill.name,
+    description: skill.description,
+    location: skill.location,
+  }));
+
+  return JSON.stringify({ available_skills: data }, null, 2);
+}

--- a/src/skills/skill-loader.test.ts
+++ b/src/skills/skill-loader.test.ts
@@ -1,0 +1,514 @@
+// src/skills/skill-loader.test.ts — Unit tests for SkillLoader
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { SkillLoader } from "./skill-loader.js";
+
+describe("SkillLoader", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Create temporary directory for test skills
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "skill-loader-test-"));
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function createSkill(
+    name: string,
+    content: string,
+    subdir?: string,
+  ): Promise<string> {
+    const skillDir = subdir
+      ? path.join(tempDir, subdir, name)
+      : path.join(tempDir, name);
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillPath = path.join(skillDir, "SKILL.md");
+    await fs.writeFile(skillPath, content);
+    return skillPath;
+  }
+
+  describe("load()", () => {
+    it("loads skills from a directory", async () => {
+      await createSkill(
+        "test-skill",
+        `---
+name: test-skill
+description: A test skill
+---
+
+# Test Skill
+
+This is a test.`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const result = await loader.load();
+
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].name).toBe("test-skill");
+      expect(result.skills[0].description).toBe("A test skill");
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("loads multiple skills", async () => {
+      await createSkill(
+        "skill-one",
+        `---
+name: skill-one
+description: First skill
+---
+Content`,
+      );
+
+      await createSkill(
+        "skill-two",
+        `---
+name: skill-two
+description: Second skill
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const result = await loader.load();
+
+      expect(result.skills).toHaveLength(2);
+      const names = result.skills.map((s) => s.name).sort();
+      expect(names).toEqual(["skill-one", "skill-two"]);
+    });
+
+    it("collects errors for invalid skills", async () => {
+      // Valid skill
+      await createSkill(
+        "valid-skill",
+        `---
+name: valid-skill
+description: Valid
+---
+Content`,
+      );
+
+      // Invalid skill (missing description)
+      await createSkill(
+        "invalid-skill",
+        `---
+name: invalid-skill
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const result = await loader.load();
+
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].name).toBe("valid-skill");
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].error).toContain("description");
+    });
+
+    it("collects warnings for skills with validation issues", async () => {
+      // Skill with invalid name format (warning, not error)
+      await createSkill(
+        "bad-name",
+        `---
+name: BadName
+description: Has invalid name
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const result = await loader.load();
+
+      // Still loads successfully
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].name).toBe("BadName");
+      // But has warning
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0].warning).toContain("Invalid name format");
+    });
+
+    it("returns empty result for non-existent directory", async () => {
+      const loader = new SkillLoader({
+        globalPath: "/non/existent/path",
+        logWarnings: false,
+      });
+      const result = await loader.load();
+
+      expect(result.skills).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("logs warnings by default", async () => {
+      await createSkill(
+        "warning-skill",
+        `---
+name: BadName
+description: Has invalid name
+---
+Content`,
+      );
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        // logWarnings defaults to true
+      });
+      await loader.load();
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy.mock.calls[0][0]).toContain("[skills]");
+
+      warnSpy.mockRestore();
+    });
+
+    it("does not log warnings when logWarnings is false", async () => {
+      await createSkill(
+        "warning-skill",
+        `---
+name: BadName
+description: Has invalid name
+---
+Content`,
+      );
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      await loader.load();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("caching", () => {
+    it("caches result after first load", async () => {
+      await createSkill(
+        "cached-skill",
+        `---
+name: cached-skill
+description: Will be cached
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+
+      const result1 = await loader.load();
+      const result2 = await loader.load();
+
+      // Should be the exact same object reference
+      expect(result1).toBe(result2);
+    });
+
+    it("clearCache() forces re-scan on next load", async () => {
+      await createSkill(
+        "initial-skill",
+        `---
+name: initial-skill
+description: Initial
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+
+      const result1 = await loader.load();
+      expect(result1.skills).toHaveLength(1);
+
+      // Add another skill
+      await createSkill(
+        "new-skill",
+        `---
+name: new-skill
+description: New
+---
+Content`,
+      );
+
+      // Still returns cached result
+      const result2 = await loader.load();
+      expect(result2.skills).toHaveLength(1);
+
+      // Clear cache and reload
+      loader.clearCache();
+      const result3 = await loader.load();
+      expect(result3.skills).toHaveLength(2);
+    });
+  });
+
+  describe("getSkills()", () => {
+    it("returns skills array", async () => {
+      await createSkill(
+        "get-skill",
+        `---
+name: get-skill
+description: For getSkills test
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const skills = await loader.getSkills();
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].name).toBe("get-skill");
+    });
+
+    it("only returns successfully loaded skills", async () => {
+      await createSkill(
+        "valid",
+        `---
+name: valid
+description: Valid skill
+---
+Content`,
+      );
+
+      await createSkill(
+        "invalid",
+        `---
+name: invalid
+---
+Missing description`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const skills = await loader.getSkills();
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].name).toBe("valid");
+    });
+
+    it("uses cached result", async () => {
+      await createSkill(
+        "cache-test",
+        `---
+name: cache-test
+description: Test
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+
+      // First call loads
+      const skills1 = await loader.getSkills();
+      // Second call uses cache
+      const skills2 = await loader.getSkills();
+
+      expect(skills1).toBe(skills2);
+    });
+  });
+
+  describe("generatePrompt()", () => {
+    it("generates XML prompt by default", async () => {
+      await createSkill(
+        "prompt-skill",
+        `---
+name: prompt-skill
+description: For prompt test
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const prompt = await loader.generatePrompt();
+
+      expect(prompt).toContain("## Skills");
+      expect(prompt).toContain("<available_skills>");
+      expect(prompt).toContain("<name>prompt-skill</name>");
+    });
+
+    it("supports format option", async () => {
+      await createSkill(
+        "format-skill",
+        `---
+name: format-skill
+description: For format test
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const prompt = await loader.generatePrompt({ format: "json" });
+
+      expect(prompt).toContain('"available_skills"');
+      expect(prompt).toContain('"name": "format-skill"');
+    });
+
+    it("returns empty string when no skills", async () => {
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const prompt = await loader.generatePrompt();
+
+      expect(prompt).toBe("");
+    });
+
+    it("supports includeInstructions option", async () => {
+      await createSkill(
+        "no-instr-skill",
+        `---
+name: no-instr-skill
+description: Test
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const prompt = await loader.generatePrompt({ includeInstructions: false });
+
+      expect(prompt).not.toContain("## Skills");
+      expect(prompt).toContain("<available_skills>");
+    });
+  });
+
+  describe("LoadedSkill structure", () => {
+    it("includes location and directory fields", async () => {
+      const skillPath = await createSkill(
+        "struct-skill",
+        `---
+name: struct-skill
+description: Structure test
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const skills = await loader.getSkills();
+
+      expect(skills[0].location).toBe(skillPath);
+      expect(skills[0].directory).toBe(path.dirname(skillPath));
+    });
+
+    it("preserves raw metadata", async () => {
+      await createSkill(
+        "raw-skill",
+        `---
+name: raw-skill
+description: Raw test
+customField: customValue
+---
+Content`,
+      );
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        logWarnings: false,
+      });
+      const skills = await loader.getSkills();
+
+      expect(skills[0].raw).toBeDefined();
+      expect(skills[0].raw?.customField).toBe("customValue");
+    });
+  });
+
+  describe("workspace path integration", () => {
+    it("loads skills from workspace path", async () => {
+      const workspaceDir = path.join(tempDir, "workspace");
+      const skillsDir = path.join(workspaceDir, "skills");
+      await fs.mkdir(skillsDir, { recursive: true });
+
+      await createSkill("ws-skill", `---
+name: ws-skill
+description: Workspace skill
+---
+Content`, "workspace/skills");
+
+      const loader = new SkillLoader({
+        globalPath: "/non/existent", // No global skills
+        workspacePath: workspaceDir,
+        logWarnings: false,
+      });
+      const result = await loader.load();
+
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].name).toBe("ws-skill");
+    });
+
+    it("merges skills from global and workspace", async () => {
+      // Create global skill
+      await createSkill(
+        "global-skill",
+        `---
+name: global-skill
+description: Global
+---
+Content`,
+      );
+
+      // Create workspace skill
+      const workspaceDir = path.join(tempDir, "workspace");
+      await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+      await createSkill("ws-skill", `---
+name: ws-skill
+description: Workspace
+---
+Content`, "workspace/skills");
+
+      const loader = new SkillLoader({
+        globalPath: tempDir,
+        workspacePath: workspaceDir,
+        logWarnings: false,
+      });
+      const result = await loader.load();
+
+      expect(result.skills).toHaveLength(2);
+      const names = result.skills.map((s) => s.name).sort();
+      expect(names).toEqual(["global-skill", "ws-skill"]);
+    });
+  });
+});

--- a/src/skills/skill-loader.ts
+++ b/src/skills/skill-loader.ts
@@ -1,0 +1,108 @@
+// src/skills/skill-loader.ts — Unified skill loading and caching
+// Combines discovery, parsing, and prompt generation into a single class.
+
+import { DiscoveryOptions, discoverSkills } from "./discovery.js";
+import { parseSkillFile } from "./parser.js";
+import { LoadedSkill, generateSkillsPrompt, PromptGeneratorOptions } from "./prompt.js";
+
+export interface SkillLoaderOptions extends DiscoveryOptions {
+  /** Log warnings to console. Default: true */
+  logWarnings?: boolean;
+}
+
+export interface LoadResult {
+  skills: LoadedSkill[];
+  errors: Array<{ path: string; error: string }>;
+  warnings: Array<{ path: string; warning: string }>;
+}
+
+export class SkillLoader {
+  private options: SkillLoaderOptions;
+  private cachedResult: LoadResult | null = null;
+
+  constructor(options?: SkillLoaderOptions) {
+    this.options = options ?? {};
+  }
+
+  /**
+   * Discover and load all skills.
+   * Caches result for subsequent calls.
+   */
+  async load(): Promise<LoadResult> {
+    if (this.cachedResult) {
+      return this.cachedResult;
+    }
+
+    const { logWarnings = true, ...discoveryOptions } = this.options;
+
+    const skills: LoadedSkill[] = [];
+    const errors: Array<{ path: string; error: string }> = [];
+    const warnings: Array<{ path: string; warning: string }> = [];
+
+    // Discover skill files
+    const discovered = await discoverSkills(discoveryOptions);
+
+    // Parse each discovered skill
+    for (const { skillPath, directory } of discovered) {
+      const result = await parseSkillFile(skillPath);
+
+      if (!result.success) {
+        errors.push({
+          path: skillPath,
+          error: result.error ?? "Unknown parse error",
+        });
+        continue;
+      }
+
+      // Collect warnings
+      if (result.warnings) {
+        for (const warning of result.warnings) {
+          warnings.push({ path: skillPath, warning });
+          if (logWarnings) {
+            console.warn(`[skills] ${skillPath}: ${warning}`);
+          }
+        }
+      }
+
+      // Add successfully parsed skill
+      if (result.metadata) {
+        skills.push({
+          name: result.metadata.name,
+          description: result.metadata.description,
+          raw: result.metadata.raw,
+          location: skillPath,
+          directory,
+        });
+      }
+    }
+
+    this.cachedResult = { skills, errors, warnings };
+    return this.cachedResult;
+  }
+
+  /**
+   * Clear cached skills.
+   * Next call to load() or getSkills() will re-scan.
+   */
+  clearCache(): void {
+    this.cachedResult = null;
+  }
+
+  /**
+   * Get cached skills or load if not cached.
+   * Returns only successfully loaded skills.
+   */
+  async getSkills(): Promise<LoadedSkill[]> {
+    const result = await this.load();
+    return result.skills;
+  }
+
+  /**
+   * Generate system prompt block for loaded skills.
+   * Loads skills if not already cached.
+   */
+  async generatePrompt(options?: PromptGeneratorOptions): Promise<string> {
+    const skills = await this.getSkills();
+    return generateSkillsPrompt(skills, options);
+  }
+}


### PR DESCRIPTION
## M9 Skills System

Implements the Skills system for Isotopes, enabling agents to load task-specific instructions on-demand.

### Changes

#### M9.1 - Skill Discovery (`src/skills/discovery.ts`)
- `discoverSkills()` scans directories for SKILL.md files
- Supports global (~/.isotopes/skills) and workspace paths
- Recursive scanning with ignored directories (node_modules, .git, etc.)
- Path deduplication

#### M9.2 - Frontmatter Parser (`src/skills/parser.ts`)
- Parse YAML frontmatter from SKILL.md files
- Validate name format (lowercase, alphanumeric, hyphens)
- Validate required fields (name, description)
- Return warnings for invalid name format

#### M9.3 - Prompt Generator (`src/skills/prompt.ts`)
- Generate XML-formatted skill blocks for system prompts
- Support multiple formats (xml, markdown, json)
- Escape XML special characters
- Include/exclude instruction block option

#### M9.4 - Integration (`src/skills/skill-loader.ts`, `src/skills/index.ts`)
- `SkillLoader` class integrates discovery, parsing, and prompt generation
- Caching mechanism for loaded skills
- Error and warning collection
- Re-export all public APIs

### Testing
- **88 new tests** for the skills system
- All **1063 tests pass**

### PRD
See `docs/ongoing/PRD-M9-skills.md` for full specification.