### PR TITLE
feat(tools): sessions_spawn + sessions_announce (#182)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,9 @@ export {
   CREATE_SKILL_TOOL,
   APPEND_MEMORY_TOOL,
   DEFAULT_SELF_ITERATION_FILES,
+  createSessionsSpawnTool,
+  createSessionsAnnounceTool,
+  createSessionTools,
 } from "./tools/index.js";
 export type {
   GitOptions,
@@ -263,6 +266,7 @@ export type {
   CreateIssueOptions,
   ReviewPROptions,
   SelfIterationConfig,
+  SessionsToolContext,
 } from "./tools/index.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -67,3 +67,10 @@ export {
 export type { SelfIterationConfig } from "./self-iteration.js";
 
 export { createWebFetchTool } from "./web.js";
+
+export {
+  createSessionsSpawnTool,
+  createSessionsAnnounceTool,
+  createSessionTools,
+} from "./sessions.js";
+export type { SessionsToolContext } from "./sessions.js";

--- a/src/tools/sessions.test.ts
+++ b/src/tools/sessions.test.ts
@@ -1,0 +1,214 @@
+// src/tools/sessions.test.ts — Tests for ACP session tools
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createSessionsSpawnTool,
+  createSessionsAnnounceTool,
+  createSessionTools,
+  type SessionsToolContext,
+} from "./sessions.js";
+import { AcpSessionManager } from "../acp/session-manager.js";
+import { AgentMessageBus } from "../acp/message-bus.js";
+import type { AcpConfig } from "../acp/types.js";
+
+function createTestContext(overrides?: Partial<SessionsToolContext>): SessionsToolContext {
+  const config: AcpConfig = {
+    enabled: true,
+    backend: "acpx",
+    defaultAgent: "agent-a",
+    allowedAgents: ["agent-a", "agent-b", "agent-c"],
+  };
+  const sessionManager = new AcpSessionManager(config);
+  const messageBus = new AgentMessageBus(sessionManager);
+
+  return {
+    sessionManager,
+    messageBus,
+    currentAgentId: "agent-a",
+    currentSessionId: "session-001",
+    ...overrides,
+  };
+}
+
+describe("sessions_spawn", () => {
+  let ctx: SessionsToolContext;
+
+  beforeEach(() => {
+    ctx = createTestContext();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createSessionsSpawnTool(ctx);
+    expect(tool.name).toBe("sessions_spawn");
+    expect(tool.parameters.required).toContain("target_agent_id");
+  });
+
+  it("spawns session for allowed agent", async () => {
+    const { handler } = createSessionsSpawnTool(ctx);
+    const result = JSON.parse(await handler({ target_agent_id: "agent-b" }));
+
+    expect(result.session_id).toBeDefined();
+    expect(result.agent_id).toBe("agent-b");
+    expect(result.status).toBe("active");
+  });
+
+  it("spawns session with thread binding", async () => {
+    const { handler } = createSessionsSpawnTool(ctx);
+    const result = JSON.parse(
+      await handler({ target_agent_id: "agent-b", thread_id: "thread-123" }),
+    );
+
+    expect(result.session_id).toBeDefined();
+    expect(result.agent_id).toBe("agent-b");
+    expect(result.status).toBe("active");
+
+    // Verify session is bound to thread
+    const session = ctx.sessionManager.getSessionByThread("thread-123");
+    expect(session).toBeDefined();
+    expect(session!.agentId).toBe("agent-b");
+  });
+
+  it("rejects spawn for agent not in allowedAgents", async () => {
+    const { handler } = createSessionsSpawnTool(ctx);
+    const result = JSON.parse(await handler({ target_agent_id: "agent-unknown" }));
+
+    expect(result.error).toContain("not in the allowedAgents list");
+  });
+
+  it("rejects spawn for self", async () => {
+    const { handler } = createSessionsSpawnTool(ctx);
+    const result = JSON.parse(await handler({ target_agent_id: "agent-a" }));
+
+    expect(result.error).toContain("Cannot spawn a session for yourself");
+  });
+});
+
+describe("sessions_announce", () => {
+  let ctx: SessionsToolContext;
+
+  beforeEach(() => {
+    ctx = createTestContext();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createSessionsAnnounceTool(ctx);
+    expect(tool.name).toBe("sessions_announce");
+    expect(tool.parameters.required).toContain("content");
+  });
+
+  it("sends message to specific agent", async () => {
+    // Subscribe a handler so message is delivered
+    const received: unknown[] = [];
+    ctx.messageBus.subscribe("agent-b", (msg) => {
+      received.push(msg);
+    });
+
+    const { handler } = createSessionsAnnounceTool(ctx);
+    const result = JSON.parse(
+      await handler({ content: "hello agent-b", to_agent_id: "agent-b" }),
+    );
+
+    expect(result.message_id).toBeDefined();
+    expect(result.delivered).toBe(true);
+    expect(result.recipients).toBe(1);
+    expect(received).toHaveLength(1);
+  });
+
+  it("sends message to specific session", async () => {
+    // Create a session and subscribe to it
+    const session = ctx.sessionManager.createSession("agent-b");
+    const received: unknown[] = [];
+    ctx.messageBus.subscribeSession(session.id, (msg) => {
+      received.push(msg);
+    });
+
+    const { handler } = createSessionsAnnounceTool(ctx);
+    const result = JSON.parse(
+      await handler({
+        content: "hello session",
+        to_agent_id: "agent-b",
+        to_session_id: session.id,
+      }),
+    );
+
+    expect(result.delivered).toBe(true);
+    expect(result.recipients).toBe(1);
+    expect(received).toHaveLength(1);
+  });
+
+  it("broadcasts to all agents", async () => {
+    // Subscribe handlers for two other agents
+    const receivedB: unknown[] = [];
+    const receivedC: unknown[] = [];
+    ctx.messageBus.subscribe("agent-b", (msg) => { receivedB.push(msg); });
+    ctx.messageBus.subscribe("agent-c", (msg) => { receivedC.push(msg); });
+
+    const { handler } = createSessionsAnnounceTool(ctx);
+    const result = JSON.parse(await handler({ content: "hello everyone" }));
+
+    expect(result.delivered).toBe(true);
+    expect(result.recipients).toBe(2);
+    expect(receivedB).toHaveLength(1);
+    expect(receivedC).toHaveLength(1);
+  });
+
+  it("rejects empty content", async () => {
+    const { handler } = createSessionsAnnounceTool(ctx);
+    const result = JSON.parse(await handler({ content: "" }));
+
+    expect(result.error).toContain("must not be empty");
+  });
+
+  it("rejects whitespace-only content", async () => {
+    const { handler } = createSessionsAnnounceTool(ctx);
+    const result = JSON.parse(await handler({ content: "   " }));
+
+    expect(result.error).toContain("must not be empty");
+  });
+
+  it("rejects to_session_id without to_agent_id", async () => {
+    const { handler } = createSessionsAnnounceTool(ctx);
+    const result = JSON.parse(
+      await handler({ content: "hello", to_session_id: "session-123" }),
+    );
+
+    expect(result.error).toContain("to_session_id requires to_agent_id");
+  });
+
+  it("queues message when no handler is subscribed", async () => {
+    const { handler } = createSessionsAnnounceTool(ctx);
+    const result = JSON.parse(
+      await handler({ content: "hello offline", to_agent_id: "agent-b" }),
+    );
+
+    expect(result.message_id).toBeDefined();
+    expect(result.delivered).toBe(false);
+    expect(result.recipients).toBe(0);
+
+    // Message should be pending
+    const pending = ctx.messageBus.getPending("agent-b");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].content).toBe("hello offline");
+  });
+
+  it("returns zero recipients on empty broadcast", async () => {
+    // No agents subscribed — broadcast finds no handlers
+    const { handler } = createSessionsAnnounceTool(ctx);
+    const result = JSON.parse(await handler({ content: "anyone there?" }));
+
+    expect(result.delivered).toBe(false);
+    expect(result.recipients).toBe(0);
+  });
+});
+
+describe("createSessionTools", () => {
+  it("returns both tools", () => {
+    const ctx = createTestContext();
+    const tools = createSessionTools(ctx);
+    const names = tools.map((t) => t.tool.name);
+
+    expect(names).toContain("sessions_spawn");
+    expect(names).toContain("sessions_announce");
+    expect(tools).toHaveLength(2);
+  });
+});

