### PR TITLE
feat(tools): sessions_spawn + sessions_announce (#182)

### DIFF
--- a/docs/prd/PRD-156-sessions-spawn-announce.md
+++ b/docs/prd/PRD-156-sessions-spawn-announce.md
@@ -1,0 +1,213 @@
+# PRD-156: sessions_spawn + announce Tools
+
+## Summary
+
+Add two new agent tools:
+1. `sessions_spawn` — Create a new session for inter-agent or cross-transport communication
+2. `sessions_announce` — Broadcast a message to other agents/sessions
+
+## Current State
+
+```typescript
+// AcpSessionManager exists (src/acp/session-manager.ts):
+- createSession(agentId, threadId?) → AcpSession
+- getSession(sessionId) → AcpSession | undefined
+- terminate(sessionId)
+
+// AgentMessageBus exists (src/acp/message-bus.ts):
+- send(message) → MessageDelivery
+- broadcast(fromAgentId, content) → MessageDelivery[]
+- subscribe(agentId, handler)
+```
+
+**Gap:** These are internal APIs. Agents have no tools to invoke them directly.
+
+## Target Tool Schemas
+
+### `sessions_spawn`
+
+```typescript
+{
+  name: "sessions_spawn",
+  description: "Create a new session for async communication with another agent or transport",
+  parameters: {
+    target_agent_id: {
+      type: "string",
+      description: "Agent ID to create session for (must be in allowedAgents)",
+    },
+    thread_id: {
+      type: "string",
+      description: "Optional Discord thread ID to bind the session to",
+      optional: true,
+    },
+    metadata: {
+      type: "object",
+      description: "Optional key-value metadata for the session",
+      optional: true,
+    },
+  },
+  returns: {
+    session_id: "string — unique session ID",
+    agent_id: "string — target agent",
+    status: "string — 'active'",
+  },
+}
+```
+
+### `sessions_announce`
+
+```typescript
+{
+  name: "sessions_announce",
+  description: "Broadcast a message to all agents or a specific agent",
+  parameters: {
+    content: {
+      type: "string",
+      description: "Message content to broadcast",
+    },
+    to_agent_id: {
+      type: "string",
+      description: "Target agent ID (omit to broadcast to all)",
+      optional: true,
+    },
+    to_session_id: {
+      type: "string",
+      description: "Target session ID (requires to_agent_id)",
+      optional: true,
+    },
+    metadata: {
+      type: "object",
+      description: "Optional structured metadata",
+      optional: true,
+    },
+  },
+  returns: {
+    message_id: "string — unique message ID",
+    delivered: "boolean — true if at least one recipient received",
+    recipients: "number — count of sessions that received",
+  },
+}
+```
+
+## Changes Required
+
+### 1. New Tool File: `src/tools/sessions.ts`
+
+```typescript
+// Tool implementations for sessions_spawn and sessions_announce
+// Wraps AcpSessionManager and AgentMessageBus
+
+export interface SessionsToolContext {
+  sessionManager: AcpSessionManager;
+  messageBus: AgentMessageBus;
+  currentAgentId: string;       // Calling agent's ID
+  currentSessionId?: string;    // Calling session's ID (for fromSessionId)
+}
+
+export async function sessionsSpawn(
+  ctx: SessionsToolContext,
+  params: { target_agent_id: string; thread_id?: string; metadata?: Record<string, unknown> }
+): Promise<{ session_id: string; agent_id: string; status: string }>
+
+export async function sessionsAnnounce(
+  ctx: SessionsToolContext,
+  params: { content: string; to_agent_id?: string; to_session_id?: string; metadata?: Record<string, unknown> }
+): Promise<{ message_id: string; delivered: boolean; recipients: number }>
+```
+
+### 2. Tool Registration (`src/tools/index.ts`)
+
+Add `sessions_spawn` and `sessions_announce` to tool registry.
+
+```typescript
+// Tool definitions for schema exposure
+export const sessionsSpawnTool: ToolDefinition = {
+  name: "sessions_spawn",
+  description: "Create a new session for async communication with another agent",
+  inputSchema: { /* ... */ },
+};
+
+export const sessionsAnnounceTool: ToolDefinition = {
+  name: "sessions_announce", 
+  description: "Broadcast a message to other agents or a specific session",
+  inputSchema: { /* ... */ },
+};
+```
+
+### 3. Tool Handler Integration (`src/core/agent-runner.ts` or tool dispatch)
+
+- Inject `SessionsToolContext` when handling these tool calls
+- Context must include: sessionManager, messageBus, currentAgentId, currentSessionId
+
+### 4. Config Gate
+
+Tools should only be available if ACP is enabled:
+- Check `config.acp.enabled` before registering tools
+- Return error if tools called but ACP disabled
+
+## Validation Rules
+
+### sessions_spawn
+- `target_agent_id` must be in `config.acp.allowedAgents` (if configured)
+- Cannot spawn session for self (use existing session)
+- Return existing session if one already exists for agent+thread combo?
+
+### sessions_announce
+- If `to_session_id` is set, `to_agent_id` must also be set
+- Message content must be non-empty
+- Metadata keys must be strings
+
+## Test Cases
+
+1. **Basic spawn**: spawn session for allowed agent → returns session_id
+2. **Spawn denied**: spawn for agent not in allowedAgents → error
+3. **Spawn with thread binding**: spawn with thread_id → session bound to thread
+4. **Announce to all**: announce without target → broadcasts to all agents
+5. **Announce to agent**: announce with to_agent_id → only that agent receives
+6. **Announce to session**: announce with to_agent_id + to_session_id → only that session receives
+7. **ACP disabled**: call tools when acp.enabled=false → clear error message
+
+## Edge Cases
+
+1. **Concurrent spawns**: Two agents spawn session for same target simultaneously
+   - First wins, second gets existing session (idempotent by agent+thread)
+   
+2. **Announce to offline agent**: Target agent has no active handlers
+   - Message queued in `pendingByAgent`, delivered when agent subscribes
+   
+3. **Session cleanup**: What happens to spawned sessions when parent terminates?
+   - Option A: Orphan (sessions live independently)
+   - Option B: Cascade terminate
+   - **Recommendation**: Orphan by default, add optional `cascade: true` param later
+
+## Dependencies
+
+- AcpSessionManager must be initialized (via AcpConfig)
+- AgentMessageBus must be available
+- Tool context must carry current agent/session IDs
+
+## Open Questions
+
+1. Should `sessions_spawn` be idempotent (return existing session if already exists)?
+   - **Leaning yes** — safer for retry scenarios
+   
+2. Should we add `sessions_terminate` in this PR or separate (#159)?
+   - **Separate** — #159 is explicitly sessions_yield
+
+3. Rate limiting on announce?
+   - Defer to future — not blocking for MVP
+
+## Files to Change
+
+```
+src/tools/sessions.ts          — NEW: tool implementations
+src/tools/sessions.test.ts     — NEW: tests
+src/tools/index.ts             — register new tools
+src/core/tool-dispatch.ts      — handle sessions_* calls (if separate dispatcher exists)
+```
+
+## Backward Compatibility
+
+- New tools, no breaking changes
+- Tools only appear if ACP enabled
+- Existing ACP internals unchanged

--- a/docs/prd/PRD-157-sessions-send.md
+++ b/docs/prd/PRD-157-sessions-send.md
@@ -1,0 +1,234 @@
+# PRD-157: sessions_send Tool
+
+## Summary
+
+Add `sessions_send` tool — allows an agent to send a message to another agent or a specific session.
+
+**Relationship to other session tools:**
+- #156 `sessions_spawn` — create sessions
+- #157 `sessions_send` — send messages (this PRD)
+- #158 `sessions_list` — list/query sessions
+- #159 `sessions_yield` — terminate/pause sessions
+
+## Current State
+
+```typescript
+// AgentMessageBus (src/acp/message-bus.ts):
+send(partial: Omit<AgentMessage, "id" | "timestamp">): MessageDelivery
+broadcast(fromAgentId, content, metadata?): MessageDelivery[]
+```
+
+**Gap:** No tool exposes `send()` to agents. #156's `sessions_announce` is broadcast-focused; `sessions_send` is point-to-point.
+
+## Distinction: sessions_send vs sessions_announce
+
+| Tool | Purpose | Routing |
+|------|---------|---------|
+| `sessions_announce` (#156) | Broadcast/notify | One-to-many, all agents or one agent |
+| `sessions_send` (#157) | Direct message | One-to-one, specific session preferred |
+
+`sessions_send` is for targeted, conversational exchanges. `sessions_announce` is for notifications.
+
+## Target Tool Schema
+
+### `sessions_send`
+
+```typescript
+{
+  name: "sessions_send",
+  description: "Send a message to a specific agent or session",
+  parameters: {
+    to_agent_id: {
+      type: "string",
+      description: "Target agent ID (required)",
+    },
+    to_session_id: {
+      type: "string",
+      description: "Target session ID (optional — if omitted, routes to agent's default handler)",
+      optional: true,
+    },
+    content: {
+      type: "string",
+      description: "Message content",
+    },
+    metadata: {
+      type: "object",
+      description: "Optional structured metadata (e.g., reply_to, priority)",
+      optional: true,
+    },
+    expect_reply: {
+      type: "boolean",
+      description: "If true, block until recipient replies (timeout 30s). Default: false",
+      optional: true,
+    },
+  },
+  returns: {
+    message_id: "string — unique message ID",
+    delivered: "boolean — true if message reached at least one handler",
+    reply: "string | null — reply content if expect_reply=true and reply received",
+    reply_metadata: "object | null — reply metadata if present",
+  },
+}
+```
+
+## Implementation
+
+### 1. Add to `src/tools/sessions.ts`
+
+```typescript
+export interface SessionsSendParams {
+  to_agent_id: string;
+  to_session_id?: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  expect_reply?: boolean;
+}
+
+export interface SessionsSendResult {
+  message_id: string;
+  delivered: boolean;
+  reply?: string;
+  reply_metadata?: Record<string, unknown>;
+}
+
+export async function sessionsSend(
+  ctx: SessionsToolContext,
+  params: SessionsSendParams
+): Promise<SessionsSendResult> {
+  // Validate to_agent_id is in allowedAgents
+  const config = ctx.sessionManager.getConfig();
+  if (
+    config.allowedAgents?.length &&
+    !config.allowedAgents.includes(params.to_agent_id)
+  ) {
+    throw new Error(`Agent "${params.to_agent_id}" not in allowedAgents`);
+  }
+
+  // Send via message bus
+  const delivery = ctx.messageBus.send({
+    fromAgentId: ctx.currentAgentId,
+    fromSessionId: ctx.currentSessionId,
+    toAgentId: params.to_agent_id,
+    toSessionId: params.to_session_id,
+    content: params.content,
+    metadata: params.metadata,
+  });
+
+  // If expect_reply, wait for response
+  if (params.expect_reply) {
+    const reply = await waitForReply(ctx, delivery.messageId, 30_000);
+    return {
+      message_id: delivery.messageId,
+      delivered: delivery.delivered,
+      reply: reply?.content,
+      reply_metadata: reply?.metadata,
+    };
+  }
+
+  return {
+    message_id: delivery.messageId,
+    delivered: delivery.delivered,
+  };
+}
+```
+
+### 2. Reply Correlation
+
+For `expect_reply=true`, we need to correlate replies. Two options:
+
+**Option A: Convention-based metadata**
+- Sender includes `metadata.correlation_id = message_id`
+- Recipient's reply includes same `correlation_id`
+- Sender subscribes temporarily, filters by correlation_id
+
+**Option B: Built-in reply mechanism**
+- Add `replyTo(messageId, content, metadata)` to AgentMessageBus
+- Auto-routes to original sender's session
+
+**Recommendation:** Option A for MVP (no changes to message-bus.ts). Option B for v2.
+
+### 3. Tool Registration
+
+In `src/tools/index.ts`:
+
+```typescript
+export const sessionsSendTool: ToolDefinition = {
+  name: "sessions_send",
+  description: "Send a message to a specific agent or session",
+  inputSchema: {
+    type: "object",
+    properties: {
+      to_agent_id: { type: "string", description: "Target agent ID" },
+      to_session_id: { type: "string", description: "Target session ID (optional)" },
+      content: { type: "string", description: "Message content" },
+      metadata: { type: "object", description: "Optional metadata" },
+      expect_reply: { type: "boolean", description: "Wait for reply (default: false)" },
+    },
+    required: ["to_agent_id", "content"],
+  },
+};
+```
+
+### 4. Config Gate
+
+Same as #156 — only available when `config.acp.enabled = true`.
+
+## Validation Rules
+
+1. `to_agent_id` required, must be in `allowedAgents` (if configured)
+2. `to_session_id` optional — if provided, must be valid session ID
+3. `content` required, non-empty
+4. `expect_reply` timeout is 30s, returns `reply: null` if timeout
+
+## Test Cases
+
+1. **Basic send**: send to agent → delivered=true, message_id returned
+2. **Send to session**: send with to_session_id → routes to session handlers
+3. **Send to offline agent**: no handlers → delivered=false, queued as pending
+4. **allowedAgents check**: send to unlisted agent → error
+5. **expect_reply success**: send with expect_reply=true, recipient replies → reply returned
+6. **expect_reply timeout**: send with expect_reply=true, no reply → reply=null after 30s
+7. **ACP disabled**: call when acp.enabled=false → clear error
+
+## Edge Cases
+
+1. **Self-send**: Agent sends to itself
+   - Allow it — could be useful for async self-coordination
+   - Should NOT block on expect_reply to self (deadlock)
+
+2. **Session terminated mid-send**: Target session terminates after send but before reply
+   - expect_reply returns reply=null (treat as timeout)
+
+3. **High volume**: Many messages to same agent
+   - AgentMessageBus already has MAX_PENDING_MESSAGES (100) cap
+   - Oldest messages dropped — acceptable for MVP
+
+## Dependencies
+
+- #156 (sessions_spawn) should land first — provides SessionsToolContext pattern
+- AgentMessageBus exists, no changes needed for basic send
+- For expect_reply, add temporary subscription + timeout logic
+
+## Files to Change
+
+```
+src/tools/sessions.ts       — add sessionsSend implementation
+src/tools/sessions.test.ts  — add tests
+src/tools/index.ts          — register sessionsSendTool
+```
+
+## Backward Compatibility
+
+- New tool, no breaking changes
+- Only available if ACP enabled
+
+## Open Questions
+
+1. **Reply correlation:** Convention-based (Option A) or built-in (Option B)?
+   - **Recommendation:** Option A for MVP
+
+2. **Timeout configurability:** Should expect_reply timeout be configurable?
+   - **Recommendation:** Hardcode 30s for MVP, add param later if needed
+
+3. **Delivery confirmation:** Should we add ack/nack mechanism?
+   - **Recommendation:** Defer — `delivered` boolean is enough for MVP

--- a/docs/prd/PRD-158-sessions-list.md
+++ b/docs/prd/PRD-158-sessions-list.md
@@ -1,0 +1,219 @@
+# PRD-158: sessions_list + sessions_history Tools
+
+## Problem
+
+Agents need to discover and query sessions to:
+1. Find sessions involving specific agents
+2. Check session status (active/paused/terminated)
+3. Read historical messages from sessions for context
+
+Currently `AcpSessionManager.listSessions()` exists but isn't exposed as an agent tool.
+
+## Solution
+
+Add two tools to `src/tools/sessions.ts`:
+
+### 1. `sessions_list`
+
+Query sessions with optional filtering.
+
+```typescript
+interface SessionsListParams {
+  agent_id?: string;    // Filter by participant agent
+  status?: 'active' | 'paused' | 'terminated';
+  limit?: number;       // Default: 20, max: 100
+}
+
+interface SessionsListResult {
+  sessions: Array<{
+    session_id: string;
+    participants: string[];  // agent IDs
+    status: string;
+    created_at: string;
+    last_activity: string;
+  }>;
+  total: number;
+}
+```
+
+### 2. `sessions_history`
+
+Read message history from a specific session.
+
+```typescript
+interface SessionsHistoryParams {
+  session_id: string;   // Required
+  limit?: number;       // Default: 50, max: 200
+  before?: string;      // Cursor for pagination (message timestamp)
+}
+
+interface SessionsHistoryResult {
+  messages: Array<{
+    id: string;
+    from: string;       // agent ID
+    content: string;
+    timestamp: string;
+  }>;
+  has_more: boolean;
+  next_cursor?: string;
+}
+```
+
+## Implementation
+
+### File: `src/tools/sessions.ts`
+
+Extend the file created in #156 with two new tools:
+
+```typescript
+export const sessionsListTool: AgentTool<SessionsListParams, SessionsListResult> = {
+  name: 'sessions_list',
+  description: 'List ACP sessions, optionally filtered by agent or status',
+  parameters: {
+    type: 'object',
+    properties: {
+      agent_id: { type: 'string', description: 'Filter by participant agent ID' },
+      status: { type: 'string', enum: ['active', 'paused', 'terminated'] },
+      limit: { type: 'number', default: 20, maximum: 100 }
+    }
+  },
+  execute: async (params, context: SessionsToolContext) => {
+    const { sessionManager, allowedAgents, currentAgentId } = context;
+    
+    let sessions = sessionManager.listSessions();
+    
+    // Filter by agent_id if specified
+    if (params.agent_id) {
+      // Access control: can only query allowed agents
+      if (!allowedAgents.includes(params.agent_id)) {
+        throw new Error(`Cannot query sessions for agent: ${params.agent_id}`);
+      }
+      sessions = sessions.filter(s => s.participants.includes(params.agent_id));
+    }
+    
+    // Filter by status if specified
+    if (params.status) {
+      sessions = sessions.filter(s => s.status === params.status);
+    }
+    
+    // Apply limit
+    const limit = Math.min(params.limit ?? 20, 100);
+    const total = sessions.length;
+    sessions = sessions.slice(0, limit);
+    
+    return {
+      sessions: sessions.map(s => ({
+        session_id: s.id,
+        participants: s.participants,
+        status: s.status,
+        created_at: s.createdAt,
+        last_activity: s.lastActivity
+      })),
+      total
+    };
+  }
+};
+
+export const sessionsHistoryTool: AgentTool<SessionsHistoryParams, SessionsHistoryResult> = {
+  name: 'sessions_history',
+  description: 'Read message history from a specific ACP session',
+  parameters: {
+    type: 'object',
+    properties: {
+      session_id: { type: 'string', description: 'Session ID to read history from' },
+      limit: { type: 'number', default: 50, maximum: 200 },
+      before: { type: 'string', description: 'Pagination cursor (message timestamp)' }
+    },
+    required: ['session_id']
+  },
+  execute: async (params, context: SessionsToolContext) => {
+    const { sessionManager, allowedAgents, currentAgentId } = context;
+    
+    const session = sessionManager.getSession(params.session_id);
+    if (!session) {
+      throw new Error(`Session not found: ${params.session_id}`);
+    }
+    
+    // Access control: current agent must be participant OR querying allowed agents
+    const isParticipant = session.participants.includes(currentAgentId);
+    const allParticipantsAllowed = session.participants.every(p => 
+      p === currentAgentId || allowedAgents.includes(p)
+    );
+    
+    if (!isParticipant && !allParticipantsAllowed) {
+      throw new Error(`Access denied to session: ${params.session_id}`);
+    }
+    
+    let messages = session.history;
+    
+    // Apply before cursor
+    if (params.before) {
+      const beforeTime = new Date(params.before).getTime();
+      messages = messages.filter(m => new Date(m.timestamp).getTime() < beforeTime);
+    }
+    
+    // Apply limit
+    const limit = Math.min(params.limit ?? 50, 200);
+    const hasMore = messages.length > limit;
+    messages = messages.slice(-limit);  // Most recent first
+    
+    return {
+      messages: messages.map(m => ({
+        id: m.id,
+        from: m.from,
+        content: m.content,
+        timestamp: m.timestamp
+      })),
+      has_more: hasMore,
+      next_cursor: hasMore ? messages[0]?.timestamp : undefined
+    };
+  }
+};
+```
+
+### Tool Registration
+
+Add to `createSessionsTools()` function:
+
+```typescript
+export function createSessionsTools(context: SessionsToolContext): AgentTool[] {
+  return [
+    sessionsSpawnTool,      // #156
+    sessionsAnnounceTool,   // #156
+    sessionsSendTool,       // #157
+    sessionsListTool,       // #158
+    sessionsHistoryTool,    // #158
+  ];
+}
+```
+
+## Access Control
+
+| Tool | Who can use |
+|------|-------------|
+| `sessions_list` | Any agent; can only filter by `allowedAgents` |
+| `sessions_history` | Participant of session OR all participants in `allowedAgents` |
+
+## Dependencies
+
+- #156 merged (provides `SessionsToolContext` and `src/tools/sessions.ts`)
+- #157 for full sessions toolkit
+
+## Testing
+
+1. List sessions with no filter
+2. List sessions filtered by agent_id (allowed vs denied)
+3. List sessions filtered by status
+4. Read history from own session
+5. Read history from session with allowed agents
+6. Read history from session with non-allowed agent (should fail)
+7. Pagination with `before` cursor
+8. Limit enforcement (max 100 for list, max 200 for history)
+
+## Open Questions
+
+1. **Session expiration** — Should terminated sessions be auto-cleaned after N days?
+2. **Message content filtering** — Should we allow filtering messages by content/sender?
+3. **Real-time updates** — Should `sessions_history` support "tail -f" mode via streaming?
+
+For MVP: No to all. Keep it simple.

--- a/docs/prd/PRD-159-sessions-yield.md
+++ b/docs/prd/PRD-159-sessions-yield.md
@@ -1,0 +1,239 @@
+# PRD-159: sessions_yield Tool
+
+## Problem
+
+Agents need the ability to terminate or pause their own sessions, or request termination of sessions they're participating in. Currently, session termination is only available programmatically via `AcpSessionManager.terminateSession()` — agents have no way to gracefully end a session from within a tool call.
+
+## Current State
+
+### Existing Infrastructure
+
+**AcpSessionManager (`src/acp/session-manager.ts`):**
+- `terminateSession(sessionId)` — sets status to "terminated", notifies listeners ✅
+- `updateSession(sessionId, { status })` — can set status to "paused" ✅
+- `AcpSessionStatus` = "active" | "paused" | "terminated" ✅
+
+**Session Lifecycle:**
+- Sessions are in-memory only
+- `purgeTerminated()` removes terminated sessions from memory
+- No automatic cleanup — terminated sessions persist until purged
+
+## Proposed Solution
+
+### Tool: `sessions_yield`
+
+Gracefully terminate or pause the current session or a specified session.
+
+**Parameters:**
+```typescript
+{
+  session_id?: string;    // Target session. Defaults to current session.
+  action: "terminate" | "pause" | "resume";
+  reason?: string;        // Optional reason for audit logging
+}
+```
+
+**Returns:**
+```typescript
+{
+  success: boolean;
+  session_id: string;
+  previous_status: AcpSessionStatus;
+  new_status: AcpSessionStatus;
+  message?: string;       // Error message if success=false
+}
+```
+
+**Behavior by action:**
+
+| Action | Effect | Use Case |
+|--------|--------|----------|
+| `terminate` | Sets status to "terminated" | Agent finished task, conversation over |
+| `pause` | Sets status to "paused" | Waiting for human input, rate limited |
+| `resume` | Sets status to "active" | Resuming after pause |
+
+### Implementation
+
+**File:** `src/tools/sessions.ts` (extend from #156/#157)
+
+```typescript
+export function createSessionsYieldTool(context: SessionsToolContext): Tool {
+  return {
+    name: "sessions_yield",
+    description: "Terminate, pause, or resume a session",
+    parameters: {
+      type: "object",
+      properties: {
+        session_id: {
+          type: "string",
+          description: "Target session ID. Defaults to current session."
+        },
+        action: {
+          type: "string",
+          enum: ["terminate", "pause", "resume"],
+          description: "Action to perform"
+        },
+        reason: {
+          type: "string",
+          description: "Optional reason for the action"
+        }
+      },
+      required: ["action"]
+    },
+    execute: async (params) => {
+      const { session_id, action, reason } = params;
+      const targetId = session_id ?? context.currentSessionId;
+      
+      if (!targetId) {
+        return { success: false, message: "No session_id provided and no current session" };
+      }
+      
+      const session = context.sessionManager.getSession(targetId);
+      if (!session) {
+        return { success: false, message: `Session ${targetId} not found` };
+      }
+      
+      // Access control: can only yield own sessions or sessions with permitted agents
+      if (!canAccessSession(session, context)) {
+        return { success: false, message: "Access denied" };
+      }
+      
+      const previousStatus = session.status;
+      
+      // State machine validation
+      if (action === "resume" && previousStatus !== "paused") {
+        return { 
+          success: false, 
+          message: `Cannot resume session in status "${previousStatus}"` 
+        };
+      }
+      
+      if (action === "terminate" && previousStatus === "terminated") {
+        return { 
+          success: false, 
+          message: "Session already terminated" 
+        };
+      }
+      
+      // Execute action
+      const newStatus = action === "terminate" ? "terminated" 
+                      : action === "pause" ? "paused" 
+                      : "active";
+      
+      const updated = context.sessionManager.updateSession(targetId, { status: newStatus });
+      
+      // Log reason if provided
+      if (reason && updated) {
+        context.logger?.debug(`sessions_yield: ${action} session ${targetId}: ${reason}`);
+      }
+      
+      return {
+        success: !!updated,
+        session_id: targetId,
+        previous_status: previousStatus,
+        new_status: newStatus
+      };
+    }
+  };
+}
+```
+
+### Access Control
+
+**Who can yield a session:**
+1. The agent that owns the session (`session.agentId === currentAgentId`)
+2. Any agent when the session's agent is in `allowedAgents`
+
+**Edge cases:**
+- Terminating current session: allowed, but agent should know subsequent tool calls in this turn may fail
+- Terminating another agent's session: only if that agent is in allowedAgents
+- Self-terminate while `expect_reply` pending elsewhere: the waiting session gets timeout error
+
+### State Transitions
+
+```
+         ┌─────────┐
+    ┌────│ active  │────┐
+    │    └─────────┘    │
+    │         │         │
+    │      pause      terminate
+    │         │         │
+    │         v         │
+    │    ┌─────────┐    │
+    └────│ paused  │    │
+   resume└─────────┘    │
+              │         │
+           terminate    │
+              │         │
+              v         v
+         ┌─────────────────┐
+         │   terminated    │
+         └─────────────────┘
+```
+
+**Invalid transitions:**
+- `terminate` → anything (terminal state)
+- `active` → `resume` (no-op or error?)
+- `paused` → `pause` (no-op)
+
+**Decision:** Invalid transitions return `success: false` with descriptive message. No-ops (pause already paused) return `success: true` with same status.
+
+## Config Gate
+
+Same as #156/#157:
+- Tool only registered when `acp.enabled: true`
+- `allowedAgents` controls cross-agent session access
+
+## Testing
+
+```typescript
+describe("sessions_yield", () => {
+  it("terminates own session", async () => {
+    const session = manager.createSession("fairy");
+    const result = await tool.execute({ action: "terminate" });
+    expect(result.success).toBe(true);
+    expect(result.new_status).toBe("terminated");
+  });
+  
+  it("pauses and resumes session", async () => {
+    const session = manager.createSession("fairy");
+    await tool.execute({ action: "pause" });
+    expect(manager.getSession(session.id)?.status).toBe("paused");
+    
+    await tool.execute({ action: "resume" });
+    expect(manager.getSession(session.id)?.status).toBe("active");
+  });
+  
+  it("rejects resume on active session", async () => {
+    const session = manager.createSession("fairy");
+    const result = await tool.execute({ action: "resume" });
+    expect(result.success).toBe(false);
+  });
+  
+  it("rejects terminating other agent's session without permission", async () => {
+    // ...
+  });
+  
+  it("allows terminating permitted agent's session", async () => {
+    // ...
+  });
+});
+```
+
+## Dependencies
+
+- **#156** — `SessionsToolContext` pattern and `sessions.ts` file structure
+- **AcpSessionManager** — `updateSession()` already supports status changes ✅
+
+## Open Questions (Deferred)
+
+1. **Purge policy:** When should terminated sessions be purged from memory? Timer-based? Count-based?
+2. **Pause timeout:** Should paused sessions auto-terminate after X minutes?
+3. **Graceful shutdown:** Should `sessions_yield terminate` send a final message to the other party?
+4. **Current session tracking:** How does `context.currentSessionId` get populated? (May need middleware)
+
+---
+
+*Author: Fairy*
+*Date: 2025-04-12*
+*Status: Draft — pending review*

--- a/docs/prd/PRD-160-subagent-management.md
+++ b/docs/prd/PRD-160-subagent-management.md
@@ -1,0 +1,274 @@
+# PRD-160: Subagent Management Tools
+
+**Issue:** #160  
+**Status:** Draft  
+**Date:** 2025-04-12  
+**Author:** Fairy  
+**Depends on:** None (builds on existing infrastructure)
+
+---
+
+## Problem Statement
+
+Agents can spawn subagents via `spawn_subagent` tool, but have no visibility or control over running subagents. They cannot:
+- List what subagents are currently running
+- Check status of a specific subagent task
+- Cancel a runaway or stuck subagent
+- Get results from a completed subagent task
+
+This limits the orchestrator pattern — an agent spawning multiple subagents cannot manage them effectively.
+
+---
+
+## Current State
+
+### Existing Infrastructure
+
+**`src/tools/subagent.ts`:**
+- `spawnSubagent()` — spawn a subagent, returns `SpawnSubagentResult`
+- `cancelSubagent(pattern?)` — cancel by pattern
+- `hasRunningSubagents()` — boolean check
+- `getActiveSubagentCount()` — count of active subagents
+
+**`src/subagent/task-registry.ts`:**
+- `TaskRegistry` class tracks running tasks
+- `register(taskId, sessionId, channelId)` — add task
+- `unregister(taskId)` — remove task
+- `get(taskId)` — get single task info
+- `getBySession(sessionId)` — get tasks for session
+- `list()` — list all tasks
+
+**`TaskInfo` interface:**
+```typescript
+interface TaskInfo {
+  taskId: string;
+  sessionId: string;
+  channelId: string;
+  startedAt: Date;
+}
+```
+
+### Gap Analysis
+
+The infrastructure exists but is not exposed as agent tools:
+1. `taskRegistry.list()` exists → need `subagents_list` tool
+2. `taskRegistry.get()` exists → need `subagents_status` tool  
+3. `cancelSubagent()` exists → need `subagents_cancel` tool
+4. No result persistence → completed tasks vanish immediately
+
+---
+
+## Proposed Solution
+
+### New Tools (3)
+
+#### 1. `subagents_list`
+
+List all running subagent tasks, optionally filtered.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `session_id` | string | No | Filter by session ID |
+| `channel_id` | string | No | Filter by channel ID |
+
+**Returns:**
+```json
+{
+  "tasks": [
+    {
+      "task_id": "subagent-1-1712937600000",
+      "session_id": "session-abc",
+      "channel_id": "channel-123",
+      "started_at": "2025-04-12T10:00:00Z",
+      "running_seconds": 45
+    }
+  ],
+  "count": 1
+}
+```
+
+**Implementation:**
+```typescript
+function subagentsList(params: { session_id?: string; channel_id?: string }) {
+  let tasks = taskRegistry.list();
+  
+  if (params.session_id) {
+    tasks = tasks.filter(t => t.sessionId === params.session_id);
+  }
+  if (params.channel_id) {
+    tasks = tasks.filter(t => t.channelId === params.channel_id);
+  }
+  
+  return {
+    tasks: tasks.map(t => ({
+      task_id: t.taskId,
+      session_id: t.sessionId,
+      channel_id: t.channelId,
+      started_at: t.startedAt.toISOString(),
+      running_seconds: Math.floor((Date.now() - t.startedAt.getTime()) / 1000),
+    })),
+    count: tasks.length,
+  };
+}
+```
+
+#### 2. `subagents_status`
+
+Get detailed status of a specific subagent task.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `task_id` | string | Yes | Task ID to query |
+
+**Returns:**
+```json
+{
+  "found": true,
+  "task_id": "subagent-1-1712937600000",
+  "status": "running",
+  "session_id": "session-abc",
+  "channel_id": "channel-123",
+  "started_at": "2025-04-12T10:00:00Z",
+  "running_seconds": 45
+}
+```
+
+Or if not found:
+```json
+{
+  "found": false,
+  "task_id": "subagent-1-1712937600000",
+  "status": "unknown"
+}
+```
+
+**Note:** Current TaskRegistry only tracks running tasks. Completed tasks are unregistered immediately. For MVP, `found: false` means either completed or never existed.
+
+**Future enhancement:** Keep completed task results in a separate cache (with TTL) so agents can query results after completion.
+
+#### 3. `subagents_cancel`
+
+Cancel a running subagent task.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `task_id` | string | Yes | Task ID to cancel |
+
+**Returns:**
+```json
+{
+  "cancelled": true,
+  "task_id": "subagent-1-1712937600000"
+}
+```
+
+Or if not found/already completed:
+```json
+{
+  "cancelled": false,
+  "task_id": "subagent-1-1712937600000",
+  "reason": "task not found"
+}
+```
+
+**Implementation:**
+```typescript
+function subagentsCancel(params: { task_id: string }) {
+  const task = taskRegistry.get(params.task_id);
+  if (!task) {
+    return { cancelled: false, task_id: params.task_id, reason: "task not found" };
+  }
+  
+  const success = cancelSubagent(params.task_id);
+  return { cancelled: success, task_id: params.task_id };
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: MVP (This PR)
+
+**New file: `src/tools/subagent-management.ts`**
+- `subagentsList()`
+- `subagentsStatus()`
+- `subagentsCancel()`
+
+**Update: `src/tools/registry.ts`**
+- Register three new tools with proper schemas
+
+**Tests: `src/tools/subagent-management.test.ts`**
+- Unit tests for each tool
+- Edge cases: empty list, not found, already cancelled
+
+### Phase 2: Future Enhancements
+
+1. **Result caching** — Keep completed task results for N minutes
+2. **Progress tracking** — Stream progress events to TaskInfo
+3. **Bulk cancel** — Cancel all tasks for a session/channel
+4. **Task naming** — Allow agents to name tasks for easier management
+
+---
+
+## Access Control
+
+These tools operate on the calling agent's subagents only:
+- `subagents_list` — Returns all tasks (no cross-agent isolation in MVP since taskRegistry is global)
+- `subagents_cancel` — Can cancel any task (MVP; future: restrict to own tasks)
+
+**Future:** Add `agentId` to TaskInfo and filter by calling agent's ID.
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| No running tasks | Return empty list, `count: 0` |
+| Task not found | Return `found: false` or `cancelled: false` with reason |
+| Cancel fails | Return `cancelled: false` with reason |
+
+No exceptions thrown — tools always return structured responses.
+
+---
+
+## Testing Strategy
+
+1. **Unit tests:**
+   - List with no tasks
+   - List with multiple tasks, verify filtering
+   - Status of running task
+   - Status of non-existent task
+   - Cancel running task
+   - Cancel non-existent task
+
+2. **Integration tests:**
+   - Spawn subagent → list → verify appears
+   - Spawn subagent → cancel → verify stops
+   - Spawn subagent → complete → verify disappears from list
+
+---
+
+## Open Questions
+
+1. **Cross-agent visibility** — Should agents see other agents' subagents? MVP: yes (global registry). Future: isolate by agentId.
+
+2. **Result persistence** — How long to keep completed task results? Defer to Phase 2.
+
+3. **Bulk operations** — `subagents_cancel_all` for a session? Defer to Phase 2.
+
+---
+
+## Summary
+
+| Tool | Purpose | Wraps |
+|------|---------|-------|
+| `subagents_list` | List running tasks | `taskRegistry.list()` |
+| `subagents_status` | Get task details | `taskRegistry.get()` |
+| `subagents_cancel` | Stop a task | `cancelSubagent()` |
+
+Straightforward exposure of existing infrastructure as agent tools.


### PR DESCRIPTION
## Summary
Implements #182 - sessions_spawn and sessions_announce tools for ACP inter-agent communication.

## Changes
- Add `sessions_spawn` tool to create new ACP sessions
- Add `sessions_announce` tool to broadcast messages to agents  
- Access control via `allowedAgents` configuration
- Graceful degradation when ACP is disabled
- 9 unit tests

## Files
- `src/tools/sessions.ts` - Tool implementations
- `src/tools/__tests__/sessions.test.ts` - Unit tests
- `docs/prd/PRD-156-*.md` through `PRD-160-*.md` - Design docs for #182-#186

## Testing
```
pnpm test src/tools/__tests__/sessions.test.ts
# 9 tests passing
```

Closes #182