### PR TITLE
feat(tools): tool policy deny/allow config (#187)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import {
   buildToolGuardPrompt,
   createWorkspaceToolsWithGuards,
   resolveToolGuards,
+  applyToolPolicy,
 } from "./core/tools.js";
 import { createSelfIterationTools } from "./tools/self-iteration.js";
 import { createIterateCodebaseTool } from "./tools/iterate-codebase.js";
@@ -325,7 +326,10 @@ async function main() {
       subagentEnabled,
       agentAllowedWorkspaces,
     );
-    for (const { tool, handler } of workspaceTools) {
+
+    // Apply tool policy (allow/deny) before registration
+    const filteredTools = applyToolPolicy(workspaceTools, agentConfig.toolSettings);
+    for (const { tool, handler } of filteredTools) {
       toolRegistry.register(tool, handler);
     }
 

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -405,6 +405,8 @@ agents:
       expect(resolveToolSettings()).toEqual({
         cli: false,
         fs: { workspaceOnly: true },
+        allow: undefined,
+        deny: undefined,
       });
     });
 
@@ -417,7 +419,51 @@ agents:
       ).toEqual({
         cli: true,
         fs: { workspaceOnly: false },
+        allow: undefined,
+        deny: undefined,
       });
+    });
+
+    it("passes through allow list from agent config", () => {
+      const result = resolveToolSettings({ allow: ["read_file", "list_dir"] });
+      expect(result.allow).toEqual(["read_file", "list_dir"]);
+    });
+
+    it("passes through deny list from agent config", () => {
+      const result = resolveToolSettings({ deny: ["shell", "write_file"] });
+      expect(result.deny).toEqual(["shell", "write_file"]);
+    });
+
+    it("agent allow overrides default allow", () => {
+      const result = resolveToolSettings(
+        { allow: ["read_file"] },
+        { allow: ["read_file", "shell"] },
+      );
+      expect(result.allow).toEqual(["read_file"]);
+    });
+
+    it("agent deny overrides default deny", () => {
+      const result = resolveToolSettings(
+        { deny: ["shell"] },
+        { deny: ["shell", "write_file"] },
+      );
+      expect(result.deny).toEqual(["shell"]);
+    });
+
+    it("falls back to default allow when agent has none", () => {
+      const result = resolveToolSettings(
+        {},
+        { allow: ["read_file"] },
+      );
+      expect(result.allow).toEqual(["read_file"]);
+    });
+
+    it("falls back to default deny when agent has none", () => {
+      const result = resolveToolSettings(
+        {},
+        { deny: ["shell"] },
+      );
+      expect(result.deny).toEqual(["shell"]);
     });
   });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -78,6 +78,10 @@ export interface AgentToolsConfigFile {
   fs?: {
     workspaceOnly?: boolean;
   };
+  /** Tool names to explicitly allow (if set, only these are available) */
+  allow?: string[];
+  /** Tool names to explicitly deny (takes precedence over allow) */
+  deny?: string[];
 }
 
 /** Compaction configuration in config file */
@@ -333,6 +337,9 @@ export function resolveToolSettings(
     fs: {
       workspaceOnly: agentTools?.fs?.workspaceOnly ?? defaultTools?.fs?.workspaceOnly ?? true,
     },
+    // allow/deny: agent-level overrides defaults entirely (not merged)
+    allow: agentTools?.allow ?? defaultTools?.allow,
+    deny: agentTools?.deny ?? defaultTools?.deny,
   };
 }
 

--- a/src/core/tools.test.ts
+++ b/src/core/tools.test.ts
@@ -16,6 +16,7 @@ import {
   createWorkspaceTools,
   createWorkspaceToolsWithGuards,
   resolveToolGuards,
+  applyToolPolicy,
   type ToolHandler,
 } from "./tools.js";
 import type { Tool } from "./types.js";
@@ -429,5 +430,71 @@ describe("Built-in tools", () => {
       expect(prompt).toContain("restricted to the workspace: /tmp/workspace");
       expect(prompt).toContain("Shell command execution is enabled");
     });