--- a/src/tools/sessions.ts
+++ b/src/tools/sessions.ts
@@ -1,0 +1,235 @@
+// src/tools/sessions.ts — ACP session tools for inter-agent communication
+// Exposes AcpSessionManager and AgentMessageBus to agents as callable tools.
+
+import { createLogger } from "../core/logger.js";
+import type { Tool } from "../core/types.js";
+import type { ToolHandler } from "../core/tools.js";
+import type { AcpSessionManager } from "../acp/session-manager.js";
+import type { AgentMessageBus } from "../acp/message-bus.js";
+
+const log = createLogger("tools:sessions");
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+/** Context required by session tools at runtime. */
+export interface SessionsToolContext {
+  sessionManager: AcpSessionManager;
+  messageBus: AgentMessageBus;
+  /** Agent ID of the calling agent */
+  currentAgentId: string;
+  /** Session ID of the calling agent's current session */
+  currentSessionId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// sessions_spawn
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `sessions_spawn` tool.
+ *
+ * Wraps AcpSessionManager.createSession() — lets an agent create a new ACP
+ * session for communication with another agent.
+ */
+export function createSessionsSpawnTool(
+  ctx: SessionsToolContext,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "sessions_spawn",
+      description:
+        "Create a new ACP session for async communication with another agent. " +
+        "The target agent must be in the allowed agents list.",
+      parameters: {
+        type: "object",
+        properties: {
+          target_agent_id: {
+            type: "string",
+            description: "Agent ID to create session for (must be in allowedAgents)",
+          },
+          thread_id: {
+            type: "string",
+            description: "Optional Discord thread ID to bind the session to",
+          },
+          metadata: {
+            type: "object",
+            description: "Optional key-value metadata for the session",
+          },
+        },
+        required: ["target_agent_id"],
+      },
+    },
+    handler: async (args) => {
+      const { target_agent_id, thread_id } = args as {
+        target_agent_id: string;
+        thread_id?: string;
+        metadata?: Record<string, unknown>;
+      };
+
+      // Cannot spawn session for self
+      if (target_agent_id === ctx.currentAgentId) {
+        return JSON.stringify({
+          error: "Cannot spawn a session for yourself. Use your existing session.",
+        });
+      }
+
+      try {
+        const session = ctx.sessionManager.createSession(target_agent_id, thread_id);
+
+        log.info("Session spawned", {
+          sessionId: session.id,
+          targetAgent: target_agent_id,
+          callingAgent: ctx.currentAgentId,
+          threadId: thread_id,
+        });
+
+        return JSON.stringify({
+          session_id: session.id,
+          agent_id: session.agentId,
+          status: session.status,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("Session spawn failed", { targetAgent: target_agent_id, error: message });
+        return JSON.stringify({ error: message });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// sessions_announce
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `sessions_announce` tool.
+ *
+ * Wraps AgentMessageBus.send() / broadcast() — lets an agent send messages
+ * to other agents or broadcast to all.
+ */
+export function createSessionsAnnounceTool(
+  ctx: SessionsToolContext,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "sessions_announce",
+      description:
+        "Broadcast a message to all agents or send to a specific agent/session. " +
+        "Omit to_agent_id to broadcast to all agents.",
+      parameters: {
+        type: "object",
+        properties: {
+          content: {
+            type: "string",
+            description: "Message content to broadcast or send",
+          },
+          to_agent_id: {
+            type: "string",
+            description: "Target agent ID (omit to broadcast to all)",
+          },
+          to_session_id: {
+            type: "string",
+            description: "Target session ID (requires to_agent_id)",
+          },
+          metadata: {
+            type: "object",
+            description: "Optional structured metadata",
+          },
+        },
+        required: ["content"],
+      },
+    },
+    handler: async (args) => {
+      const { content, to_agent_id, to_session_id, metadata } = args as {
+        content: string;
+        to_agent_id?: string;
+        to_session_id?: string;
+        metadata?: Record<string, unknown>;
+      };
+
+      // Validate: content must be non-empty
+      if (!content || content.trim().length === 0) {
+        return JSON.stringify({ error: "Message content must not be empty" });
+      }
+
+      // Validate: to_session_id requires to_agent_id
+      if (to_session_id && !to_agent_id) {
+        return JSON.stringify({
+          error: "to_session_id requires to_agent_id to be set",
+        });
+      }
+
+      try {
+        // Targeted send to a specific agent (optionally a specific session)
+        if (to_agent_id) {
+          const delivery = ctx.messageBus.send({
+            fromAgentId: ctx.currentAgentId,
+            fromSessionId: ctx.currentSessionId,
+            toAgentId: to_agent_id,
+            toSessionId: to_session_id,
+            content,
+            metadata,
+          });
+
+          log.info("Message sent", {
+            messageId: delivery.messageId,
+            from: ctx.currentAgentId,
+            to: to_agent_id,
+            sessionId: to_session_id,
+            delivered: delivery.delivered,
+          });
+
+          return JSON.stringify({
+            message_id: delivery.messageId,
+            delivered: delivery.delivered,
+            recipients: delivery.delivered ? 1 : 0,
+          });
+        }
+
+        // Broadcast to all agents
+        const deliveries = ctx.messageBus.broadcast(
+          ctx.currentAgentId,
+          content,
+          metadata,
+        );
+
+        const deliveredCount = deliveries.filter((d) => d.delivered).length;
+
+        log.info("Message broadcast", {
+          from: ctx.currentAgentId,
+          total: deliveries.length,
+          delivered: deliveredCount,
+        });
+
+        return JSON.stringify({
+          message_id: deliveries[0]?.messageId ?? "broadcast",
+          delivered: deliveredCount > 0,
+          recipients: deliveredCount,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("Announce failed", { from: ctx.currentAgentId, error: message });
+        return JSON.stringify({ error: message });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create both session tools with shared context.
+ * Returns an array of tool+handler pairs ready for registration.
+ */
+export function createSessionTools(
+  ctx: SessionsToolContext,
+): { tool: Tool; handler: ToolHandler }[] {
+  return [
+    createSessionsSpawnTool(ctx),
+    createSessionsAnnounceTool(ctx),
+  ];
+}


### PR DESCRIPTION
## Summary
Implements `sessions_spawn` and `sessions_announce` tools for ACP inter-agent communication.

## Changes
- **`sessions_spawn`**: Creates ACP sessions with target agents, with optional thread binding
- **`sessions_announce`**: Sends messages to specific agents or broadcasts to all
- Access control via `allowedAgents` configuration
- Graceful degradation when ACP is disabled
- 15 unit tests

## Testing
```bash
pnpm test src/tools/sessions.test.ts
```

Closes #182