### PR TITLE
fix(subagent): pass permissionMode config to AcpxBackend

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,9 @@ import {
   toAgentConfig,
   getDiscordToken,
   resolveAcpConfig,
+  resolveSubagentConfig,
 } from "./core/config.js";
+import { initSubagentBackend } from "./tools/subagent.js";
 import { PiMonoCore } from "./core/pi-mono.js";
 import { DefaultAgentManager } from "./core/agent-manager.js";
 import { DefaultSessionStore } from "./core/session-store.js";
@@ -256,6 +258,16 @@ async function main() {
 
   const config = await loadConfig(configPath);
   logger.info(`Loaded ${config.agents.length} agent(s)`);
+
+  // Initialize subagent backend with config (M8)
+  if (config.acp?.enabled) {
+    const subagentConfig = resolveSubagentConfig(config.acp.subagent);
+    initSubagentBackend({
+      permissionMode: subagentConfig.permissionMode,
+      allowedTools: subagentConfig.allowedTools,
+    });
+    logger.info(`Subagent backend initialized (permissionMode: ${subagentConfig.permissionMode})`);
+  }
 
   // Initialize core with tool registry
   const core = new PiMonoCore();

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -49,8 +49,10 @@ export {
   hasRunningSubagents,
   getActiveSubagentCount,
   getSupportedAgents,
+  initSubagentBackend,
 } from "./subagent.js";
 export type {
   SpawnSubagentOptions,
   SpawnSubagentResult,
+  SubagentBackendConfig,
 } from "./subagent.js";

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -9,12 +9,21 @@ import {
   type AcpxResult,
   type AcpxEvent,
 } from "../subagent/index.js";
+import type { SubagentPermissionMode } from "../core/config.js";
 
 const log = createLogger("tools:subagent");
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/** Configuration for the subagent backend (from acp.subagent in config) */
+export interface SubagentBackendConfig {
+  /** Permission mode for tool execution */
+  permissionMode?: SubagentPermissionMode;
+  /** Allowed tools for allowlist mode */
+  allowedTools?: string[];
+}
 
 /** Options for spawning a sub-agent */
 export interface SpawnSubagentOptions {
@@ -52,10 +61,33 @@ export interface SpawnSubagentResult {
 /** Shared backend instance (lazy initialized) */
 let sharedBackend: AcpxBackend | undefined;
 
+/** Cached backend config */
+let backendConfig: SubagentBackendConfig = {};
+
+/**
+ * Initialize the subagent backend with configuration.
+ * Should be called during app startup with config from acp.subagent.
+ * 
+ * @param config - Configuration from resolveSubagentConfig()
+ */
+export function initSubagentBackend(config: SubagentBackendConfig): void {
+  backendConfig = config;
+  // Clear existing backend so it gets recreated with new config
+  sharedBackend = undefined;
+  log.info("Subagent backend initialized", { 
+    permissionMode: config.permissionMode ?? "allowlist",
+    allowedTools: config.allowedTools,
+  });
+}
+
 function getBackend(allowedWorkspaces?: string[]): AcpxBackend {
   // Create new backend if workspaces changed or not initialized
   if (!sharedBackend || allowedWorkspaces) {
-    sharedBackend = new AcpxBackend(allowedWorkspaces);
+    sharedBackend = new AcpxBackend({
+      allowedWorkspaceRoots: allowedWorkspaces,
+      permissionMode: backendConfig.permissionMode,
+      allowedTools: backendConfig.allowedTools,
+    });
   }
   return sharedBackend;
 }


### PR DESCRIPTION
## Bug

`getBackend()` in `tools/subagent.ts` was not passing `permissionMode` from config to `AcpxBackend`, causing Claude Code to always use default `allowlist` mode instead of configured `skip` mode.

This caused Claude Code subagent to get stuck in an infinite approval loop even when `acp.subagent.permissionMode: skip` was configured.

## Fix

1. Add `initSubagentBackend()` function to configure backend with permissionMode and allowedTools
2. Call `initSubagentBackend()` during CLI startup with resolved config from `acp.subagent`
3. Export `SubagentBackendConfig` type for consumers

## Testing

- All 975 tests pass
- Type check passes

## Config Example

```yaml
acp:
  enabled: true
  subagent:
    permissionMode: skip  # Now correctly passed to AcpxBackend
```