### PR TITLE
feat(tools): edit tool for search & replace (#188)

### DIFF
--- a/src/core/tools.test.ts
+++ b/src/core/tools.test.ts
@@ -12,6 +12,7 @@ import {
   createShellTool,
   createReadFileTool,
   createWriteFileTool,
+  createEditFileTool,
   createListDirTool,
   createWorkspaceTools,
   createWorkspaceToolsWithGuards,
@@ -342,6 +343,124 @@ describe("Built-in tools", () => {
     });
   });
 
+  describe("createEditFileTool", () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "edit-test-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("replaces matching text", async () => {
+      const testFile = path.join(tempDir, "test.txt");
+      await fs.writeFile(testFile, "hello world");
+
+      const { handler } = createEditFileTool({ basePath: tempDir });
+      const result = await handler({ path: "test.txt", old_text: "hello", new_text: "goodbye" });
+
+      const parsed = JSON.parse(result);
+      expect(parsed).toEqual({ success: true, matches: 1 });
+      const content = await fs.readFile(testFile, "utf-8");
+      expect(content).toBe("goodbye world");
+    });
+
+    it("returns error for missing file", async () => {
+      const { handler } = createEditFileTool({ basePath: tempDir });
+      const result = await handler({ path: "nonexistent.txt", old_text: "hello", new_text: "goodbye" });
+
+      expect(result).toContain("[error]");
+      expect(result).toContain("not found");
+    });
+
+    it("returns error when old_text is not found", async () => {
+      const testFile = path.join(tempDir, "test.txt");
+      await fs.writeFile(testFile, "hello world");
+
+      const { handler } = createEditFileTool({ basePath: tempDir });
+      const result = await handler({ path: "test.txt", old_text: "missing", new_text: "replaced" });
+
+      expect(result).toContain("[error]");
+      expect(result).toContain("old_text not found");
+    });
+
+    it("returns error when old_text is found multiple times without expected_count", async () => {
+      const testFile = path.join(tempDir, "test.txt");
+      await fs.writeFile(testFile, "aaa bbb aaa");
+
+      const { handler } = createEditFileTool({ basePath: tempDir });
+      const result = await handler({ path: "test.txt", old_text: "aaa", new_text: "ccc" });
+
+      expect(result).toContain("[error]");
+      expect(result).toContain("2 times");
+    });
+
+    it("replaces multiple matches when expected_count matches", async () => {
+      const testFile = path.join(tempDir, "test.txt");
+      await fs.writeFile(testFile, "aaa bbb aaa");
+
+      const { handler } = createEditFileTool({ basePath: tempDir });
+      const result = await handler({ path: "test.txt", old_text: "aaa", new_text: "ccc", expected_count: 2 });
+
+      const parsed = JSON.parse(result);
+      expect(parsed).toEqual({ success: true, matches: 2 });
+      const content = await fs.readFile(testFile, "utf-8");
+      expect(content).toBe("ccc bbb ccc");
+    });
+
+    it("returns error when expected_count does not match actual count", async () => {
+      const testFile = path.join(tempDir, "test.txt");
+      await fs.writeFile(testFile, "aaa bbb aaa");
+
+      const { handler } = createEditFileTool({ basePath: tempDir });
+      const result = await handler({ path: "test.txt", old_text: "aaa", new_text: "ccc", expected_count: 3 });
+
+      expect(result).toContain("[error]");
+      expect(result).toContain("Expected 3 matches but found 2");
+    });
+
+    it("returns error when old_text is empty", async () => {
+      const testFile = path.join(tempDir, "test.txt");
+      await fs.writeFile(testFile, "hello world");
+
+      const { handler } = createEditFileTool({ basePath: tempDir });
+      const result = await handler({ path: "test.txt", old_text: "", new_text: "replaced" });
+
+      expect(result).toContain("[error]");
+      expect(result).toContain("must not be empty");
+    });
+
+    it("returns success when old_text equals new_text", async () => {
+      const testFile = path.join(tempDir, "test.txt");
+      await fs.writeFile(testFile, "hello world");
+
+      const { handler } = createEditFileTool({ basePath: tempDir });
+      const result = await handler({ path: "test.txt", old_text: "hello", new_text: "hello" });
+
+      const parsed = JSON.parse(result);
+      expect(parsed).toEqual({ success: true, matches: 1 });
+      const content = await fs.readFile(testFile, "utf-8");
+      expect(content).toBe("hello world");
+    });
+
+    it("rejects edits that escape the workspace", async () => {
+      const outsideFile = path.join(os.tmpdir(), `outside-edit-${Date.now()}.txt`);
+      await fs.writeFile(outsideFile, "secret data");
+
+      try {
+        const { handler } = createEditFileTool({ basePath: tempDir });
+        const result = await handler({ path: outsideFile, old_text: "secret", new_text: "public" });
+
+        expect(result).toContain("[error]");
+        expect(result).toContain("Path escapes workspace");
+      } finally {
+        await fs.rm(outsideFile, { force: true });
+      }
+    });
+  });
+
   describe("createListDirTool", () => {
     let tempDir: string;
 
@@ -389,6 +508,7 @@ describe("Built-in tools", () => {
       const names = tools.map((t) => t.tool.name);
       expect(names).toContain("read_file");
       expect(names).toContain("write_file");
+      expect(names).toContain("edit");
       expect(names).toContain("list_dir");
       expect(names).toContain("get_current_time");
       expect(names).not.toContain("shell");

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -590,6 +590,87 @@ export function createListDirTool(options: FileToolOptions = {}): { tool: Tool; 
     },
   };
 }
+/**
+ * Create a file edit tool (search & replace).
+ */
+export function createEditFileTool(options: FileToolOptions = {}): { tool: Tool; handler: ToolHandler } {
+  const { basePath, constrainToWorkspace = true, allowedWorkspaces = [] } = options;
+  return {
+    tool: {
+      name: "edit",
+      description:
+        "Edit a file by replacing exact text matches. Safer than rewriting the entire file — only the matched portions are modified. By default old_text must appear exactly once; use expected_count to allow replacing a specific number of occurrences.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Path to the file to edit (relative to workspace or absolute)",
+          },
+          old_text: {
+            type: "string",
+            description: "Exact text to search for in the file",
+          },
+          new_text: {
+            type: "string",
+            description: "Replacement text",
+          },
+          expected_count: {
+            type: "number",
+            description: "Expected number of matches. If provided, the actual match count must equal this value or the edit is rejected. If omitted, old_text must appear exactly once.",
+          },
+        },
+        required: ["path", "old_text", "new_text"],
+      },
+    },
+    handler: async (args) => {
+      const { path: filePath, old_text, new_text, expected_count } = args as {
+        path: string;
+        old_text: string;
+        new_text: string;
+        expected_count?: number;
+      };
+      try {
+        if (!old_text) {
+          return "[error] old_text must not be empty";
+        }
+        const resolvedPath = await resolveWorkspaceConstrainedPath(filePath, basePath, "write", constrainToWorkspace, allowedWorkspaces);
+        const content = await fs.readFile(resolvedPath, "utf-8");
+        // Count occurrences
+        let matches = 0;
+        let searchFrom = 0;
+        while (true) {
+          const idx = content.indexOf(old_text, searchFrom);
+          if (idx === -1) break;
+          matches++;
+          searchFrom = idx + old_text.length;
+        }
+        if (matches === 0) {
+          return `[error] old_text not found in ${filePath}`;
+        }
+        if (expected_count !== undefined) {
+          if (matches !== expected_count) {
+            return `[error] Expected ${expected_count} matches but found ${matches} in ${filePath}`;
+          }
+        } else if (matches > 1) {
+          return `[error] old_text found ${matches} times in ${filePath} — provide expected_count to replace multiple occurrences, or be more specific`;
+        }
+        if (old_text === new_text) {
+          return JSON.stringify({ success: true, matches });
+        }
+        const updated = content.split(old_text).join(new_text);
+        await fs.writeFile(resolvedPath, updated, "utf-8");
+        return JSON.stringify({ success: true, matches });
+      } catch (error) {
+        const err = error as { code?: string; message?: string };
+        if (err.code === "ENOENT") {
+          return `[error] File not found: ${filePath}`;
+        }
+        return `[error] ${err.message || String(error)}`;
+      }
+    },
+  };
+}
 export function buildToolGuardPrompt(
   tools: Tool[],
   guards: ResolvedToolGuards,
@@ -678,6 +759,7 @@ export function createWorkspaceToolsWithGuards(
   const tools = [
     createReadFileTool({ basePath: fileBasePath, constrainToWorkspace, allowedWorkspaces }),
     createWriteFileTool({ basePath: fileBasePath, constrainToWorkspace, allowedWorkspaces }),
+    createEditFileTool({ basePath: fileBasePath, constrainToWorkspace, allowedWorkspaces }),
     createListDirTool({ basePath: fileBasePath, constrainToWorkspace, allowedWorkspaces }),
     createTimeTool(),
   ];


### PR DESCRIPTION
## Summary
- Add `edit` tool (`createEditFileTool`) for targeted file editing via search & replace
- Supports single-match replacement by default, with optional `expected_count` parameter for controlled multi-match replacement
- Returns JSON `{ success, matches }` on success; `[error] ...` on failure
- Respects workspace constraints via `resolveWorkspaceConstrainedPath()` (same as `read_file`/`write_file`)
- Registered in `createWorkspaceToolsWithGuards()` alongside existing file tools

## Test plan
- [x] Replaces matching text and verifies file content
- [x] Returns error for missing file (ENOENT)
- [x] Returns error when old_text is not found
- [x] Returns error when old_text is found multiple times (no expected_count)
- [x] Replaces multiple matches when expected_count matches actual count
- [x] Returns error when expected_count doesn't match actual count
- [x] Returns error when old_text is empty
- [x] Returns success (no-op) when old_text equals new_text
- [x] Rejects edits that escape the workspace
- [x] Included in standard workspace tools set

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)