### PR TITLE
feat(tools): subagent management tools (#186)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -74,3 +74,9 @@ export {
   createSessionTools,
 } from "./sessions.js";
 export type { SessionsToolContext } from "./sessions.js";
+
+export {
+  createSubagentsListTool,
+  createSubagentsStatusTool,
+  createSubagentsCancelTool,
+} from "./subagent-management.js";

--- a/src/tools/subagent-management.test.ts
+++ b/src/tools/subagent-management.test.ts
@@ -1,0 +1,179 @@
+// src/tools/subagent-management.test.ts — Tests for subagent management tools
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { taskRegistry } from "../subagent/task-registry.js";
+import {
+  createSubagentsListTool,
+  createSubagentsStatusTool,
+  createSubagentsCancelTool,
+} from "./subagent-management.js";
+
+vi.mock("./subagent.js", () => ({
+  cancelSubagent: vi.fn(() => true),
+}));
+
+// Access the mock for assertions
+import { cancelSubagent } from "./subagent.js";
+const cancelSubagentMock = vi.mocked(cancelSubagent);
+
+beforeEach(() => {
+  // Clear the task registry between tests
+  for (const task of taskRegistry.list()) {
+    taskRegistry.unregister(task.taskId);
+  }
+  cancelSubagentMock.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// subagents_list
+// ---------------------------------------------------------------------------
+
+describe("subagents_list", () => {
+  it("returns tool with correct schema", () => {
+    const { tool } = createSubagentsListTool();
+    expect(tool.name).toBe("subagents_list");
+    expect(tool.parameters.properties).toHaveProperty("session_id");
+    expect(tool.parameters.properties).toHaveProperty("channel_id");
+  });
+
+  it("returns empty list when no tasks", async () => {
+    const { handler } = createSubagentsListTool();
+    const result = JSON.parse(await handler({}));
+
+    expect(result.tasks).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  it("lists all running tasks", async () => {
+    taskRegistry.register("task-1", "session-a", "channel-1");
+    taskRegistry.register("task-2", "session-b", "channel-2");
+
+    const { handler } = createSubagentsListTool();
+    const result = JSON.parse(await handler({}));
+
+    expect(result.count).toBe(2);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.tasks[0].task_id).toBe("task-1");
+    expect(result.tasks[0].session_id).toBe("session-a");
+    expect(result.tasks[0].channel_id).toBe("channel-1");
+    expect(result.tasks[0]).toHaveProperty("started_at");
+    expect(result.tasks[0]).toHaveProperty("running_seconds");
+    expect(result.tasks[1].task_id).toBe("task-2");
+  });
+
+  it("filters by session_id", async () => {
+    taskRegistry.register("task-1", "session-a", "channel-1");
+    taskRegistry.register("task-2", "session-b", "channel-2");
+    taskRegistry.register("task-3", "session-a", "channel-3");
+
+    const { handler } = createSubagentsListTool();
+    const result = JSON.parse(await handler({ session_id: "session-a" }));
+
+    expect(result.count).toBe(2);
+    expect(result.tasks.every((t: { session_id: string }) => t.session_id === "session-a")).toBe(true);
+  });
+
+  it("filters by channel_id", async () => {
+    taskRegistry.register("task-1", "session-a", "channel-1");
+    taskRegistry.register("task-2", "session-b", "channel-1");
+    taskRegistry.register("task-3", "session-a", "channel-2");
+
+    const { handler } = createSubagentsListTool();
+    const result = JSON.parse(await handler({ channel_id: "channel-1" }));
+
+    expect(result.count).toBe(2);
+    expect(result.tasks.every((t: { channel_id: string }) => t.channel_id === "channel-1")).toBe(true);
+  });
+
+  it("filters by both session_id and channel_id", async () => {
+    taskRegistry.register("task-1", "session-a", "channel-1");
+    taskRegistry.register("task-2", "session-a", "channel-2");
+    taskRegistry.register("task-3", "session-b", "channel-1");
+
+    const { handler } = createSubagentsListTool();
+    const result = JSON.parse(await handler({ session_id: "session-a", channel_id: "channel-1" }));
+
+    expect(result.count).toBe(1);
+    expect(result.tasks[0].task_id).toBe("task-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subagents_status
+// ---------------------------------------------------------------------------
+
+describe("subagents_status", () => {
+  it("returns tool with correct schema", () => {
+    const { tool } = createSubagentsStatusTool();
+    expect(tool.name).toBe("subagents_status");
+    expect(tool.parameters.required).toContain("task_id");
+  });
+
+  it("returns status of a running task", async () => {
+    taskRegistry.register("task-1", "session-a", "channel-1");
+
+    const { handler } = createSubagentsStatusTool();
+    const result = JSON.parse(await handler({ task_id: "task-1" }));
+
+    expect(result.found).toBe(true);
+    expect(result.task_id).toBe("task-1");
+    expect(result.status).toBe("running");
+    expect(result.session_id).toBe("session-a");
+    expect(result.channel_id).toBe("channel-1");
+    expect(result).toHaveProperty("started_at");
+    expect(result).toHaveProperty("running_seconds");
+  });
+
+  it("returns not found for unknown task", async () => {
+    const { handler } = createSubagentsStatusTool();
+    const result = JSON.parse(await handler({ task_id: "nonexistent" }));
+
+    expect(result.found).toBe(false);
+    expect(result.task_id).toBe("nonexistent");
+    expect(result.status).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subagents_cancel
+// ---------------------------------------------------------------------------
+
+describe("subagents_cancel", () => {
+  it("returns tool with correct schema", () => {
+    const { tool } = createSubagentsCancelTool();
+    expect(tool.name).toBe("subagents_cancel");
+    expect(tool.parameters.required).toContain("task_id");
+  });
+
+  it("cancels a running task", async () => {
+    taskRegistry.register("task-1", "session-a", "channel-1");
+
+    const { handler } = createSubagentsCancelTool();
+    const result = JSON.parse(await handler({ task_id: "task-1" }));
+
+    expect(result.cancelled).toBe(true);
+    expect(result.task_id).toBe("task-1");
+    expect(cancelSubagentMock).toHaveBeenCalledWith("task-1");
+  });
+
+  it("returns not found for unknown task", async () => {
+    const { handler } = createSubagentsCancelTool();
+    const result = JSON.parse(await handler({ task_id: "nonexistent" }));
+
+    expect(result.cancelled).toBe(false);
+    expect(result.task_id).toBe("nonexistent");
+    expect(result.reason).toBe("task not found");
+    expect(cancelSubagentMock).not.toHaveBeenCalled();
+  });
+
+  it("reports failure when cancelSubagent returns false", async () => {
+    taskRegistry.register("task-1", "session-a", "channel-1");
+    cancelSubagentMock.mockReturnValueOnce(false);
+
+    const { handler } = createSubagentsCancelTool();
+    const result = JSON.parse(await handler({ task_id: "task-1" }));
+
+    expect(result.cancelled).toBe(false);
+    expect(result.task_id).toBe("task-1");
+  });
+});

--- a/src/tools/subagent-management.ts
+++ b/src/tools/subagent-management.ts
@@ -1,0 +1,164 @@
+// src/tools/subagent-management.ts — Tools for listing, inspecting, and cancelling subagent tasks
+// Exposes TaskRegistry and cancelSubagent to agents as callable tools.
+
+import type { Tool } from "../core/types.js";
+import type { ToolHandler } from "../core/tools.js";
+import { taskRegistry } from "../subagent/task-registry.js";
+import { cancelSubagent } from "./subagent.js";
+
+// ---------------------------------------------------------------------------
+// subagents_list
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `subagents_list` tool.
+ *
+ * Lists running subagent tasks, optionally filtered by session_id or
+ * channel_id.
+ */
+export function createSubagentsListTool(): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "subagents_list",
+      description:
+        "List running subagent tasks. Optionally filter by session_id or channel_id.",
+      parameters: {
+        type: "object",
+        properties: {
+          session_id: {
+            type: "string",
+            description: "Filter by session ID",
+          },
+          channel_id: {
+            type: "string",
+            description: "Filter by channel ID",
+          },
+        },
+      },
+    },
+    handler: async (args) => {
+      const { session_id, channel_id } = args as {
+        session_id?: string;
+        channel_id?: string;
+      };
+
+      let tasks = taskRegistry.list();
+
+      if (session_id) {
+        tasks = tasks.filter((t) => t.sessionId === session_id);
+      }
+      if (channel_id) {
+        tasks = tasks.filter((t) => t.channelId === channel_id);
+      }
+
+      return JSON.stringify({
+        tasks: tasks.map((t) => ({
+          task_id: t.taskId,
+          session_id: t.sessionId,
+          channel_id: t.channelId,
+          started_at: t.startedAt.toISOString(),
+          running_seconds: Math.floor((Date.now() - t.startedAt.getTime()) / 1000),
+        })),
+        count: tasks.length,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// subagents_status
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `subagents_status` tool.
+ *
+ * Returns detailed status of a specific subagent task by task_id.
+ */
+export function createSubagentsStatusTool(): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "subagents_status",
+      description:
+        "Get status of a specific subagent task by task_id.",
+      parameters: {
+        type: "object",
+        properties: {
+          task_id: {
+            type: "string",
+            description: "Task ID to query",
+          },
+        },
+        required: ["task_id"],
+      },
+    },
+    handler: async (args) => {
+      const { task_id } = args as { task_id: string };
+
+      const task = taskRegistry.get(task_id);
+      if (!task) {
+        return JSON.stringify({
+          found: false,
+          task_id,
+          status: "unknown",
+        });
+      }
+
+      return JSON.stringify({
+        found: true,
+        task_id: task.taskId,
+        status: "running",
+        session_id: task.sessionId,
+        channel_id: task.channelId,
+        started_at: task.startedAt.toISOString(),
+        running_seconds: Math.floor((Date.now() - task.startedAt.getTime()) / 1000),
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// subagents_cancel
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `subagents_cancel` tool.
+ *
+ * Cancels a running subagent task by task_id.
+ */
+export function createSubagentsCancelTool(): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "subagents_cancel",
+      description:
+        "Cancel a running subagent task by task_id.",
+      parameters: {
+        type: "object",
+        properties: {
+          task_id: {
+            type: "string",
+            description: "Task ID to cancel",
+          },
+        },
+        required: ["task_id"],
+      },
+    },
+    handler: async (args) => {
+      const { task_id } = args as { task_id: string };
+
+      const task = taskRegistry.get(task_id);
+      if (!task) {
+        return JSON.stringify({
+          cancelled: false,
+          task_id,
+          reason: "task not found",
+        });
+      }
+
+      const success = cancelSubagent(task_id);
+      return JSON.stringify({
+        cancelled: success,
+        task_id,
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add `subagents_list` tool — lists running subagent tasks with optional `session_id`/`channel_id` filtering
- Add `subagents_status` tool — returns detailed status of a specific task by `task_id`
- Add `subagents_cancel` tool — cancels a running task by `task_id`

Wraps existing `TaskRegistry` and `cancelSubagent()` infrastructure as agent-callable tools, enabling agents to manage spawned subagents (orchestrator pattern).

## Test plan
- [x] `pnpm tsc --noEmit` — passes
- [x] `npx vitest run src/tools/subagent-management.test.ts` — 13 tests pass
- [x] `pnpm lint` — passes
- [x] Unit tests cover: empty list, filtered list, status found/not found, cancel success/not found/failure

🤖 Generated with [Claude Code](https://claude.ai/code)