### PR TITLE
feat(tools): sessions_send tool (#183)

### DIFF
--- a/src/tools/sessions.test.ts
+++ b/src/tools/sessions.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   createSessionsSpawnTool,
   createSessionsAnnounceTool,
+  createSessionsSendTool,
   createSessionTools,
   type SessionsToolContext,
 } from "./sessions.js";
@@ -202,13 +203,178 @@ describe("sessions_announce", () => {
 });
 
 describe("createSessionTools", () => {
-  it("returns both tools", () => {
+  it("returns all three tools", () => {
     const ctx = createTestContext();
     const tools = createSessionTools(ctx);
     const names = tools.map((t) => t.tool.name);
 
     expect(names).toContain("sessions_spawn");
     expect(names).toContain("sessions_announce");
-    expect(tools).toHaveLength(2);
+    expect(names).toContain("sessions_send");
+    expect(tools).toHaveLength(3);
+  });
+});
+
+describe("sessions_send", () => {
+  let ctx: SessionsToolContext;
+
+  beforeEach(() => {
+    ctx = createTestContext();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createSessionsSendTool(ctx);
+    expect(tool.name).toBe("sessions_send");
+    expect(tool.parameters.required).toContain("to_agent_id");
+    expect(tool.parameters.required).toContain("content");
+  });
+
+  it("sends message to agent successfully", async () => {
+    const received: unknown[] = [];
+    ctx.messageBus.subscribe("agent-b", (msg) => {
+      received.push(msg);
+    });
+
+    const { handler } = createSessionsSendTool(ctx);
+    const result = JSON.parse(
+      await handler({ to_agent_id: "agent-b", content: "hello direct" }),
+    );
+
+    expect(result.message_id).toBeDefined();
+    expect(result.delivered).toBe(true);
+    expect(received).toHaveLength(1);
+  });
+
+  it("sends message to specific session", async () => {
+    const session = ctx.sessionManager.createSession("agent-b");
+    const received: unknown[] = [];
+    ctx.messageBus.subscribeSession(session.id, (msg) => {
+      received.push(msg);
+    });
+
+    const { handler } = createSessionsSendTool(ctx);
+    const result = JSON.parse(
+      await handler({
+        to_agent_id: "agent-b",
+        to_session_id: session.id,
+        content: "hello session",
+      }),
+    );
+
+    expect(result.delivered).toBe(true);
+    expect(received).toHaveLength(1);
+  });
+
+  it("returns reply when expect_reply receives correlated response", async () => {
+    // Subscribe to agent-b and auto-reply with correlation_id
+    ctx.messageBus.subscribe("agent-b", (msg) => {
+      ctx.messageBus.send({
+        fromAgentId: "agent-b",
+        toAgentId: msg.fromAgentId,
+        content: "reply content",
+        metadata: { correlation_id: msg.id },
+      });
+    });
+
+    const { handler } = createSessionsSendTool(ctx);
+    const result = JSON.parse(
+      await handler({
+        to_agent_id: "agent-b",
+        content: "need a reply",
+        expect_reply: true,
+      }),
+    );
+
+    expect(result.message_id).toBeDefined();
+    expect(result.delivered).toBe(true);
+    expect(result.reply).toBe("reply content");
+    expect(result.reply_metadata).toBeDefined();
+    expect(result.reply_metadata.correlation_id).toBe(result.message_id);
+  });
+
+  it("returns null reply on expect_reply timeout", async () => {
+    // Subscribe to agent-b but do NOT reply — will timeout
+    ctx.messageBus.subscribe("agent-b", () => {
+      // intentionally no reply
+    });
+
+    const { handler } = createSessionsSendTool(ctx);
+
+    const start = Date.now();
+    const result = JSON.parse(
+      await handler({
+        to_agent_id: "agent-b",
+        content: "waiting for reply",
+        expect_reply: true,
+      }),
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.delivered).toBe(true);
+    expect(result.reply).toBeNull();
+    expect(result.reply_metadata).toBeNull();
+    // Should have waited for the timeout (30s)
+    expect(elapsed).toBeGreaterThanOrEqual(29_000);
+  }, 35_000);
+
+  it("returns error on self-send with expect_reply", async () => {
+    const { handler } = createSessionsSendTool(ctx);
+    const result = JSON.parse(
+      await handler({
+        to_agent_id: "agent-a",
+        content: "talking to myself",
+        expect_reply: true,
+      }),
+    );
+
+    expect(result.error).toContain("deadlock");
+  });
+
+  it("allows self-send without expect_reply", async () => {
+    const received: unknown[] = [];
+    ctx.messageBus.subscribe("agent-a", (msg) => {
+      received.push(msg);
+    });
+
+    const { handler } = createSessionsSendTool(ctx);
+    const result = JSON.parse(
+      await handler({ to_agent_id: "agent-a", content: "self note" }),
+    );
+
+    expect(result.message_id).toBeDefined();
+    expect(result.delivered).toBe(true);
+    expect(received).toHaveLength(1);
+  });
+
+  it("rejects empty content", async () => {
+    const { handler } = createSessionsSendTool(ctx);
+    const result = JSON.parse(
+      await handler({ to_agent_id: "agent-b", content: "" }),
+    );
+
+    expect(result.error).toContain("must not be empty");
+  });
+
+  it("rejects whitespace-only content", async () => {
+    const { handler } = createSessionsSendTool(ctx);
+    const result = JSON.parse(
+      await handler({ to_agent_id: "agent-b", content: "   " }),
+    );
+
+    expect(result.error).toContain("must not be empty");
+  });
+
+  it("queues message when no handler is subscribed", async () => {
+    const { handler } = createSessionsSendTool(ctx);
+    const result = JSON.parse(
+      await handler({ to_agent_id: "agent-b", content: "hello offline" }),
+    );
+
+    expect(result.message_id).toBeDefined();
+    expect(result.delivered).toBe(false);
+
+    const pending = ctx.messageBus.getPending("agent-b");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].content).toBe("hello offline");
   });
 });

