### PR TITLE
feat(tools): exec + process tools (#189)

### DIFF
--- a/src/tools/exec.test.ts
+++ b/src/tools/exec.test.ts
@@ -1,0 +1,326 @@
+// src/tools/exec.test.ts — Tests for exec + process tools
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../core/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  ProcessRegistry,
+  createExecTool,
+  createProcessListTool,
+  createProcessKillTool,
+  createExecTools,
+} from "./exec.js";
+
+// ---------------------------------------------------------------------------
+// ProcessRegistry
+// ---------------------------------------------------------------------------
+
+describe("ProcessRegistry", () => {
+  let registry: ProcessRegistry;
+
+  beforeEach(() => {
+    registry = new ProcessRegistry();
+  });
+
+  afterEach(() => {
+    registry.clear();
+  });
+
+  it("spawns a process and assigns an id", () => {
+    const info = registry.spawn("echo hello", process.cwd());
+    expect(info.process_id).toBe("proc_1");
+    expect(info.command).toBe("echo hello");
+    expect(info.status).toBe("running");
+    expect(info.start_time).toBeDefined();
+  });
+
+  it("assigns incrementing ids", () => {
+    const a = registry.spawn("echo a", process.cwd());
+    const b = registry.spawn("echo b", process.cwd());
+    expect(a.process_id).toBe("proc_1");
+    expect(b.process_id).toBe("proc_2");
+  });
+
+  it("lists all processes", () => {
+    registry.spawn("echo a", process.cwd());
+    registry.spawn("echo b", process.cwd());
+    expect(registry.list()).toHaveLength(2);
+  });
+
+  it("gets process by id", () => {
+    const info = registry.spawn("echo test", process.cwd());
+    expect(registry.get(info.process_id)).toBe(info);
+    expect(registry.get("nonexistent")).toBeUndefined();
+  });
+
+  it("kills a running process", () => {
+    const info = registry.spawn("sleep 60", process.cwd());
+    expect(registry.kill(info.process_id)).toBe(true);
+    expect(info.status).toBe("exited");
+  });
+
+  it("returns false when killing a nonexistent process", () => {
+    expect(registry.kill("proc_999")).toBe(false);
+  });
+
+  it("clears all processes", () => {
+    registry.spawn("echo a", process.cwd());
+    registry.spawn("echo b", process.cwd());
+    registry.clear();
+    expect(registry.list()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exec tool — foreground
+// ---------------------------------------------------------------------------
+
+describe("exec tool", () => {
+  let registry: ProcessRegistry;
+
+  beforeEach(() => {
+    registry = new ProcessRegistry();
+  });
+
+  afterEach(() => {
+    registry.clear();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createExecTool({ registry });
+    expect(tool.name).toBe("exec");
+    expect(tool.parameters.required).toContain("command");
+  });
+
+  it("executes a basic command", async () => {
+    const { handler } = createExecTool({ registry });
+    const result = JSON.parse(await handler({ command: "echo hello" }));
+    expect(result.stdout.trim()).toBe("hello");
+    expect(result.exit_code).toBe(0);
+  });
+
+  it("captures stderr", async () => {
+    const { handler } = createExecTool({ registry });
+    const result = JSON.parse(
+      await handler({ command: "echo err >&2" }),
+    );
+    expect(result.stderr.trim()).toBe("err");
+    expect(result.exit_code).toBe(0);
+  });
+
+  it("returns non-zero exit code on failure", async () => {
+    const { handler } = createExecTool({ registry });
+    const result = JSON.parse(await handler({ command: "exit 42" }));
+    expect(result.exit_code).not.toBe(0);
+  });
+
+  it("returns error for empty command", async () => {
+    const { handler } = createExecTool({ registry });
+    const result = JSON.parse(await handler({ command: "" }));
+    expect(result.error).toContain("must not be empty");
+  });
+
+  it("times out with custom timeout", async () => {
+    const { handler } = createExecTool({ registry });
+    const result = JSON.parse(
+      await handler({ command: "sleep 10", timeout: 1 }),
+    );
+    expect(result.error).toContain("timed out");
+    expect(result.exit_code).toBe(124);
+  }, 10_000);
+
+  it("clamps timeout to max 300s", async () => {
+    // We can't easily test the actual clamping without waiting, but we can
+    // verify the tool doesn't reject large values
+    const { tool } = createExecTool({ registry });
+    expect(tool.parameters.properties).toHaveProperty("timeout");
+  });
+
+  // ---------------------------------------------------------------------------
+  // exec tool — background
+  // ---------------------------------------------------------------------------
+
+  it("runs a command in background mode", async () => {
+    const { handler } = createExecTool({ registry });
+    const result = JSON.parse(
+      await handler({ command: "sleep 60", background: true }),
+    );
+
+    expect(result.process_id).toBe("proc_1");
+    expect(result.status).toBe("running");
+    expect(result.command).toBe("sleep 60");
+    expect(result.start_time).toBeDefined();
+  });
+
+  it("background process appears in registry", async () => {
+    const { handler } = createExecTool({ registry });
+    await handler({ command: "sleep 60", background: true });
+    expect(registry.list()).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// process_list tool
+// ---------------------------------------------------------------------------
+
+describe("process_list tool", () => {
+  let registry: ProcessRegistry;
+
+  beforeEach(() => {
+    registry = new ProcessRegistry();
+  });
+
+  afterEach(() => {
+    registry.clear();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createProcessListTool(registry);
+    expect(tool.name).toBe("process_list");
+  });
+
+  it("returns empty list when no processes", async () => {
+    const { handler } = createProcessListTool(registry);
+    const result = JSON.parse(await handler({}));
+    expect(result.processes).toEqual([]);
+  });
+
+  it("lists running and exited processes", async () => {
+    registry.spawn("sleep 60", process.cwd());
+    const shortProc = registry.spawn("echo done", process.cwd());
+
+    // Wait a bit for the echo to finish
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const { handler } = createProcessListTool(registry);
+    const result = JSON.parse(await handler({}));
+
+    expect(result.processes).toHaveLength(2);
+
+    const running = result.processes.find(
+      (p: { status: string }) => p.status === "running",
+    );
+    const exited = result.processes.find(
+      (p: { process_id: string }) => p.process_id === shortProc.process_id,
+    );
+
+    expect(running).toBeDefined();
+    expect(exited).toBeDefined();
+    expect(exited.status).toBe("exited");
+    expect(exited.exit_code).toBe(0);
+  });
+
+  it("does not expose internal _proc field", async () => {
+    registry.spawn("echo hello", process.cwd());
+    const { handler } = createProcessListTool(registry);
+    const result = JSON.parse(await handler({}));
+    expect(result.processes[0]._proc).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// process_kill tool
+// ---------------------------------------------------------------------------
+
+describe("process_kill tool", () => {
+  let registry: ProcessRegistry;
+
+  beforeEach(() => {
+    registry = new ProcessRegistry();
+  });
+
+  afterEach(() => {
+    registry.clear();
+  });
+
+  it("returns tool with correct schema", () => {
+    const { tool } = createProcessKillTool(registry);
+    expect(tool.name).toBe("process_kill");
+    expect(tool.parameters.required).toContain("process_id");
+  });
+
+  it("kills a running process", async () => {
+    const info = registry.spawn("sleep 60", process.cwd());
+    const { handler } = createProcessKillTool(registry);
+    const result = JSON.parse(
+      await handler({ process_id: info.process_id }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.process_id).toBe(info.process_id);
+    expect(result.was_running).toBe(true);
+  });
+
+  it("handles killing an already exited process", async () => {
+    const info = registry.spawn("echo fast", process.cwd());
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const { handler } = createProcessKillTool(registry);
+    const result = JSON.parse(
+      await handler({ process_id: info.process_id }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.was_running).toBe(false);
+  });
+
+  it("returns error for unknown process_id", async () => {
+    const { handler } = createProcessKillTool(registry);
+    const result = JSON.parse(
+      await handler({ process_id: "proc_999" }),
+    );
+    expect(result.error).toContain("Process not found");
+  });
+
+  it("returns error when process_id is missing", async () => {
+    const { handler } = createProcessKillTool(registry);
+    const result = JSON.parse(await handler({}));
+    expect(result.error).toContain("process_id is required");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createExecTools factory
+// ---------------------------------------------------------------------------
+
+describe("createExecTools", () => {
+  it("returns all three tools", () => {
+    const tools = createExecTools();
+    const names = tools.map((t) => t.tool.name);
+    expect(names).toContain("exec");
+    expect(names).toContain("process_list");
+    expect(names).toContain("process_kill");
+    expect(tools).toHaveLength(3);
+  });
+
+  it("shares registry across tools", async () => {
+    const tools = createExecTools();
+    const execHandler = tools.find((t) => t.tool.name === "exec")!.handler;
+    const listHandler = tools.find((t) => t.tool.name === "process_list")!.handler;
+    const killHandler = tools.find((t) => t.tool.name === "process_kill")!.handler;
+
+    // Start a background process
+    const execResult = JSON.parse(
+      await execHandler({ command: "sleep 60", background: true }),
+    );
+
+    // List should show it
+    const listResult = JSON.parse(await listHandler({}));
+    expect(listResult.processes).toHaveLength(1);
+    expect(listResult.processes[0].process_id).toBe(execResult.process_id);
+
+    // Kill it
+    const killResult = JSON.parse(
+      await killHandler({ process_id: execResult.process_id }),
+    );
+    expect(killResult.success).toBe(true);
+  });
+});

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -1,0 +1,395 @@
+// src/tools/exec.ts — Shell execution and background process management tools
+// Provides exec (with background mode), process_list, and process_kill tools.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { createLogger } from "../core/logger.js";
+import type { Tool } from "../core/types.js";
+import type { ToolHandler } from "../core/tools.js";
+
+const execAsync = promisify(exec);
+const log = createLogger("tools:exec");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default timeout for foreground exec in seconds. */
+const DEFAULT_TIMEOUT_SEC = 30;
+
+/** Maximum allowed timeout in milliseconds. */
+const MAX_TIMEOUT_MS = 300_000;
+
+/** Maximum output size in bytes (100 KB). */
+const MAX_OUTPUT_BYTES = 100 * 1024;
+
+// ---------------------------------------------------------------------------
+// ProcessRegistry — tracks background processes
+// ---------------------------------------------------------------------------
+
+export interface ProcessInfo {
+  process_id: string;
+  command: string;
+  status: "running" | "exited";
+  start_time: string;
+  exit_code: number | null;
+  stdout: string;
+  stderr: string;
+  /** Internal reference to the child process (not serialised). */
+  _proc: ChildProcess;
+}
+
+/**
+ * ProcessRegistry — singleton that tracks background processes spawned by
+ * the exec tool. Each agent workspace gets its own registry instance.
+ */
+export class ProcessRegistry {
+  private processes = new Map<string, ProcessInfo>();
+  private nextId = 1;
+
+  /** Spawn a background process and register it. */
+  spawn(command: string, cwd: string): ProcessInfo {
+    const id = `proc_${this.nextId++}`;
+
+    const child = spawn("sh", ["-c", command], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: false,
+    });
+
+    const info: ProcessInfo = {
+      process_id: id,
+      command,
+      status: "running",
+      start_time: new Date().toISOString(),
+      exit_code: null,
+      stdout: "",
+      stderr: "",
+      _proc: child,
+    };
+
+    // Capture output (truncated to MAX_OUTPUT_BYTES)
+    child.stdout?.on("data", (chunk: Buffer) => {
+      if (info.stdout.length < MAX_OUTPUT_BYTES) {
+        info.stdout += chunk.toString().slice(0, MAX_OUTPUT_BYTES - info.stdout.length);
+      }
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      if (info.stderr.length < MAX_OUTPUT_BYTES) {
+        info.stderr += chunk.toString().slice(0, MAX_OUTPUT_BYTES - info.stderr.length);
+      }
+    });
+
+    child.on("exit", (code) => {
+      info.status = "exited";
+      info.exit_code = code ?? 1;
+    });
+
+    child.on("error", (err) => {
+      info.status = "exited";
+      info.exit_code = 1;
+      info.stderr += `\n[spawn error] ${err.message}`;
+    });
+
+    this.processes.set(id, info);
+    return info;
+  }
+
+  /** Get a process by ID. */
+  get(id: string): ProcessInfo | undefined {
+    return this.processes.get(id);
+  }
+
+  /** List all tracked processes. */
+  list(): ProcessInfo[] {
+    return Array.from(this.processes.values());
+  }
+
+  /** Kill a process by ID. Returns true if killed, false if not found. */
+  kill(id: string): boolean {
+    const info = this.processes.get(id);
+    if (!info) return false;
+
+    if (info.status === "running") {
+      try {
+        info._proc.kill("SIGTERM");
+      } catch {
+        // Process may have already exited between status check and kill
+      }
+      info.status = "exited";
+      info.exit_code = info.exit_code ?? 137;
+    }
+
+    return true;
+  }
+
+  /** Clear all processes (for testing). */
+  clear(): void {
+    for (const info of this.processes.values()) {
+      if (info.status === "running") {
+        try {
+          info._proc.kill("SIGTERM");
+        } catch {
+          // ignore
+        }
+      }
+    }
+    this.processes.clear();
+    this.nextId = 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// exec tool
+// ---------------------------------------------------------------------------
+
+export interface ExecToolOptions {
+  /** Working directory for command execution. */
+  cwd?: string;
+  /** ProcessRegistry instance for background process tracking. */
+  registry?: ProcessRegistry;
+}
+
+/**
+ * Create the `exec` tool.
+ *
+ * Execute shell commands with configurable timeout.
+ * Supports `background: true` for long-running processes.
+ */
+export function createExecTool(
+  options: ExecToolOptions = {},
+): { tool: Tool; handler: ToolHandler } {
+  const { cwd = process.cwd() } = options;
+  const registry = options.registry ?? new ProcessRegistry();
+
+  return {
+    tool: {
+      name: "exec",
+      description:
+        "Execute a shell command. Returns stdout, stderr, and exit_code. " +
+        "Set background=true for long-running processes (returns immediately with process_id). " +
+        "Default timeout: 30s, max: 300s.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: {
+            type: "string",
+            description: "The shell command to execute",
+          },
+          timeout: {
+            type: "number",
+            description:
+              "Timeout in seconds (default 30, max 300). Ignored for background processes.",
+          },
+          background: {
+            type: "boolean",
+            description:
+              "If true, run the command in the background and return a process_id immediately.",
+          },
+        },
+        required: ["command"],
+      },
+    },
+    handler: async (args) => {
+      const {
+        command,
+        timeout: timeoutSec,
+        background,
+      } = args as {
+        command: string;
+        timeout?: number;
+        background?: boolean;
+      };
+
+      if (!command || command.trim().length === 0) {
+        return JSON.stringify({ error: "Command must not be empty" });
+      }
+
+      // Background mode — spawn and return immediately
+      if (background) {
+        const info = registry.spawn(command, cwd);
+
+        log.info("Background process started", {
+          processId: info.process_id,
+          command,
+          cwd,
+        });
+
+        return JSON.stringify({
+          process_id: info.process_id,
+          command: info.command,
+          status: "running",
+          start_time: info.start_time,
+        });
+      }
+
+      // Foreground mode — run with timeout
+      const timeoutMs = Math.min(
+        Math.max((timeoutSec ?? DEFAULT_TIMEOUT_SEC) * 1000, 1000),
+        MAX_TIMEOUT_MS,
+      );
+
+      try {
+        const { stdout, stderr } = await execAsync(command, {
+          cwd,
+          timeout: timeoutMs,
+          maxBuffer: MAX_OUTPUT_BYTES,
+        });
+
+        log.info("Command executed", { command, cwd, exitCode: 0 });
+
+        return JSON.stringify({
+          stdout: stdout || "",
+          stderr: stderr || "",
+          exit_code: 0,
+        });
+      } catch (error) {
+        const err = error as {
+          message?: string;
+          code?: number;
+          signal?: string;
+          stdout?: string;
+          stderr?: string;
+        };
+
+        if (err.signal === "SIGTERM") {
+          log.warn("Command timed out", { command, timeoutMs });
+          return JSON.stringify({
+            stdout: err.stdout || "",
+            stderr: err.stderr || "",
+            exit_code: 124,
+            error: `Command timed out after ${timeoutMs / 1000}s`,
+          });
+        }
+
+        const exitCode = typeof err.code === "number" ? err.code : 1;
+        log.info("Command failed", { command, exitCode });
+
+        return JSON.stringify({
+          stdout: err.stdout || "",
+          stderr: err.stderr || "",
+          exit_code: exitCode,
+        });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// process_list tool
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `process_list` tool.
+ *
+ * Lists all background processes started by the agent.
+ */
+export function createProcessListTool(
+  registry: ProcessRegistry,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "process_list",
+      description:
+        "List all background processes started by the agent. " +
+        "Shows process_id, command, status, start_time, and exit_code.",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+    },
+    handler: async () => {
+      const processes = registry.list().map((p) => ({
+        process_id: p.process_id,
+        command: p.command,
+        status: p.status,
+        start_time: p.start_time,
+        exit_code: p.exit_code,
+      }));
+
+      log.info("Process list requested", { count: processes.length });
+
+      return JSON.stringify({ processes });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// process_kill tool
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `process_kill` tool.
+ *
+ * Kills a background process by process_id.
+ */
+export function createProcessKillTool(
+  registry: ProcessRegistry,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "process_kill",
+      description:
+        "Kill a background process by its process_id. " +
+        "Returns success or error if the process is not found.",
+      parameters: {
+        type: "object",
+        properties: {
+          process_id: {
+            type: "string",
+            description: "The process_id returned by exec with background=true",
+          },
+        },
+        required: ["process_id"],
+      },
+    },
+    handler: async (args) => {
+      const { process_id } = args as { process_id: string };
+
+      if (!process_id) {
+        return JSON.stringify({ error: "process_id is required" });
+      }
+
+      const info = registry.get(process_id);
+      if (!info) {
+        return JSON.stringify({ error: `Process not found: ${process_id}` });
+      }
+
+      const wasRunning = info.status === "running";
+      registry.kill(process_id);
+
+      log.info("Process killed", {
+        processId: process_id,
+        wasRunning,
+      });
+
+      return JSON.stringify({
+        success: true,
+        process_id,
+        was_running: wasRunning,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create all exec/process tools with a shared ProcessRegistry.
+ * Returns an array of tool+handler pairs ready for registration.
+ */
+export function createExecTools(
+  options: ExecToolOptions = {},
+): { tool: Tool; handler: ToolHandler }[] {
+  const registry = options.registry ?? new ProcessRegistry();
+  const execOptions = { ...options, registry };
+
+  return [
+    createExecTool(execOptions),
+    createProcessListTool(registry),
+    createProcessKillTool(registry),
+  ];
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -80,3 +80,12 @@ export {
   createSessionTools,
 } from "./sessions.js";
 export type { SessionsToolContext } from "./sessions.js";
+
+export {
+  ProcessRegistry,
+  createExecTool,
+  createProcessListTool,
+  createProcessKillTool,
+  createExecTools,
+} from "./exec.js";
+export type { ExecToolOptions, ProcessInfo } from "./exec.js";


### PR DESCRIPTION
Implements #189

- `exec`: shell command execution with configurable timeout (default 30s, max 300s) and background mode
- `process_list`: list all background processes with status, start time, exit code
- `process_kill`: terminate a background process by process_id
- `ProcessRegistry` singleton for background process lifecycle management
- Comprehensive tests (27 tests covering foreground/background exec, timeout, process lifecycle, shared registry)