### PR TITLE
fix(discord): add historyLimit to prevent context overflow

### DIFF
--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -160,6 +160,8 @@ export interface DiscordTransportConfig {
   subagentShowToolCalls?: boolean;
   /** Whether to respond to messages from other bots. Default: false */
   allowBots?: boolean;
+  /** Maximum number of messages to include in context. Default: 50 */
+  historyLimit?: number;
 }
 
 /**
@@ -300,7 +302,12 @@ export class DiscordTransport implements Transport {
     };
     await sessionStore.addMessage(session.id, userMessage);
 
-    const promptInput = await sessionStore.getMessages(session.id);
+    const allMessages = await sessionStore.getMessages(session.id);
+    // Limit context to recent messages to prevent context overflow
+    const historyLimit = this.config.historyLimit ?? 50;
+    const promptInput = allMessages.length > historyLimit
+      ? allMessages.slice(-historyLimit)
+      : allMessages;
 
     // Run agent and stream response
     await this.runAgentAndRespond(


### PR DESCRIPTION
## Problem
Discord transport loads all session messages into context without limit. When a channel has many messages, the first request exceeds the context window limit (~168k tokens).

## Root Cause
`sessionStore.getMessages()` returns all messages. No truncation was applied before passing to the agent.

## Fix
Added `historyLimit` config option (default: 50) to Discord transport. Messages are now truncated to most recent N before sending to agent:

```typescript
const allMessages = await sessionStore.getMessages(session.id);
const historyLimit = this.config.historyLimit ?? 50;
const promptInput = allMessages.length > historyLimit
  ? allMessages.slice(-historyLimit)
  : allMessages;
```

## Related
- PR #70 fixed compaction config passthrough
- This fix prevents overflow before compaction can trigger

Closes #71 (if issue exists)