--- a/src/tools/sessions.ts
+++ b/src/tools/sessions.ts
@@ -5,7 +5,7 @@ import { createLogger } from "../core/logger.js";
 import type { Tool } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";
 import type { AcpSessionManager } from "../acp/session-manager.js";
-import type { AgentMessageBus } from "../acp/message-bus.js";
+import type { AgentMessageBus, AgentMessage } from "../acp/message-bus.js";
 
 const log = createLogger("tools:sessions");
 
@@ -218,6 +218,210 @@ export function createSessionsAnnounceTool(
 }
 
 // ---------------------------------------------------------------------------
+// sessions_send
+// ---------------------------------------------------------------------------
+
+/** Default timeout for expect_reply in milliseconds. */
+const REPLY_TIMEOUT_MS = 30_000;
+
+/**
+ * Create the `sessions_send` tool.
+ *
+ * Sends a directed message to a specific agent or session via
+ * AgentMessageBus.send(). Optionally waits for a correlated reply
+ * (convention-based: matching correlation_id in metadata).
+ */
+export function createSessionsSendTool(
+  ctx: SessionsToolContext,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "sessions_send",
+      description:
+        "Send a message to a specific agent or session. " +
+        "Set expect_reply=true to block until the recipient replies (30s timeout).",
+      parameters: {
+        type: "object",
+        properties: {
+          to_agent_id: {
+            type: "string",
+            description: "Target agent ID (required)",
+          },
+          to_session_id: {
+            type: "string",
+            description: "Target session ID (optional — if omitted, routes to agent's default handler)",
+          },
+          content: {
+            type: "string",
+            description: "Message content",
+          },
+          metadata: {
+            type: "object",
+            description: "Optional structured metadata (e.g., reply_to, priority)",
+          },
+          expect_reply: {
+            type: "boolean",
+            description: "If true, block until recipient replies (timeout 30s). Default: false",
+          },
+        },
+        required: ["to_agent_id", "content"],
+      },
+    },
+    handler: async (args) => {
+      const { to_agent_id, to_session_id, content, metadata, expect_reply } = args as {
+        to_agent_id: string;
+        to_session_id?: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+        expect_reply?: boolean;
+      };
+
+      // Validate: content must be non-empty
+      if (!content || content.trim().length === 0) {
+        return JSON.stringify({ error: "Message content must not be empty" });
+      }
+
+      // Deadlock prevention: self-send with expect_reply
+      if (expect_reply && to_agent_id === ctx.currentAgentId) {
+        return JSON.stringify({
+          error: "Cannot expect_reply when sending to yourself (deadlock prevention)",
+        });
+      }
+
+      try {
+        // When expect_reply is requested, set up the reply listener BEFORE
+        // sending so we catch synchronous reply chains.
+        let replyPromise: Promise<ReplyData | undefined> | undefined;
+        let setCorrelationId: ((id: string) => void) | undefined;
+
+        if (expect_reply) {
+          const setup = prepareReplyListener(ctx, REPLY_TIMEOUT_MS);
+          replyPromise = setup.promise;
+          setCorrelationId = setup.setCorrelationId;
+        }
+
+        const delivery = ctx.messageBus.send({
+          fromAgentId: ctx.currentAgentId,
+          fromSessionId: ctx.currentSessionId,
+          toAgentId: to_agent_id,
+          toSessionId: to_session_id,
+          content,
+          metadata,
+        });
+
+        log.info("Message sent (sessions_send)", {
+          messageId: delivery.messageId,
+          from: ctx.currentAgentId,
+          to: to_agent_id,
+          sessionId: to_session_id,
+          delivered: delivery.delivered,
+          expectReply: !!expect_reply,
+        });
+
+        if (!expect_reply) {
+          return JSON.stringify({
+            message_id: delivery.messageId,
+            delivered: delivery.delivered,
+          });
+        }
+
+        // Now that we have the message ID, tell the listener what to correlate on
+        setCorrelationId!(delivery.messageId);
+
+        const reply = await replyPromise!;
+
+        return JSON.stringify({
+          message_id: delivery.messageId,
+          delivered: delivery.delivered,
+          reply: reply?.content ?? null,
+          reply_metadata: reply?.metadata ?? null,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("sessions_send failed", { from: ctx.currentAgentId, error: message });
+        return JSON.stringify({ error: message });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reply correlation helper
+// ---------------------------------------------------------------------------
+
+interface ReplyData {
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Set up a reply listener BEFORE sending the message. This avoids TDZ issues
+ * when the recipient handler replies synchronously during `messageBus.send()`.
+ *
+ * Returns a promise that resolves with the reply data (or undefined on
+ * timeout), plus a callback to set the correlation ID once it's known
+ * (i.e., after the send returns the message ID).
+ */
+function prepareReplyListener(
+  ctx: SessionsToolContext,
+  timeoutMs: number,
+): { promise: Promise<ReplyData | undefined>; setCorrelationId: (id: string) => void } {
+  let correlationId: string | undefined;
+  let buffered: AgentMessage[] = [];
+  let resolvePromise: (value: ReplyData | undefined) => void;
+  let settled = false;
+
+  const promise = new Promise<ReplyData | undefined>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  // Subscribe to incoming messages for the calling agent.
+  // Messages arriving before correlationId is set are buffered.
+  const unsubscribe = ctx.messageBus.subscribe(ctx.currentAgentId, (msg) => {
+    if (settled) return;
+    if (correlationId === undefined) {
+      buffered.push(msg);
+      return;
+    }
+    if (msg.metadata?.correlation_id === correlationId) {
+      settled = true;
+      if (timer) clearTimeout(timer);
+      unsubscribe();
+      resolvePromise({ content: msg.content, metadata: msg.metadata });
+    }
+  });
+
+  let timer: ReturnType<typeof setTimeout>;
+
+  const setCorrelationId = (id: string) => {
+    correlationId = id;
+
+    // Check buffered messages for a match (handles synchronous replies)
+    for (const msg of buffered) {
+      if (settled) break;
+      if (msg.metadata?.correlation_id === id) {
+        settled = true;
+        unsubscribe();
+        resolvePromise({ content: msg.content, metadata: msg.metadata });
+        break;
+      }
+    }
+    buffered = [];
+
+    if (settled) return;
+
+    timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      unsubscribe();
+      resolvePromise(undefined);
+    }, timeoutMs);
+  };
+
+  return { promise, setCorrelationId };
+}
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -231,5 +435,6 @@ export function createSessionTools(
   return [
     createSessionsSpawnTool(ctx),
     createSessionsAnnounceTool(ctx),
+    createSessionsSendTool(ctx),
   ];
 }


### PR DESCRIPTION
## Summary
Add `sessions_send` tool for point-to-point cross-session messaging.

## Changes
- Add `createSessionsSendTool()` for directed agent-to-agent messaging
- `expect_reply=true` blocks up to 30s for correlated reply
- Reply correlation via `metadata.correlation_id`
- `prepareReplyListener()` buffers messages before correlation ID is known
- Deadlock prevention: self-send + expect_reply returns error

## Tests
10 new test cases including 30s timeout test

## Closes
Closes #183