### PR TITLE
feat(tools): sessions_yield tool (#185)

### DIFF
--- a/src/acp/types.ts
+++ b/src/acp/types.ts
@@ -25,7 +25,7 @@ export interface AcpConfig {
 // ---------------------------------------------------------------------------
 
 /** Status of an ACP session */
-export type AcpSessionStatus = "active" | "idle" | "terminated";
+export type AcpSessionStatus = "active" | "idle" | "paused" | "terminated";
 
 /** A single message in an ACP session history */
 export interface AcpMessage {

--- a/src/tools/sessions.test.ts
+++ b/src/tools/sessions.test.ts
@@ -7,6 +7,7 @@ import {
   createSessionsSendTool,
   createSessionsListTool,
   createSessionsHistoryTool,
+  createSessionsYieldTool,
   createSessionTools,
   type SessionsToolContext,
 } from "./sessions.js";
@@ -205,7 +206,7 @@ describe("sessions_announce", () => {
 });
 
 describe("createSessionTools", () => {
-  it("returns all five tools", () => {
+  it("returns all six tools", () => {
     const ctx = createTestContext();
     const tools = createSessionTools(ctx);
     const names = tools.map((t) => t.tool.name);
@@ -215,7 +216,8 @@ describe("createSessionTools", () => {
     expect(names).toContain("sessions_send");
     expect(names).toContain("sessions_list");
     expect(names).toContain("sessions_history");
-    expect(tools).toHaveLength(5);
+    expect(names).toContain("sessions_yield");
+    expect(tools).toHaveLength(6);
   });
 });
 
@@ -678,5 +680,192 @@ describe("sessions_history", () => {
 
     expect(result.has_more).toBe(true);
     expect(result.next_cursor).toBe(result.messages[0].timestamp);
+  });
+});
+
+describe("sessions_yield", () => {
+  let ctx: SessionsToolContext;
+
+  beforeEach(() => {
+    ctx = createTestContext();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createSessionsYieldTool(ctx);
+    expect(tool.name).toBe("sessions_yield");
+    expect(tool.parameters.required).toContain("action");
+    expect(tool.parameters.properties).toHaveProperty("session_id");
+    expect(tool.parameters.properties).toHaveProperty("reason");
+  });
+
+  it("terminates own session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    const yieldCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      currentSessionId: session.id,
+    });
+
+    const { handler } = createSessionsYieldTool(yieldCtx);
+    const result = JSON.parse(await handler({ action: "terminate" }));
+
+    expect(result.success).toBe(true);
+    expect(result.session_id).toBe(session.id);
+    expect(result.previous_status).toBe("active");
+    expect(result.new_status).toBe("terminated");
+
+    // Verify session is actually terminated
+    const updated = ctx.sessionManager.getSession(session.id);
+    expect(updated?.status).toBe("terminated");
+  });
+
+  it("terminates session by explicit session_id", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+
+    const { handler } = createSessionsYieldTool(ctx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, action: "terminate" }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.new_status).toBe("terminated");
+  });
+
+  it("pauses and resumes session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    const yieldCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      currentSessionId: session.id,
+    });
+    const { handler } = createSessionsYieldTool(yieldCtx);
+
+    // Pause
+    const pauseResult = JSON.parse(await handler({ action: "pause" }));
+    expect(pauseResult.success).toBe(true);
+    expect(pauseResult.previous_status).toBe("active");
+    expect(pauseResult.new_status).toBe("paused");
+    expect(ctx.sessionManager.getSession(session.id)?.status).toBe("paused");
+
+    // Resume
+    const resumeResult = JSON.parse(await handler({ action: "resume" }));
+    expect(resumeResult.success).toBe(true);
+    expect(resumeResult.previous_status).toBe("paused");
+    expect(resumeResult.new_status).toBe("active");
+    expect(ctx.sessionManager.getSession(session.id)?.status).toBe("active");
+  });
+
+  it("rejects resume on active session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    const yieldCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      currentSessionId: session.id,
+    });
+    const { handler } = createSessionsYieldTool(yieldCtx);
+
+    const result = JSON.parse(await handler({ action: "resume" }));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Cannot resume");
+    expect(result.message).toContain("active");
+  });
+
+  it("rejects terminate on already terminated session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    ctx.sessionManager.terminateSession(session.id);
+
+    const { handler } = createSessionsYieldTool(ctx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, action: "terminate" }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("already terminated");
+  });
+
+  it("returns no-op success when pausing already paused session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    ctx.sessionManager.updateSession(session.id, { status: "paused" });
+
+    const { handler } = createSessionsYieldTool(ctx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, action: "pause" }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.previous_status).toBe("paused");
+    expect(result.new_status).toBe("paused");
+  });
+
+  it("rejects access to other agent's session without permission", async () => {
+    // Create a restricted context with no allowed agents
+    const mgr = new AcpSessionManager({
+      enabled: true,
+      backend: "acpx",
+      defaultAgent: "agent-a",
+      allowedAgents: [],
+    });
+    const session = mgr.createSession("agent-x");
+
+    const restrictedCtx = createTestContext({
+      sessionManager: mgr,
+      currentAgentId: "agent-a",
+    });
+
+    const { handler } = createSessionsYieldTool(restrictedCtx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, action: "terminate" }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Access denied");
+  });
+
+  it("allows access to permitted agent's session", async () => {
+    // agent-b is in allowedAgents, so agent-a can yield agent-b's session
+    const session = ctx.sessionManager.createSession("agent-b");
+
+    const { handler } = createSessionsYieldTool(ctx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, action: "terminate" }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.new_status).toBe("terminated");
+  });
+
+  it("returns error when no session_id and no current session", async () => {
+    const noSessionCtx = createTestContext({ currentSessionId: undefined });
+    const { handler } = createSessionsYieldTool(noSessionCtx);
+
+    const result = JSON.parse(await handler({ action: "terminate" }));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("No session_id");
+  });
+
+  it("returns error for non-existent session", async () => {
+    const { handler } = createSessionsYieldTool(ctx);
+    const result = JSON.parse(
+      await handler({ session_id: "non-existent", action: "terminate" }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Session not found");
+  });
+
+  it("terminates paused session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    ctx.sessionManager.updateSession(session.id, { status: "paused" });
+
+    const { handler } = createSessionsYieldTool(ctx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, action: "terminate" }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.previous_status).toBe("paused");
+    expect(result.new_status).toBe("terminated");
   });
 });

