### PR TITLE
feat(discord): add context window debug logging

### DIFF
--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -314,6 +314,17 @@ export class DiscordTransport implements Transport {
       ? allMessages.slice(-historyLimit)
       : allMessages;
 
+    // Debug: Log context window contents
+    log.info(`[context-debug] Session ${session.id}: total=${allMessages.length}, sending=${promptInput.length}, historyLimit=${historyLimit}`);
+    for (let i = 0; i < promptInput.length; i++) {
+      const m = promptInput[i];
+      const contentStr = Array.isArray(m.content) 
+        ? m.content.map(c => 'text' in c ? c.text : '[block]').join(' ')
+        : String(m.content);
+      const preview = contentStr.slice(0, 100).replace(/\n/g, ' ');
+      log.debug(`[context-debug] msg[${i}] role=${m.role} len=${contentStr.length} preview="${preview}..."`);
+    }
+
     // Clear agent internal state before prompting with fresh context
     // This prevents message accumulation across prompts
     agent.clearMessages?.();


### PR DESCRIPTION
## Summary

Adds debug logging for context window contents when processing Discord messages.

## What's logged

- `[context-debug] Session xxx: total=N, sending=M, historyLimit=20`
- For each message: `[context-debug] msg[i] role=user/assistant len=X preview="first 100 chars..."`

## Why

Helps diagnose context management issues:
- When compaction should trigger but doesn't
- What messages are being sent vs dropped due to historyLimit
- Understanding why task instructions get "forgotten"

## Log level

- Summary line: INFO level (always visible)
- Per-message details: DEBUG level (verbose, requires debug mode)