### PR TITLE
feat(tools): sessions_kill and sessions_status tools (#186)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -71,6 +71,12 @@ export { createWebFetchTool } from "./web.js";
 export {
   createSessionsSpawnTool,
   createSessionsAnnounceTool,
+  createSessionsSendTool,
+  createSessionsListTool,
+  createSessionsHistoryTool,
+  createSessionsYieldTool,
+  createSessionsKillTool,
+  createSessionsStatusTool,
   createSessionTools,
 } from "./sessions.js";
 export type { SessionsToolContext } from "./sessions.js";

--- a/src/tools/sessions.test.ts
+++ b/src/tools/sessions.test.ts
@@ -8,6 +8,8 @@ import {
   createSessionsListTool,
   createSessionsHistoryTool,
   createSessionsYieldTool,
+  createSessionsKillTool,
+  createSessionsStatusTool,
   createSessionTools,
   type SessionsToolContext,
 } from "./sessions.js";
@@ -206,7 +208,7 @@ describe("sessions_announce", () => {
 });
 
 describe("createSessionTools", () => {
-  it("returns all six tools", () => {
+  it("returns all eight tools", () => {
     const ctx = createTestContext();
     const tools = createSessionTools(ctx);
     const names = tools.map((t) => t.tool.name);
@@ -217,7 +219,9 @@ describe("createSessionTools", () => {
     expect(names).toContain("sessions_list");
     expect(names).toContain("sessions_history");
     expect(names).toContain("sessions_yield");
-    expect(tools).toHaveLength(6);
+    expect(names).toContain("sessions_kill");
+    expect(names).toContain("sessions_status");
+    expect(tools).toHaveLength(8);
   });
 });
 
@@ -867,5 +871,209 @@ describe("sessions_yield", () => {
     expect(result.success).toBe(true);
     expect(result.previous_status).toBe("paused");
     expect(result.new_status).toBe("terminated");
+  });
+});
+
+describe("sessions_kill", () => {
+  let ctx: SessionsToolContext;
+
+  beforeEach(() => {
+    ctx = createTestContext();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createSessionsKillTool(ctx);
+    expect(tool.name).toBe("sessions_kill");
+    expect(tool.parameters.required).toContain("session_id");
+    expect(tool.parameters.properties).toHaveProperty("reason");
+  });
+
+  it("terminates an active session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+
+    const { handler } = createSessionsKillTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.success).toBe(true);
+    expect(result.session_id).toBe(session.id);
+    expect(result.status).toBe("terminated");
+    expect(result.previous_status).toBe("active");
+
+    // Verify session is actually terminated
+    const updated = ctx.sessionManager.getSession(session.id);
+    expect(updated?.status).toBe("terminated");
+  });
+
+  it("terminates a paused session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    ctx.sessionManager.updateSession(session.id, { status: "paused" });
+
+    const { handler } = createSessionsKillTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.success).toBe(true);
+    expect(result.previous_status).toBe("paused");
+    expect(result.status).toBe("terminated");
+  });
+
+  it("returns success with message for already terminated session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    ctx.sessionManager.terminateSession(session.id);
+
+    const { handler } = createSessionsKillTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe("terminated");
+    expect(result.message).toContain("already terminated");
+  });
+
+  it("returns error for non-existent session", async () => {
+    const { handler } = createSessionsKillTool(ctx);
+    const result = JSON.parse(await handler({ session_id: "non-existent" }));
+
+    expect(result.error).toContain("Session not found");
+  });
+
+  it("allows killing allowed agent's session", async () => {
+    // agent-b is in allowedAgents, so agent-a can kill it
+    const session = ctx.sessionManager.createSession("agent-b");
+
+    const { handler } = createSessionsKillTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe("terminated");
+  });
+
+  it("rejects access to non-allowed agent's session", async () => {
+    const mgr = new AcpSessionManager({
+      enabled: true,
+      backend: "acpx",
+      defaultAgent: "agent-a",
+      allowedAgents: [],
+    });
+    const session = mgr.createSession("agent-x");
+
+    const restrictedCtx = createTestContext({
+      sessionManager: mgr,
+      currentAgentId: "agent-a",
+    });
+
+    const { handler } = createSessionsKillTool(restrictedCtx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.error).toContain("Access denied");
+  });
+
+  it("accepts optional reason parameter", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+
+    const { handler } = createSessionsKillTool(ctx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, reason: "stuck subagent" }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe("terminated");
+  });
+});
+
+describe("sessions_status", () => {
+  let ctx: SessionsToolContext;
+
+  beforeEach(() => {
+    ctx = createTestContext();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createSessionsStatusTool(ctx);
+    expect(tool.name).toBe("sessions_status");
+    expect(tool.parameters.required).toContain("session_id");
+  });
+
+  it("returns correct fields for active session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    ctx.sessionManager.addMessage(session.id, { role: "user", content: "hello" });
+    ctx.sessionManager.addMessage(session.id, { role: "assistant", content: "hi" });
+
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.session_id).toBe(session.id);
+    expect(result.agent_id).toBe("agent-a");
+    expect(result.status).toBe("active");
+    expect(result.message_count).toBe(2);
+    expect(result.thread_id).toBeNull();
+    // Verify timestamps are valid ISO strings
+    expect(new Date(result.created_at).toISOString()).toBe(result.created_at);
+    expect(new Date(result.last_activity).toISOString()).toBe(result.last_activity);
+  });
+
+  it("returns thread_id when session is bound to a thread", async () => {
+    const session = ctx.sessionManager.createSession("agent-a", "thread-456");
+
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.thread_id).toBe("thread-456");
+  });
+
+  it("returns status for terminated session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    ctx.sessionManager.terminateSession(session.id);
+
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.status).toBe("terminated");
+  });
+
+  it("returns error for non-existent session", async () => {
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ session_id: "non-existent" }));
+
+    expect(result.error).toContain("Session not found");
+  });
+
+  it("allows status of allowed agent's session", async () => {
+    // agent-b is in allowedAgents
+    const session = ctx.sessionManager.createSession("agent-b");
+
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.session_id).toBe(session.id);
+    expect(result.agent_id).toBe("agent-b");
+    expect(result.status).toBe("active");
+  });
+
+  it("rejects access to non-allowed agent's session", async () => {
+    const mgr = new AcpSessionManager({
+      enabled: true,
+      backend: "acpx",
+      defaultAgent: "agent-a",
+      allowedAgents: [],
+    });
+    const session = mgr.createSession("agent-x");
+
+    const restrictedCtx = createTestContext({
+      sessionManager: mgr,
+      currentAgentId: "agent-a",
+    });
+
+    const { handler } = createSessionsStatusTool(restrictedCtx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.error).toContain("Access denied");
+  });
+
+  it("returns zero message_count for empty session", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.message_count).toBe(0);
   });
 });