--- a/src/tools/sessions.ts
+++ b/src/tools/sessions.ts
@@ -6,6 +6,7 @@ import type { Tool } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";
 import type { AcpSessionManager } from "../acp/session-manager.js";
 import type { AgentMessageBus, AgentMessage } from "../acp/message-bus.js";
+import type { AcpSessionStatus } from "../acp/types.js";
 
 const log = createLogger("tools:sessions");
 
@@ -476,9 +477,9 @@ export function createSessionsListTool(
       }
 
       try {
-        const filter: { agentId?: string; status?: "active" | "idle" | "terminated" } = {};
+        const filter: { agentId?: string; status?: AcpSessionStatus } = {};
         if (agent_id) filter.agentId = agent_id;
-        if (status) filter.status = status as "active" | "idle" | "terminated";
+        if (status) filter.status = status as AcpSessionStatus;
 
         const allSessions = ctx.sessionManager.listSessions(
           Object.keys(filter).length > 0 ? filter : undefined,
@@ -615,6 +616,149 @@ export function createSessionsHistoryTool(
 }
 
 // ---------------------------------------------------------------------------
+// sessions_yield
+// ---------------------------------------------------------------------------
+
+/** Valid target status for each (current_status, action) pair. null = invalid. */
+const YIELD_TRANSITIONS: Record<string, Record<string, AcpSessionStatus | null>> = {
+  active:     { terminate: "terminated", pause: "paused", resume: null },
+  paused:     { terminate: "terminated", pause: null,     resume: "active" },
+  idle:       { terminate: "terminated", pause: "paused", resume: null },
+  terminated: { terminate: null,         pause: null,     resume: null },
+};
+
+/**
+ * Create the `sessions_yield` tool.
+ *
+ * Allows agents to terminate, pause, or resume ACP sessions they own or
+ * are permitted to access via allowedAgents.
+ */
+export function createSessionsYieldTool(
+  ctx: SessionsToolContext,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "sessions_yield",
+      description:
+        "Terminate, pause, or resume an ACP session. " +
+        "Defaults to the current session if session_id is omitted.",
+      parameters: {
+        type: "object",
+        properties: {
+          session_id: {
+            type: "string",
+            description: "Target session ID. Defaults to current session.",
+          },
+          action: {
+            type: "string",
+            enum: ["terminate", "pause", "resume"],
+            description: "Action to perform on the session",
+          },
+          reason: {
+            type: "string",
+            description: "Optional reason for audit logging",
+          },
+        },
+        required: ["action"],
+      },
+    },
+    handler: async (args) => {
+      const { session_id, action, reason } = args as {
+        session_id?: string;
+        action: "terminate" | "pause" | "resume";
+        reason?: string;
+      };
+
+      const targetId = session_id ?? ctx.currentSessionId;
+
+      if (!targetId) {
+        return JSON.stringify({
+          success: false,
+          message: "No session_id provided and no current session",
+        });
+      }
+
+      const session = ctx.sessionManager.getSession(targetId);
+      if (!session) {
+        return JSON.stringify({
+          success: false,
+          message: `Session not found: ${targetId}`,
+        });
+      }
+
+      // Access control: agent must own the session OR session's agent is in allowedAgents
+      const allowedAgents = ctx.sessionManager.getConfig().allowedAgents ?? [];
+      const isOwner = session.agentId === ctx.currentAgentId;
+      const isAllowed = allowedAgents.includes(session.agentId);
+
+      if (!isOwner && !isAllowed) {
+        return JSON.stringify({
+          success: false,
+          session_id: targetId,
+          message: `Access denied to session: ${targetId}`,
+        });
+      }
+
+      const previousStatus = session.status;
+      const newStatus = YIELD_TRANSITIONS[previousStatus]?.[action];
+
+      // No-op: pause an already paused session
+      if (newStatus === null && action === "pause" && previousStatus === "paused") {
+        return JSON.stringify({
+          success: true,
+          session_id: targetId,
+          previous_status: previousStatus,
+          new_status: previousStatus,
+        });
+      }
+
+      // Invalid transition
+      if (newStatus === null || newStatus === undefined) {
+        let message: string;
+        if (action === "terminate" && previousStatus === "terminated") {
+          message = "Session already terminated";
+        } else if (action === "resume") {
+          message = `Cannot resume session in status "${previousStatus}"`;
+        } else {
+          message = `Cannot ${action} session in status "${previousStatus}"`;
+        }
+
+        return JSON.stringify({
+          success: false,
+          session_id: targetId,
+          previous_status: previousStatus,
+          new_status: previousStatus,
+          message,
+        });
+      }
+
+      // Execute the transition
+      if (action === "terminate") {
+        ctx.sessionManager.terminateSession(targetId);
+      } else {
+        ctx.sessionManager.updateSession(targetId, { status: newStatus });
+      }
+
+      log.info("Session yield", {
+        sessionId: targetId,
+        callingAgent: ctx.currentAgentId,
+        action,
+        previousStatus,
+        newStatus,
+        reason,
+      });
+
+      return JSON.stringify({
+        success: true,
+        session_id: targetId,
+        previous_status: previousStatus,
+        new_status: newStatus,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -631,5 +775,6 @@ export function createSessionTools(
     createSessionsSendTool(ctx),
     createSessionsListTool(ctx),
     createSessionsHistoryTool(ctx),
+    createSessionsYieldTool(ctx),
   ];
 }


### PR DESCRIPTION
## Summary
- Add `sessions_yield` tool to `src/tools/sessions.ts` enabling agents to terminate, pause, or resume ACP sessions
- Extend `AcpSessionStatus` type with `"paused"` status in `src/acp/types.ts`
- Implement state machine validation (terminate from active/paused/idle, pause from active/idle, resume from paused only, pause-on-paused is no-op)
- Access control: agents can yield own sessions or sessions belonging to agents in `allowedAgents`

## Test plan
- [x] Terminates own session (via currentSessionId default)
- [x] Terminates session by explicit session_id
- [x] Pauses and resumes session round-trip
- [x] Rejects resume on active session
- [x] Rejects terminate on already terminated session
- [x] Pause on already paused is no-op (success, same status)
- [x] Rejects access to other agent's session without permission
- [x] Allows access to permitted agent's session
- [x] Returns error when no session_id and no current session
- [x] Returns error for non-existent session
- [x] Terminates paused session
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] All 58 tests pass (including 30s timeout test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)