### PR TITLE
fix: clear agent messages before prompt to prevent accumulation

### DIFF
--- a/src/core/compaction.test.ts
+++ b/src/core/compaction.test.ts
@@ -12,6 +12,9 @@ import {
   compactMessages,
   createTransformContext,
   resolveCompactionConfig,
+  isContextOverflow,
+  forceCompact,
+  iterativeCompact,
 } from "./compaction.js";
 
 // ---------------------------------------------------------------------------
@@ -376,5 +379,223 @@ describe("createTransformContext", () => {
 
     expect(result).toBe(messages);
     expect(summarize).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isContextOverflow
+// ---------------------------------------------------------------------------
+
+describe("isContextOverflow", () => {
+  it("returns false for undefined or empty error message", () => {
+    expect(isContextOverflow(undefined)).toBe(false);
+    expect(isContextOverflow("")).toBe(false);
+  });
+
+  it("detects Anthropic overflow error", () => {
+    expect(isContextOverflow("prompt is too long: 213462 tokens > 200000 maximum")).toBe(true);
+  });
+
+  it("detects OpenAI overflow error", () => {
+    expect(isContextOverflow("Your input exceeds the context window of this model")).toBe(true);
+  });
+
+  it("detects Google Gemini overflow error", () => {
+    expect(isContextOverflow("The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)")).toBe(true);
+  });
+
+  it("detects generic overflow patterns", () => {
+    expect(isContextOverflow("context length exceeded")).toBe(true);
+    expect(isContextOverflow("too many tokens in request")).toBe(true);
+    expect(isContextOverflow("token limit exceeded")).toBe(true);
+  });
+
+  it("detects Cerebras 400/413 status code errors", () => {
+    expect(isContextOverflow("400 status code (no body)")).toBe(true);
+    expect(isContextOverflow("413 (no body)")).toBe(true);
+  });
+
+  it("returns false for non-overflow errors", () => {
+    expect(isContextOverflow("rate limit exceeded")).toBe(false);
+    expect(isContextOverflow("invalid API key")).toBe(false);
+    expect(isContextOverflow("network timeout")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forceCompact
+// ---------------------------------------------------------------------------
+
+describe("forceCompact", () => {
+  it("compacts messages regardless of threshold", async () => {
+    // Small messages that wouldn't trigger normal compaction
+    const messages = makeMessages(20, 100);
+    const summarize = vi.fn().mockResolvedValue("forced summary");
+
+    const result = await forceCompact({
+      messages,
+      config: makeConfig({ preserveRecent: 5 }),
+      summarize,
+    });
+
+    // Should have 1 summary + 5 recent = 6 messages
+    expect(result).toHaveLength(6);
+    expect(summarize).toHaveBeenCalledOnce();
+
+    const summary = result[0] as unknown as Record<string, unknown>;
+    expect(summary.content).toContain("[Previous conversation summary]");
+    expect(summary.content).toContain("forced summary");
+  });
+
+  it("returns original messages when not enough to compact", async () => {
+    const messages = makeMessages(5, 100);
+    const summarize = vi.fn();
+
+    const result = await forceCompact({
+      messages,
+      config: makeConfig({ preserveRecent: 5 }),
+      summarize,
+    });
+
+    expect(result).toBe(messages);
+    expect(summarize).not.toHaveBeenCalled();
+  });
+
+  it("throws when summarize fails", async () => {
+    const messages = makeMessages(20, 100);
+    const summarize = vi.fn().mockRejectedValue(new Error("LLM error"));
+
+    await expect(
+      forceCompact({
+        messages,
+        config: makeConfig({ preserveRecent: 5 }),
+        summarize,
+      }),
+    ).rejects.toThrow("LLM error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// iterativeCompact
+// ---------------------------------------------------------------------------
+
+describe("iterativeCompact", () => {
+  it("returns messages unchanged if already under threshold", async () => {
+    const messages = makeMessages(5, 100);
+    const summarize = vi.fn();
+
+    const result = await iterativeCompact({
+      messages,
+      config: makeConfig(),
+      summarize,
+    });
+
+    expect(result).toBe(messages);
+    expect(summarize).not.toHaveBeenCalled();
+  });
+
+  it("performs multiple rounds until under threshold", async () => {
+    // Create messages that need multiple rounds of compaction
+    // Start with 100 messages * 5000 chars = 500000 chars → ~166666 tokens (with JSON estimate)
+    const messages = makeMessages(100, 5000);
+    let callCount = 0;
+    const summarize = vi.fn().mockImplementation(() => {
+      callCount++;
+      // Each summary is small, simulating good compression
+      return Promise.resolve(`Round ${callCount} summary - brief`);
+    });
+
+    const result = await iterativeCompact({
+      messages,
+      config: makeConfig({
+        contextWindow: 128_000,
+        threshold: 0.5,
+        preserveRecent: 10,
+      }),
+      summarize,
+      maxRounds: 3,
+    });
+
+    // Should have compacted at least once
+    expect(summarize).toHaveBeenCalled();
+    // Result should be smaller than original
+    expect(result.length).toBeLessThan(messages.length);
+  });
+
+  it("stops at max rounds even if still over threshold", async () => {
+    // Very large messages that can't be compacted enough
+    const messages = makeMessages(20, 50_000);
+    const summarize = vi.fn().mockResolvedValue("x".repeat(40_000)); // Summary is still big
+
+    const result = await iterativeCompact({
+      messages,
+      config: makeConfig({
+        contextWindow: 10_000,
+        threshold: 0.5,
+        preserveRecent: 5,
+      }),
+      summarize,
+      maxRounds: 2,
+    });
+
+    // Should have attempted maxRounds compactions
+    expect(summarize).toHaveBeenCalledTimes(2);
+    // Should return what we have even if still over threshold
+    expect(result).toBeDefined();
+  });
+
+  it("stops when not enough messages to compact further", async () => {
+    // 15 messages with large content that exceeds threshold
+    // preserveRecent=14 means after first compaction we have 1 summary + 14 recent = 15 messages
+    // But 15 messages with preserveRecent=14 means only 1 message can be summarized
+    // Eventually we hit the minimum and can't compact further
+    const messages = makeMessages(15, 10_000);
+    const summarize = vi.fn().mockResolvedValue("short summary");
+
+    const result = await iterativeCompact({
+      messages,
+      config: makeConfig({
+        contextWindow: 50_000,
+        threshold: 0.3,
+        preserveRecent: 14,
+      }),
+      summarize,
+      maxRounds: 5,
+    });
+
+    // Should have attempted compaction
+    expect(summarize).toHaveBeenCalled();
+    // Result should be returned
+    expect(result).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token estimation with JSON content
+// ---------------------------------------------------------------------------
+
+describe("estimateMessageTokens with JSON content", () => {
+  it("uses more conservative estimate for JSON-like content", () => {
+    const jsonMsg = makeMessage("assistant", '{"type":"text","output":"result"}');
+    const textMsg = makeMessage("user", "This is a plain text message here");
+
+    // JSON should use 3 chars/token, text uses 4 chars/token
+    // JSON: 35 chars → ceil(35/3) = 12 tokens
+    // Text: 35 chars → ceil(35/4) = 9 tokens
+    expect(estimateMessageTokens(jsonMsg)).toBeGreaterThan(estimateMessageTokens(textMsg));
+  });
+
+  it("detects array JSON content", () => {
+    const arrayMsg = makeMessage("assistant", '[{"id":1},{"id":2}]');
+    // 19 chars, JSON-like → ceil(19/3) = 7 tokens
+    expect(estimateMessageTokens(arrayMsg)).toBe(7);
+  });
+
+  it("detects tool result patterns", () => {
+    const toolResultMsg = makeMessage("assistant", 'Some prefix "output": "tool result here"');
+    // Contains "output": pattern, should be treated as JSON-like
+    const plainMsg = makeMessage("user", "Some prefix output tool result here");
+
+    expect(estimateMessageTokens(toolResultMsg)).toBeGreaterThan(estimateMessageTokens(plainMsg));
   });
 });

--- a/src/core/compaction.ts
+++ b/src/core/compaction.ts
@@ -15,6 +15,12 @@ const log = createLogger("compaction");
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_PRESERVE_RECENT = 10;
 const CHARS_PER_TOKEN = 4;
+/** More conservative estimate for JSON/tool content which is less token-efficient */
+const CHARS_PER_TOKEN_JSON = 3;
+/** Safety margin multiplier applied to threshold (e.g., 0.9 means trigger 10% earlier) */
+const THRESHOLD_SAFETY_MARGIN = 0.9;
+/** Maximum compaction rounds to prevent infinite loops */
+const MAX_COMPACTION_ROUNDS = 3;
 
 /** Default threshold ratios per mode */
 const DEFAULT_THRESHOLDS: Record<CompactionMode, number> = {
@@ -28,12 +34,30 @@ const DEFAULT_THRESHOLDS: Record<CompactionMode, number> = {
 // ---------------------------------------------------------------------------
 
 /**
+ * Check if message content appears to be JSON or tool-related content.
+ * These are less token-efficient and need more conservative estimation.
+ */
+function isJsonLikeContent(content: string): boolean {
+  const trimmed = content.trim();
+  // Check for JSON object/array patterns or common tool result patterns
+  return (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]")) ||
+    trimmed.includes('"type":') ||
+    trimmed.includes('"output":') ||
+    trimmed.includes('"result":')
+  );
+}
+
+/**
  * Estimate the token count of a single AgentMessage.
- * Uses a rough heuristic: 4 characters ≈ 1 token.
+ * Uses a rough heuristic: 4 characters ≈ 1 token for plain text,
+ * 3 characters ≈ 1 token for JSON/tool content (more conservative).
  */
 export function estimateMessageTokens(message: AgentMessage): number {
   const content = extractMessageText(message);
-  return Math.ceil(content.length / CHARS_PER_TOKEN);
+  const charsPerToken = isJsonLikeContent(content) ? CHARS_PER_TOKEN_JSON : CHARS_PER_TOKEN;
+  return Math.ceil(content.length / charsPerToken);
 }
 
 /**
@@ -127,6 +151,7 @@ export function buildSummaryPrompt(messages: AgentMessage[]): string {
 
 /**
  * Determine whether compaction should be triggered based on config and message count.
+ * Applies a safety margin to trigger compaction slightly earlier than the raw threshold.
  */
 export function shouldCompact(
   messages: AgentMessage[],
@@ -137,7 +162,9 @@ export function shouldCompact(
   const tokenEstimate = estimateTotalTokens(messages);
   const contextWindow = config.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
   const threshold = config.threshold ?? DEFAULT_THRESHOLDS[config.mode];
-  const limit = Math.floor(contextWindow * threshold);
+  // Apply safety margin to trigger compaction earlier
+  const effectiveThreshold = threshold * THRESHOLD_SAFETY_MARGIN;
+  const limit = Math.floor(contextWindow * effectiveThreshold);
 
   // Need at least preserveRecent + 1 messages to have something to compact
   const preserveRecent = config.preserveRecent ?? DEFAULT_PRESERVE_RECENT;
@@ -249,4 +276,178 @@ export function createTransformContext(
       signal,
     });
   };
+}
+
+// ---------------------------------------------------------------------------
+// Overflow detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex patterns to detect context overflow errors from different providers.
+ * Based on patterns from @mariozechner/pi-ai/utils/overflow.
+ */
+const OVERFLOW_PATTERNS = [
+  /prompt is too long/i,                            // Anthropic
+  /input is too long for requested model/i,         // Amazon Bedrock
+  /exceeds the context window/i,                    // OpenAI
+  /input token count.*exceeds the maximum/i,        // Google (Gemini)
+  /maximum prompt length is \d+/i,                  // xAI (Grok)
+  /reduce the length of the messages/i,             // Groq
+  /maximum context length is \d+ tokens/i,          // OpenRouter
+  /exceeds the limit of \d+/i,                      // GitHub Copilot
+  /exceeds the available context size/i,            // llama.cpp server
+  /greater than the context length/i,               // LM Studio
+  /context window exceeds limit/i,                  // MiniMax
+  /exceeded model token limit/i,                    // Kimi For Coding
+  /too large for model with \d+ maximum context length/i, // Mistral
+  /model_context_window_exceeded/i,                 // z.ai
+  /prompt too long; exceeded (?:max )?context length/i, // Ollama
+  /context[_ ]length[_ ]exceeded/i,                 // Generic fallback
+  /too many tokens/i,                               // Generic fallback
+  /token limit exceeded/i,                          // Generic fallback
+];
+
+/**
+ * Check if an error message indicates a context overflow error.
+ * This is used to detect when we need to force compaction and retry.
+ */
+export function isContextOverflow(errorMessage: string | undefined): boolean {
+  if (!errorMessage) return false;
+
+  // Check known patterns
+  if (OVERFLOW_PATTERNS.some((p) => p.test(errorMessage))) {
+    return true;
+  }
+
+  // Cerebras returns 400/413 with no body for context overflow
+  if (/^4(00|13)\s*(status code)?\s*\(no body\)/i.test(errorMessage)) {
+    return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Force compaction (for overflow recovery)
+// ---------------------------------------------------------------------------
+
+export interface ForceCompactOptions {
+  messages: AgentMessage[];
+  config: CompactionConfig;
+  summarize: (prompt: string, signal?: AbortSignal) => Promise<string>;
+  signal?: AbortSignal;
+}
+
+/**
+ * Force a compaction regardless of threshold.
+ * Used for overflow recovery when we must reduce context size.
+ * Returns the compacted messages or throws if compaction is not possible.
+ */
+export async function forceCompact(
+  opts: ForceCompactOptions,
+): Promise<AgentMessage[]> {
+  const { messages, config, summarize, signal } = opts;
+
+  const preserveRecent = config.preserveRecent ?? DEFAULT_PRESERVE_RECENT;
+
+  // Can't compact if we don't have enough messages
+  if (messages.length <= preserveRecent) {
+    log.warn(
+      `Cannot force compact: only ${messages.length} messages, need more than ${preserveRecent} to compact`,
+    );
+    return messages;
+  }
+
+  const splitIndex = messages.length - preserveRecent;
+  const oldMessages = messages.slice(0, splitIndex);
+  const recentMessages = messages.slice(splitIndex);
+
+  log.info(
+    `Force compacting: ${messages.length} messages → summarizing ${oldMessages.length}, keeping ${recentMessages.length}`,
+  );
+
+  const tokensBefore = estimateTotalTokens(messages);
+
+  const prompt = buildSummaryPrompt(oldMessages);
+  const summaryText = await summarize(prompt, signal);
+
+  const summaryMessage = createSummaryMessage(summaryText);
+  const compacted = [summaryMessage, ...recentMessages];
+
+  const tokensAfter = estimateTotalTokens(compacted);
+  log.info(
+    `Force compaction complete: ~${tokensBefore} → ~${tokensAfter} tokens (${Math.round((1 - tokensAfter / tokensBefore) * 100)}% reduction)`,
+  );
+
+  return compacted;
+}
+
+// ---------------------------------------------------------------------------
+// Iterative compaction (for stubborn overflow)
+// ---------------------------------------------------------------------------
+
+export interface IterativeCompactOptions {
+  messages: AgentMessage[];
+  config: CompactionConfig;
+  summarize: (prompt: string, signal?: AbortSignal) => Promise<string>;
+  signal?: AbortSignal;
+  /** Maximum number of compaction rounds. Default: 3 */
+  maxRounds?: number;
+}
+
+/**
+ * Perform iterative compaction until under threshold or max rounds reached.
+ * This is more aggressive than regular compaction - it will keep compacting
+ * until the context is small enough.
+ */
+export async function iterativeCompact(
+  opts: IterativeCompactOptions,
+): Promise<AgentMessage[]> {
+  const { config, summarize, signal, maxRounds = MAX_COMPACTION_ROUNDS } = opts;
+  let { messages } = opts;
+
+  const contextWindow = config.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+  const threshold = config.threshold ?? DEFAULT_THRESHOLDS[config.mode];
+  const limit = Math.floor(contextWindow * threshold);
+  const preserveRecent = config.preserveRecent ?? DEFAULT_PRESERVE_RECENT;
+
+  for (let round = 1; round <= maxRounds; round++) {
+    const tokenEstimate = estimateTotalTokens(messages);
+
+    if (tokenEstimate <= limit) {
+      log.info(`Iterative compaction complete after ${round - 1} round(s): ~${tokenEstimate} tokens`);
+      return messages;
+    }
+
+    // Can't compact further if we're at minimum message count
+    if (messages.length <= preserveRecent) {
+      log.warn(
+        `Cannot compact further: only ${messages.length} messages remain, ~${tokenEstimate} tokens still over limit`,
+      );
+      return messages;
+    }
+
+    log.info(
+      `Iterative compaction round ${round}/${maxRounds}: ~${tokenEstimate} tokens > ${limit} limit`,
+    );
+
+    try {
+      messages = await forceCompact({
+        messages,
+        config,
+        summarize,
+        signal,
+      });
+    } catch (err) {
+      log.error(`Iterative compaction round ${round} failed`, err);
+      return messages;
+    }
+  }
+
+  const finalTokens = estimateTotalTokens(messages);
+  log.warn(
+    `Iterative compaction reached max rounds (${maxRounds}): ~${finalTokens} tokens`,
+  );
+
+  return messages;
 }

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -16,7 +16,14 @@ import {
   type Tool,
 } from "./types.js";
 import type { ToolRegistry } from "./tools.js";
-import { createTransformContext, resolveCompactionConfig } from "./compaction.js";
+import {
+  createTransformContext,
+  resolveCompactionConfig,
+  isContextOverflow,
+  forceCompact,
+  iterativeCompact,
+  estimateTotalTokens,
+} from "./compaction.js";
 import { createLogger } from "./logger.js";
 
 // ---------------------------------------------------------------------------
@@ -250,6 +257,12 @@ function toAgentTool(tool: Tool, handler: (args: unknown) => Promise<string>): A
 // PiMonoCore
 // ---------------------------------------------------------------------------
 
+/** Options passed to PiMonoInstance for overflow recovery */
+interface CompactionContext {
+  config: ReturnType<typeof resolveCompactionConfig>;
+  summarize: (prompt: string, signal?: AbortSignal) => Promise<string>;
+}
+
 /**
  * PiMonoCore — {@link AgentCore} implementation backed by pi-agent-core.
  *
@@ -284,6 +297,7 @@ export class PiMonoCore implements AgentCore {
 
     // Build transformContext hook for context compaction
     let transformContext: ((messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>) | undefined;
+    let compactionContext: CompactionContext | undefined;
 
     if (config.compaction && config.compaction.mode !== "off") {
       const compactionConfig = resolveCompactionConfig(config.compaction);
@@ -309,6 +323,9 @@ export class PiMonoCore implements AgentCore {
         config: compactionConfig,
         summarize,
       });
+
+      // Pass compaction context to instance for overflow recovery
+      compactionContext = { config: compactionConfig, summarize };
     }
 
     const agent = new Agent({
@@ -324,7 +341,7 @@ export class PiMonoCore implements AgentCore {
         : {}),
     });
 
-    return new PiMonoInstance(agent);
+    return new PiMonoInstance(agent, compactionContext);
   }
 }
 
@@ -332,10 +349,16 @@ export class PiMonoCore implements AgentCore {
 // PiMonoInstance — wraps a single pi-agent-core Agent instance
 // ---------------------------------------------------------------------------
 
+/** Maximum number of overflow recovery attempts */
+const MAX_OVERFLOW_RETRIES = 2;
+
 class PiMonoInstance implements AgentInstance {
   private promptQueue: Promise<void> = Promise.resolve();
 
-  constructor(private agent: Agent) {}
+  constructor(
+    private agent: Agent,
+    private compactionContext?: CompactionContext,
+  ) {}
 
   async *prompt(input: string | Message[]): AsyncIterable<AgentEvent> {
     let releaseQueue: (() => void) | undefined;
@@ -346,11 +369,37 @@ class PiMonoInstance implements AgentInstance {
 
     await waitForTurn;
 
-    // Subscribe before calling prompt so we don't miss events
+    try {
+      // Attempt prompt with overflow recovery
+      yield* this.promptWithOverflowRecovery(input);
+    } finally {
+      releaseQueue?.();
+    }
+  }
+
+  /**
+   * Execute prompt with overflow detection and recovery.
+   * If an overflow error is detected, compact context and retry.
+   */
+  private async *promptWithOverflowRecovery(
+    input: string | Message[],
+    retryCount = 0,
+  ): AsyncIterable<AgentEvent> {
     const events: (CoreEvent | null)[] = [];
     let resolve: (() => void) | null = null;
+    let overflowDetected = false;
+    let overflowErrorMessage: string | undefined;
 
     const unsub = this.agent.subscribe((e: CoreEvent) => {
+      // Check for overflow in agent_end events
+      if (e.type === "agent_end") {
+        const messages = e.messages.map(fromAgentMessage);
+        const { errorMessage } = getAgentEndMetadata(messages);
+        if (errorMessage && isContextOverflow(errorMessage)) {
+          overflowDetected = true;
+          overflowErrorMessage = errorMessage;
+        }
+      }
       events.push(e);
       resolve?.();
     });
@@ -366,16 +415,22 @@ class PiMonoInstance implements AgentInstance {
         resolve?.();
       },
       (err) => {
-        // Push error sentinel so the while loop exits
+        // Check if the error itself indicates overflow
+        const errMessage = err instanceof Error ? err.message : String(err);
+        if (isContextOverflow(errMessage)) {
+          overflowDetected = true;
+          overflowErrorMessage = errMessage;
+        }
         events.push(null);
         resolve?.();
-        // Re-throw to propagate the error to `await done`
         throw err;
       },
     );
 
     try {
       let finished = false;
+      const collectedEvents: AgentEvent[] = [];
+
       while (!finished) {
         if (events.length === 0) {
           await new Promise<void>((r) => {
@@ -389,13 +444,70 @@ class PiMonoInstance implements AgentInstance {
             break;
           }
           const mapped = mapEvent(ev);
-          if (mapped) yield mapped;
+          if (mapped) {
+            collectedEvents.push(mapped);
+          }
         }
       }
-      await done;
+
+      // Try to await done, but catch overflow errors
+      try {
+        await done;
+      } catch (err) {
+        const errMessage = err instanceof Error ? err.message : String(err);
+        if (isContextOverflow(errMessage)) {
+          overflowDetected = true;
+          overflowErrorMessage = errMessage;
+        } else {
+          // Re-throw non-overflow errors
+          throw err;
+        }
+      }
+
+      // Handle overflow recovery
+      if (overflowDetected && this.compactionContext && retryCount < MAX_OVERFLOW_RETRIES) {
+        log.warn(
+          `Context overflow detected (attempt ${retryCount + 1}/${MAX_OVERFLOW_RETRIES}): ${overflowErrorMessage}`,
+        );
+
+        // Get current messages from agent state and perform iterative compaction
+        const currentMessages = this.agent.state.messages;
+        const tokensBefore = estimateTotalTokens(currentMessages);
+
+        log.info(`Performing overflow recovery compaction: ~${tokensBefore} tokens in ${currentMessages.length} messages`);
+
+        try {
+          const compactedMessages = await iterativeCompact({
+            messages: currentMessages,
+            config: this.compactionContext.config,
+            summarize: this.compactionContext.summarize,
+            maxRounds: 3,
+          });
+
+          const tokensAfter = estimateTotalTokens(compactedMessages);
+          log.info(
+            `Overflow recovery compaction complete: ~${tokensBefore} → ~${tokensAfter} tokens`,
+          );
+
+          // Replace agent messages with compacted version
+          this.agent.replaceMessages(compactedMessages);
+
+          // Retry the prompt with compacted context
+          // Don't re-yield the failed events, start fresh
+          yield* this.promptWithOverflowRecovery(input, retryCount + 1);
+          return;
+        } catch (compactErr) {
+          log.error("Overflow recovery compaction failed", compactErr);
+          // Fall through to yield original events
+        }
+      }
+
+      // Yield all collected events
+      for (const event of collectedEvents) {
+        yield event;
+      }
     } finally {
       unsub();
-      releaseQueue?.();
     }
   }
 
@@ -409,6 +521,51 @@ class PiMonoInstance implements AgentInstance {
 
   followUp(msg: Message): void {
     this.agent.followUp(toAgentMessage(msg));
+  }
+
+  clearMessages(): void {
+    this.agent.clearMessages();
+  }
+
+  /**
+   * Force context compaction for overflow recovery.
+   * Returns true if compaction occurred, false if not possible or not configured.
+   */
+  async forceCompact(): Promise<boolean> {
+    if (!this.compactionContext) {
+      log.warn("forceCompact called but compaction is not configured");
+      return false;
+    }
+
+    const currentMessages = this.agent.state.messages;
+    const preserveRecent = this.compactionContext.config.preserveRecent ?? 10;
+
+    if (currentMessages.length <= preserveRecent) {
+      log.warn(
+        `Cannot force compact: only ${currentMessages.length} messages, need more than ${preserveRecent}`,
+      );
+      return false;
+    }
+
+    const tokensBefore = estimateTotalTokens(currentMessages);
+    log.info(`Force compacting: ~${tokensBefore} tokens in ${currentMessages.length} messages`);
+
+    try {
+      const compactedMessages = await forceCompact({
+        messages: currentMessages,
+        config: this.compactionContext.config,
+        summarize: this.compactionContext.summarize,
+      });
+
+      const tokensAfter = estimateTotalTokens(compactedMessages);
+      log.info(`Force compaction complete: ~${tokensBefore} → ~${tokensAfter} tokens`);
+
+      this.agent.replaceMessages(compactedMessages);
+      return true;
+    } catch (err) {
+      log.error("Force compaction failed", err);
+      return false;
+    }
   }
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -137,6 +137,10 @@ export interface AgentInstance {
   abort(): void;
   steer(msg: Message): void;
   followUp(msg: Message): void;
+  /** Force context compaction for overflow recovery. Returns true if compaction occurred. */
+  forceCompact?(): Promise<boolean>;
+  /** Clear internal message state before prompting with fresh context */
+  clearMessages?(): void;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -309,6 +309,10 @@ export class DiscordTransport implements Transport {
       ? allMessages.slice(-historyLimit)
       : allMessages;
 
+    // Clear agent internal state before prompting with fresh context
+    // This prevents message accumulation across prompts
+    agent.clearMessages?.();
+
     // Run agent and stream response
     await this.runAgentAndRespond(
       agent,


### PR DESCRIPTION
## Problem
Token count keeps growing (900k → 1M+) even with `historyLimit` truncation.

## Root Cause
`agent.prompt(messages)` **appends** messages to Agent's internal `_state.messages`, not replaces. So:
1. First prompt: 50 messages → Agent has 50
2. Second prompt: 50 messages → Agent has 100 (50 + 50)
3. ...accumulates to 1M tokens

## Fix
1. Add `clearMessages()` method to `AgentInstance` interface
2. Implement in `PiMonoInstance` → calls `this.agent.clearMessages()`
3. Discord transport calls `agent.clearMessages?.()` before each `prompt()`

This ensures Agent starts fresh with only the truncated session messages each time.

## Related
- PR #71 added `historyLimit` (necessary but not sufficient)
- This fix completes the solution by preventing Agent-internal accumulation