### PR TITLE
fix(subagent): use workspacesKey for backend singleton

### DIFF
--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -82,7 +82,8 @@ export function initSubagentBackend(config: SubagentBackendConfig): void {
 
 function getBackend(allowedWorkspaces?: string[]): AcpxBackend {
   // Create new backend if workspaces changed or not initialized
-  if (!sharedBackend || allowedWorkspaces) {
+  const key = allowedWorkspaces?.sort().join(":") ?? "";
+  if (!sharedBackend || sharedBackend.workspacesKey !== key) {
     sharedBackend = new AcpxBackend({
       allowedWorkspaceRoots: allowedWorkspaces,
       permissionMode: backendConfig.permissionMode,


### PR DESCRIPTION
M8.5: Fix getBackend() to properly compare workspacesKey instead of truthy check