+  });
+});
+
+describe("applyToolPolicy", () => {
+  function makeTools(...names: string[]) {
+    return names.map((name) => ({
+      tool: { name, description: `${name} tool`, parameters: {} } as Tool,
+      handler: (async () => "") as ToolHandler,
+    }));
+  }
+
+  it("returns all tools when no policy is provided", () => {
+    const tools = makeTools("a", "b", "c");
+    const result = applyToolPolicy(tools, undefined);
+    expect(result.map((t) => t.tool.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns all tools when policy has neither allow nor deny", () => {
+    const tools = makeTools("a", "b", "c");
+    const result = applyToolPolicy(tools, {});
+    expect(result.map((t) => t.tool.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters to only allowed tools when allow is set", () => {
+    const tools = makeTools("read_file", "write_file", "shell", "get_current_time");
+    const result = applyToolPolicy(tools, { allow: ["read_file", "get_current_time"] });
+    expect(result.map((t) => t.tool.name)).toEqual(["read_file", "get_current_time"]);
+  });
+
+  it("removes denied tools when deny is set", () => {
+    const tools = makeTools("read_file", "write_file", "shell", "get_current_time");
+    const result = applyToolPolicy(tools, { deny: ["shell", "write_file"] });
+    expect(result.map((t) => t.tool.name)).toEqual(["read_file", "get_current_time"]);
+  });
+
+  it("deny takes precedence over allow", () => {
+    const tools = makeTools("read_file", "write_file", "shell");
+    const result = applyToolPolicy(tools, {
+      allow: ["read_file", "write_file", "shell"],
+      deny: ["shell"],
+    });
+    expect(result.map((t) => t.tool.name)).toEqual(["read_file", "write_file"]);
+  });
+
+  it("returns empty array when all tools are denied", () => {
+    const tools = makeTools("a", "b");
+    const result = applyToolPolicy(tools, { deny: ["a", "b"] });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when allow is empty", () => {
+    const tools = makeTools("a", "b");
+    const result = applyToolPolicy(tools, { allow: [] });
+    expect(result).toEqual([]);
+  });
+
+  it("ignores deny entries that do not match any tool", () => {
+    const tools = makeTools("a", "b");
+    const result = applyToolPolicy(tools, { deny: ["nonexistent"] });
+    expect(result.map((t) => t.tool.name)).toEqual(["a", "b"]);
+  });
+
+  it("ignores allow entries that do not match any tool", () => {
+    const tools = makeTools("a", "b");
+    const result = applyToolPolicy(tools, { allow: ["a", "nonexistent"] });
+    expect(result.map((t) => t.tool.name)).toEqual(["a"]);
   });
 });

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -622,6 +622,37 @@ export function buildToolGuardPrompt(
   return lines.join("\n");
 }
 // ---------------------------------------------------------------------------
+// Tool policy — per-agent allow/deny filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply tool policy (allow/deny lists) to a set of tool entries.
+ *
+ * - If `allow` is set, only tools in the allow list pass through.
+ * - If `deny` is set, those tools are removed.
+ * - `deny` takes precedence over `allow` (a tool in both lists is denied).
+ */
+export function applyToolPolicy(
+  tools: { tool: Tool; handler: ToolHandler }[],
+  policy?: { allow?: string[]; deny?: string[] },
+): { tool: Tool; handler: ToolHandler }[] {
+  if (!policy) return tools;
+  const { allow, deny } = policy;
+  if (!allow && !deny) return tools;
+
+  const denySet = deny ? new Set(deny) : undefined;
+  const allowSet = allow ? new Set(allow) : undefined;
+
+  return tools.filter(({ tool }) => {
+    // deny takes precedence
+    if (denySet?.has(tool.name)) return false;
+    // if allow is set, tool must be in the allow list
+    if (allowSet && !allowSet.has(tool.name)) return false;
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Tool set helpers
 // ---------------------------------------------------------------------------
 /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -66,12 +66,16 @@ export interface FileToolPolicy {
   workspaceOnly?: boolean;
 }
 
-/** Per-agent tool policy (CLI access, file system restrictions). */
+/** Per-agent tool policy (CLI access, file system restrictions, per-tool allow/deny). */
 export interface AgentToolSettings {
   /** Enable web_search and web_fetch tools */
   web?: boolean;
   cli?: boolean;
   fs?: FileToolPolicy;
+  /** Tool names to explicitly allow (if set, only these are available) */
+  allow?: string[];
+  /** Tool names to explicitly deny (takes precedence over allow) */
+  deny?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `allow` and `deny` fields to `AgentToolSettings` and `AgentToolsConfigFile` for per-agent tool filtering
- Add `applyToolPolicy()` function that filters tools before registration — `deny` takes precedence over `allow`
- Apply policy in `cli.ts` after `createWorkspaceToolsWithGuards()` and before `toolRegistry.register()`

### Example config
```yaml
agents:
  defaults:
    tools:
      deny: [shell]  # deny shell for all agents by default
  list:
    - id: safe-agent
      tools:
        allow: [read_file, list_dir, get_current_time]  # read-only
    - id: power-agent
      tools:
        deny: []  # override default, allow everything
```

## Test plan
- [x] `applyToolPolicy` unit tests: allow-only, deny-only, both (deny wins), empty lists, non-matching entries
- [x] `resolveToolSettings` tests: allow/deny passthrough, agent overrides defaults, fallback to defaults
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1641 tests)
- [x] `pnpm lint` passes

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)