### PR TITLE
feat(transport): NO_REPLY/HEARTBEAT_OK silent reply (#212)

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -7,6 +7,7 @@ import { addRoute } from "./routes.js";
 import { sendJson, sendError } from "./middleware.js";
 import { createLogger } from "../core/logger.js";
 import { textContent } from "../core/types.js";
+import { isSilentReply } from "../transports/silent-reply.js";
 
 const log = createLogger("api:chat");
 
@@ -94,6 +95,13 @@ addRoute("POST", "/api/chat/message", async (req, res, deps) => {
       content: textContent(responseText),
       timestamp: Date.now(),
     });
+  }
+
+  // Suppress silent replies — log internally but don't return content to client
+  if (isSilentReply(responseText)) {
+    log.info(`Silent reply detected (${responseText.trim()}), suppressing WebChat response`);
+    sendJson(res, 200, { sessionId, reply: null, silent: true });
+    return;
   }
 
   if (errorMessage) {
@@ -198,6 +206,12 @@ addRoute("POST", "/api/chat/stream", async (req, res, deps) => {
       content: textContent(responseText),
       timestamp: Date.now(),
     });
+  }
+
+  // Signal silent reply to the client so the UI can suppress display
+  if (isSilentReply(responseText)) {
+    log.info(`Silent reply detected (${responseText.trim()}), signaling SSE client`);
+    writeSseEvent(res, JSON.stringify({ silent: true }));
   }
 
   // Signal stream end

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -26,6 +26,7 @@ import { shouldRespondToMessage } from "../core/mention.js";
 import { loggers } from "../core/logger.js";
 import { ThreadBindingManager } from "../core/thread-bindings.js";
 import { runAgentLoop } from "../core/agent-runner.js";