--- a/src/tools/sessions.ts
+++ b/src/tools/sessions.ts
@@ -451,7 +451,7 @@ export function createSessionsListTool(
           },
           status: {
             type: "string",
-            enum: ["active", "idle", "terminated"],
+            enum: ["active", "idle", "paused", "terminated"],
             description: "Filter by session status",
           },
           limit: {
@@ -759,6 +759,153 @@ export function createSessionsYieldTool(
 }
 
 // ---------------------------------------------------------------------------
+// sessions_kill
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `sessions_kill` tool.
+ *
+ * Terminates an ACP session. Access control: the calling agent must own the
+ * session OR the session's agent must be in allowedAgents.
+ */
+export function createSessionsKillTool(
+  ctx: SessionsToolContext,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "sessions_kill",
+      description:
+        "Terminate an ACP session immediately. " +
+        "Sets the session status to terminated and cleans up resources.",
+      parameters: {
+        type: "object",
+        properties: {
+          session_id: {
+            type: "string",
+            description: "Session ID to terminate",
+          },
+          reason: {
+            type: "string",
+            description: "Optional reason for termination (for audit logging)",
+          },
+        },
+        required: ["session_id"],
+      },
+    },
+    handler: async (args) => {
+      const { session_id, reason } = args as {
+        session_id: string;
+        reason?: string;
+      };
+
+      const session = ctx.sessionManager.getSession(session_id);
+      if (!session) {
+        return JSON.stringify({ error: `Session not found: ${session_id}` });
+      }
+
+      // Access control: agent must own the session OR session's agent is in allowedAgents
+      const allowedAgents = ctx.sessionManager.getConfig().allowedAgents ?? [];
+      const isOwner = session.agentId === ctx.currentAgentId;
+      const isAllowed = allowedAgents.includes(session.agentId);
+
+      if (!isOwner && !isAllowed) {
+        return JSON.stringify({
+          error: `Access denied to session: ${session_id}`,
+        });
+      }
+
+      // Already terminated — no-op success
+      if (session.status === "terminated") {
+        return JSON.stringify({
+          success: true,
+          session_id,
+          status: "terminated",
+          message: "Session already terminated",
+        });
+      }
+
+      const previousStatus = session.status;
+      ctx.sessionManager.terminateSession(session_id);
+
+      log.info("Session killed", {
+        sessionId: session_id,
+        callingAgent: ctx.currentAgentId,
+        previousStatus,
+        reason,
+      });
+
+      return JSON.stringify({
+        success: true,
+        session_id,
+        status: "terminated",
+        previous_status: previousStatus,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// sessions_status
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `sessions_status` tool.
+ *
+ * Returns detailed status and metadata for a specific ACP session.
+ * Access control: same as sessions_kill.
+ */
+export function createSessionsStatusTool(
+  ctx: SessionsToolContext,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "sessions_status",
+      description:
+        "Get the current status and metadata for a specific ACP session.",
+      parameters: {
+        type: "object",
+        properties: {
+          session_id: {
+            type: "string",
+            description: "Session ID to query",
+          },
+        },
+        required: ["session_id"],
+      },
+    },
+    handler: async (args) => {
+      const { session_id } = args as { session_id: string };
+
+      const session = ctx.sessionManager.getSession(session_id);
+      if (!session) {
+        return JSON.stringify({ error: `Session not found: ${session_id}` });
+      }
+
+      // Access control: agent must own the session OR session's agent is in allowedAgents
+      const allowedAgents = ctx.sessionManager.getConfig().allowedAgents ?? [];
+      const isOwner = session.agentId === ctx.currentAgentId;
+      const isAllowed = allowedAgents.includes(session.agentId);
+
+      if (!isOwner && !isAllowed) {
+        return JSON.stringify({
+          error: `Access denied to session: ${session_id}`,
+        });
+      }
+
+      return JSON.stringify({
+        session_id: session.id,
+        agent_id: session.agentId,
+        status: session.status,
+        created_at: session.createdAt.toISOString(),
+        last_activity: session.lastActivityAt.toISOString(),
+        message_count: session.history.length,
+        thread_id: session.threadId ?? null,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -776,5 +923,7 @@ export function createSessionTools(
     createSessionsListTool(ctx),
     createSessionsHistoryTool(ctx),
     createSessionsYieldTool(ctx),
+    createSessionsKillTool(ctx),
+    createSessionsStatusTool(ctx),
   ];
 }


### PR DESCRIPTION
## Summary

- **sessions_kill**: Terminates an ACP session immediately. Accepts `session_id` (required) and `reason` (optional for audit logging). Returns no-op success if already terminated, error if session not found or access denied.
- **sessions_status**: Returns session metadata — `status`, `agent_id`, `created_at`, `last_activity`, `message_count`, `thread_id`. Error if session not found or access denied.
- Both tools enforce the same access control as existing session tools (owner or `allowedAgents`).
- Updated `createSessionTools()` factory (6 → 8 tools) and `src/tools/index.ts` exports.
- Also fixed `sessions_list` status enum to include `"paused"`.

## Test plan

- [x] sessions_kill: terminate active session
- [x] sessions_kill: terminate paused session
- [x] sessions_kill: no-op for already terminated session
- [x] sessions_kill: error for non-existent session
- [x] sessions_kill: access control (allowed vs denied)
- [x] sessions_kill: optional reason parameter
- [x] sessions_status: returns all fields for active session
- [x] sessions_status: returns thread_id when bound
- [x] sessions_status: terminated session status
- [x] sessions_status: error for non-existent session
- [x] sessions_status: access control (allowed vs denied)
- [x] sessions_status: zero message_count for empty session
- [x] createSessionTools returns 8 tools
- [x] `pnpm tsc --noEmit` passes
- [x] `npx vitest run src/tools/sessions.test.ts` — 74 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)