+import { isSilentReply } from "./silent-reply.js";
 import type { UsageTracker } from "../core/usage-tracker.js";
 import { buildSessionKey } from "../core/session-keys.js";
 import {
@@ -570,18 +571,28 @@ export class DiscordTransport implements Transport {
 
       // Run with or without subagent context based on config
       let errorMessage: string | null;
+      let responseText: string;
 
       if (this.config.enableSubagentStreaming !== false) {
         // Run with subagent Discord context enabled
         const subagentContext = this.createSubagentContext(channel);
         const result = await runWithSubagentContextAsync(subagentContext, runLoop);
-        
+
         errorMessage = result.errorMessage;
+        responseText = result.responseText;
       } else {
         // Run without subagent context (original behavior)
         const result = await runLoop();
-        
+
         errorMessage = result.errorMessage;
+        responseText = result.responseText;
+      }
+
+      // Check for silent reply tokens — suppress outbound delivery
+      if (isSilentReply(responseText)) {
+        log.info(`Silent reply detected (${responseText.trim()}), suppressing Discord send`);
+        typing.stop();
+        return;
       }
 
       // Flush any remaining content in the buffer

--- a/src/transports/feishu.ts
+++ b/src/transports/feishu.ts
@@ -17,6 +17,7 @@ import type { ContextConfigFile } from "../core/config.js";
 import { resolveBinding } from "../core/bindings.js";
 import { loggers } from "../core/logger.js";
 import { runAgentLoop } from "../core/agent-runner.js";
+import { isSilentReply } from "./silent-reply.js";
 import type { UsageTracker } from "../core/usage-tracker.js";
 import { buildSessionKey, type SessionScope } from "../core/session-keys.js";
 import { preparePromptMessages } from "../core/context.js";
@@ -468,6 +469,12 @@ export class FeishuTransport implements Transport {
         log,
         usageTracker: this.config.usageTracker,
       });
+
+      // Check for silent reply tokens — suppress outbound delivery
+      if (isSilentReply(responseText)) {
+        log.info(`Silent reply detected (${responseText.trim()}), suppressing Feishu send`);
+        return;
+      }
 
       // Send reply to Feishu
       const replyText = errorMessage ? `Error: ${errorMessage}` : responseText;

--- a/src/transports/silent-reply.test.ts
+++ b/src/transports/silent-reply.test.ts
@@ -1,0 +1,56 @@
+// src/transports/silent-reply.test.ts — Tests for silent reply token detection
+
+import { describe, it, expect } from "vitest";
+import { isSilentReply, SILENT_REPLY_TOKENS } from "./silent-reply.js";
+
+describe("isSilentReply", () => {
+  // ---- Positive cases ----
+
+  it("detects [NO_REPLY] as silent", () => {
+    expect(isSilentReply("[NO_REPLY]")).toBe(true);
+  });
+
+  it("detects [HEARTBEAT_OK] as silent", () => {
+    expect(isSilentReply("[HEARTBEAT_OK]")).toBe(true);
+  });
+
+  it("detects [NO_REPLY] with leading/trailing whitespace", () => {
+    expect(isSilentReply("  [NO_REPLY]  ")).toBe(true);
+  });
+
+  it("detects [HEARTBEAT_OK] with newlines", () => {
+    expect(isSilentReply("\n[HEARTBEAT_OK]\n")).toBe(true);
+  });
+
+  // ---- Negative cases ----
+
+  it("rejects normal text", () => {
+    expect(isSilentReply("Hello, how can I help?")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isSilentReply("")).toBe(false);
+  });
+
+  it("rejects token embedded in other text", () => {
+    expect(isSilentReply("Sure, [NO_REPLY] is the token")).toBe(false);
+  });
+
+  it("rejects partial token match", () => {
+    expect(isSilentReply("[NO_REPLY")).toBe(false);
+  });
+
+  it("rejects case-insensitive variant (must be exact)", () => {
+    expect(isSilentReply("[no_reply]")).toBe(false);
+  });
+
+  it("rejects similar-looking but different token", () => {
+    expect(isSilentReply("[HEARTBEAT_FAIL]")).toBe(false);
+  });
+});
+
+describe("SILENT_REPLY_TOKENS", () => {
+  it("contains exactly the expected tokens", () => {
+    expect(SILENT_REPLY_TOKENS).toEqual(["[NO_REPLY]", "[HEARTBEAT_OK]"]);
+  });
+});

--- a/src/transports/silent-reply.ts
+++ b/src/transports/silent-reply.ts
@@ -1,0 +1,21 @@
+// src/transports/silent-reply.ts — Silent reply token detection
+// Agents can return these tokens to suppress outbound messages while still
+// logging internally. Used for heartbeat checks and explicit "no reply" signals.
+
+/** Tokens that suppress outbound delivery when returned by an agent. */
+export const SILENT_REPLY_TOKENS = ["[NO_REPLY]", "[HEARTBEAT_OK]"] as const;
+
+export type SilentReplyToken = (typeof SILENT_REPLY_TOKENS)[number];
+
+/**
+ * Check whether the agent's full response text is a silent reply.
+ *
+ * A response is considered silent when its trimmed content exactly matches
+ * one of the known tokens. If the agent returns additional text alongside
+ * a token, the response is treated as a normal reply — the token must be
+ * the *entire* response.
+ */
+export function isSilentReply(content: string): boolean {
+  const trimmed = content.trim();
+  return (SILENT_REPLY_TOKENS as readonly string[]).includes(trimmed);
+}


### PR DESCRIPTION
## Summary
- Add `[NO_REPLY]` and `[HEARTBEAT_OK]` silent reply token detection across all transport/API layers
- When an agent returns one of these tokens as its entire response, outbound delivery is suppressed (Discord, Feishu, WebChat) while the response is still stored in the session and logged internally
- New `src/transports/silent-reply.ts` module with `isSilentReply()` helper and `SILENT_REPLY_TOKENS` constant

## Changes
- `src/transports/silent-reply.ts` — New module defining silent reply tokens and detection
- `src/transports/discord.ts` — Check for silent reply after agent loop, skip `channel.send()` and stop typing indicator
- `src/transports/feishu.ts` — Check for silent reply after agent loop, skip `sendTextMessage()`
- `src/api/chat.ts` — Sync endpoint returns `{ silent: true, reply: null }`; SSE endpoint emits `{ silent: true }` event

## Test plan
- [x] 11 unit tests covering positive cases (both tokens, whitespace/newline trimming) and negative cases (normal text, empty string, embedded token, partial match, case sensitivity, wrong token)
- [x] Lint passes
- [x] Typecheck passes
- [x] Full test suite passes (1688 tests)

Closes #212