### PR TITLE
feat(commands): add slash commands (#192)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -484,6 +484,7 @@ async function main() {
           allowBots: config.discord.allowBots,
           context: config.discord.context,
           usageTracker,
+          adminUsers: config.discord.adminUsers,
         },
       });
 

--- a/src/commands/slash-commands.test.ts
+++ b/src/commands/slash-commands.test.ts
@@ -1,0 +1,248 @@
+// src/commands/slash-commands.test.ts — Tests for slash command handler
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SlashCommandHandler, type CommandContext } from "./slash-commands.js";
+import { createMockAgentManager, createMockSessionStore } from "../core/test-helpers.js";
+
+function createContext(overrides?: Partial<CommandContext>): CommandContext {
+  return {
+    agentManager: createMockAgentManager(),
+    sessionStore: createMockSessionStore(),
+    agentId: "agent-1",
+    userId: "admin-123",
+    username: "admin",
+    ...overrides,
+  };
+}
+
+describe("SlashCommandHandler", () => {
+  let handler: SlashCommandHandler;
+
+  beforeEach(() => {
+    handler = new SlashCommandHandler(["admin-123"]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Parsing
+  // -----------------------------------------------------------------------
+
+  describe("parse", () => {
+    it("parses /command", () => {
+      expect(handler.parse("/status")).toEqual({ name: "status", args: "" });
+    });
+
+    it("parses !command", () => {
+      expect(handler.parse("!reload")).toEqual({ name: "reload", args: "" });
+    });
+
+    it("parses command with args", () => {
+      expect(handler.parse("/model claude-sonnet-4")).toEqual({
+        name: "model",
+        args: "claude-sonnet-4",
+      });
+    });
+
+    it("normalizes command name to lowercase", () => {
+      expect(handler.parse("/STATUS")).toEqual({ name: "status", args: "" });
+    });
+
+    it("trims whitespace", () => {
+      expect(handler.parse("  /status  ")).toEqual({ name: "status", args: "" });
+    });
+
+    it("returns null for non-commands", () => {
+      expect(handler.parse("hello")).toBeNull();
+      expect(handler.parse("")).toBeNull();
+    });
+
+    it("returns null for bare prefix", () => {
+      expect(handler.parse("/")).toBeNull();
+      expect(handler.parse("!")).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // isCommand
+  // -----------------------------------------------------------------------
+
+  describe("isCommand", () => {
+    it("returns true for known commands", () => {
+      expect(handler.isCommand("/status")).toBe(true);
+      expect(handler.isCommand("/reload")).toBe(true);
+      expect(handler.isCommand("/model gpt-4")).toBe(true);
+      expect(handler.isCommand("!status")).toBe(true);
+    });
+
+    it("returns false for unknown commands", () => {
+      expect(handler.isCommand("/unknown")).toBe(false);
+      expect(handler.isCommand("/help")).toBe(false);
+    });
+
+    it("returns false for non-commands", () => {
+      expect(handler.isCommand("hello")).toBe(false);
+      expect(handler.isCommand("")).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Admin check
+  // -----------------------------------------------------------------------
+
+  describe("admin authorization", () => {
+    it("rejects non-admin users", async () => {
+      const ctx = createContext({ userId: "non-admin-456", username: "nobody" });
+      const result = await handler.execute("/status", ctx);
+      expect(result.response).toContain("not authorized");
+    });
+
+    it("allows admin users", async () => {
+      const ctx = createContext({ userId: "admin-123" });
+      const result = await handler.execute("/status", ctx);
+      expect(result.response).toContain("Agent Status");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // /status
+  // -----------------------------------------------------------------------
+
+  describe("/status", () => {
+    it("returns uptime, model, agent, and session info", async () => {
+      const agentManager = createMockAgentManager();
+      (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
+        { id: "agent-1", systemPrompt: "", provider: { type: "anthropic", model: "claude-sonnet-4" } },
+      ]);
+
+      const sessionStore = createMockSessionStore();
+      (sessionStore.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: "s1", agentId: "agent-1", lastActiveAt: new Date() },
+        { id: "s2", agentId: "agent-1", lastActiveAt: new Date() },
+      ]);
+
+      const ctx = createContext({ agentManager, sessionStore });
+      const result = await handler.execute("/status", ctx);
+
+      expect(result.response).toContain("Agent Status");
+      expect(result.response).toContain("claude-sonnet-4");
+      expect(result.response).toContain("agent-1");
+      expect(result.response).toContain("Active sessions: 2");
+    });
+
+    it("shows default model when no provider configured", async () => {
+      const agentManager = createMockAgentManager();
+      (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
+        { id: "agent-1", systemPrompt: "" },
+      ]);
+
+      const ctx = createContext({ agentManager });
+      const result = await handler.execute("/status", ctx);
+      expect(result.response).toContain("claude-opus-4.5");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // /reload
+  // -----------------------------------------------------------------------
+
+  describe("/reload", () => {
+    it("calls reloadWorkspace and reports success", async () => {
+      const agentManager = createMockAgentManager();
+      (agentManager.reloadWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+      const ctx = createContext({ agentManager });
+      const result = await handler.execute("/reload", ctx);
+
+      expect(agentManager.reloadWorkspace).toHaveBeenCalledWith("agent-1");
+      expect(result.response).toContain("Workspace reloaded");
+    });
+
+    it("reports errors on reload failure", async () => {
+      const agentManager = createMockAgentManager();
+      (agentManager.reloadWorkspace as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("No workspace path"),
+      );
+
+      const ctx = createContext({ agentManager });
+      const result = await handler.execute("/reload", ctx);
+
+      expect(result.response).toContain("Reload failed");
+      expect(result.response).toContain("No workspace path");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // /model
+  // -----------------------------------------------------------------------
+
+  describe("/model", () => {
+    it("shows current model when no args given", async () => {
+      const agentManager = createMockAgentManager();
+      (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
+        { id: "agent-1", systemPrompt: "", provider: { type: "anthropic", model: "claude-sonnet-4" } },
+      ]);
+
+      const ctx = createContext({ agentManager });
+      const result = await handler.execute("/model", ctx);
+
+      expect(result.response).toContain("Current model");
+      expect(result.response).toContain("claude-sonnet-4");
+    });
+
+    it("switches model on agent", async () => {
+      const agentManager = createMockAgentManager();
+      (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
+        { id: "agent-1", systemPrompt: "", provider: { type: "anthropic", model: "claude-opus-4.5" } },
+      ]);
+      (agentManager.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      const ctx = createContext({ agentManager });
+      const result = await handler.execute("/model claude-sonnet-4", ctx);
+
+      expect(agentManager.update).toHaveBeenCalledWith("agent-1", {
+        provider: { type: "anthropic", model: "claude-sonnet-4" },
+      });
+      expect(result.response).toContain("Model switched");
+      expect(result.response).toContain("claude-sonnet-4");
+    });
+
+    it("reports errors on invalid model", async () => {
+      const agentManager = createMockAgentManager();
+      (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
+        { id: "agent-1", systemPrompt: "" },
+      ]);
+      (agentManager.update as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("Unknown anthropic model: fake-model"),
+      );
+
+      const ctx = createContext({ agentManager });
+      const result = await handler.execute("/model fake-model", ctx);
+
+      expect(result.response).toContain("Model switch failed");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Unknown command
+  // -----------------------------------------------------------------------
+
+  describe("unknown commands", () => {
+    it("returns unknown command response for known admin", async () => {
+      const ctx = createContext();
+      const result = await handler.execute("/foo", ctx);
+      expect(result.response).toContain("Unknown command");
+      expect(result.response).toContain("/foo");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Invalid input
+  // -----------------------------------------------------------------------
+
+  describe("invalid input", () => {
+    it("returns invalid command for unparseable input", async () => {
+      const ctx = createContext();
+      const result = await handler.execute("hello", ctx);
+      expect(result.response).toBe("Invalid command.");
+    });
+  });
+});

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -1,0 +1,192 @@
+// src/commands/slash-commands.ts — Slash command handler for admin operations
+// Parses and dispatches /status, /reload, /model commands from chat messages.
+
+import type { AgentManager, SessionStore } from "../core/types.js";
+import { createLogger } from "../core/logger.js";
+
+const log = createLogger("commands");
+
+/** Parsed slash command */
+export interface ParsedCommand {
+  name: string;
+  args: string;
+}
+
+/** Context passed to command handlers */
+export interface CommandContext {
+  agentManager: AgentManager;
+  sessionStore: SessionStore;
+  /** The agent ID this message was routed to */
+  agentId: string;
+  /** Discord user ID of the invoker */
+  userId: string;
+  /** Discord username of the invoker */
+  username: string;
+}
+
+/** Result of executing a slash command */
+export interface CommandResult {
+  /** Response text to send back */
+  response: string;
+}
+
+/**
+ * SlashCommandHandler — parses and dispatches slash commands.
+ *
+ * Commands are prefixed with `/` or `!`. Only users in the `adminUsers`
+ * list are allowed to execute commands.
+ */
+export class SlashCommandHandler {
+  private adminUsers: Set<string>;
+  private startTime: number;
+
+  constructor(adminUsers: string[] = []) {
+    this.adminUsers = new Set(adminUsers);
+    this.startTime = Date.now();
+  }
+
+  /**
+   * Check if a message is a slash command.
+   * Returns true for messages starting with `/` or `!` followed by a known command.
+   */
+  isCommand(content: string): boolean {
+    const parsed = this.parse(content);
+    if (!parsed) return false;
+    return KNOWN_COMMANDS.has(parsed.name);
+  }
+
+  /**
+   * Parse a slash command from message content.
+   * Returns null if the content is not a valid command.
+   */
+  parse(content: string): ParsedCommand | null {
+    const trimmed = content.trim();
+    if (!trimmed.startsWith("/") && !trimmed.startsWith("!")) return null;
+
+    // Strip the prefix
+    const withoutPrefix = trimmed.slice(1);
+    const spaceIdx = withoutPrefix.indexOf(" ");
+
+    const name = spaceIdx === -1
+      ? withoutPrefix.toLowerCase()
+      : withoutPrefix.slice(0, spaceIdx).toLowerCase();
+    const args = spaceIdx === -1
+      ? ""
+      : withoutPrefix.slice(spaceIdx + 1).trim();
+
+    if (!name) return null;
+    return { name, args };
+  }
+
+  /**
+   * Execute a slash command. Checks admin permissions before dispatch.
+   */
+  async execute(content: string, ctx: CommandContext): Promise<CommandResult> {
+    const parsed = this.parse(content);
+    if (!parsed) {
+      return { response: "Invalid command." };
+    }
+
+    // Admin check
+    if (!this.adminUsers.has(ctx.userId)) {
+      log.warn(`Unauthorized command attempt by ${ctx.username} (${ctx.userId}): ${parsed.name}`);
+      return { response: "⛔ You are not authorized to run commands." };
+    }
+
+    log.info(`Command /${parsed.name} from ${ctx.username} (${ctx.userId})`);
+
+    switch (parsed.name) {
+      case "status":
+        return this.handleStatus(ctx);
+      case "reload":
+        return this.handleReload(ctx);
+      case "model":
+        return this.handleModel(ctx, parsed.args);
+      default:
+        return { response: `Unknown command: /${parsed.name}` };
+    }
+  }
+
+  private async handleStatus(ctx: CommandContext): Promise<CommandResult> {
+    const uptimeMs = Date.now() - this.startTime;
+    const uptime = formatUptime(uptimeMs);
+
+    const agents = ctx.agentManager.list();
+    const sessions = await ctx.sessionStore.list();
+
+    // Find current agent's model
+    const agentConfig = agents.find((a) => a.id === ctx.agentId);
+    const model = agentConfig?.provider?.model ?? "claude-opus-4.5";
+
+    const lines = [
+      "**Agent Status**",
+      `• Uptime: ${uptime}`,
+      `• Model: \`${model}\``,
+      `• Agent: \`${ctx.agentId}\``,
+      `• Agents loaded: ${agents.length}`,
+      `• Active sessions: ${sessions.length}`,
+    ];
+
+    return { response: lines.join("\n") };
+  }
+
+  private async handleReload(ctx: CommandContext): Promise<CommandResult> {
+    try {
+      await ctx.agentManager.reloadWorkspace(ctx.agentId);
+      log.info(`Workspace reloaded for agent ${ctx.agentId} by ${ctx.username}`);
+      return { response: `✅ Workspace reloaded for agent \`${ctx.agentId}\`.` };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Reload failed for agent ${ctx.agentId}: ${msg}`);
+      return { response: `❌ Reload failed: ${msg}` };
+    }
+  }
+
+  private async handleModel(ctx: CommandContext, args: string): Promise<CommandResult> {
+    const modelName = args.trim();
+    if (!modelName) {
+      // Show current model
+      const agents = ctx.agentManager.list();
+      const agentConfig = agents.find((a) => a.id === ctx.agentId);
+      const current = agentConfig?.provider?.model ?? "claude-opus-4.5";
+      return { response: `Current model: \`${current}\`` };
+    }
+
+    try {
+      const agents = ctx.agentManager.list();
+      const agentConfig = agents.find((a) => a.id === ctx.agentId);
+      const currentProvider = agentConfig?.provider;
+
+      await ctx.agentManager.update(ctx.agentId, {
+        provider: {
+          ...currentProvider,
+          type: currentProvider?.type ?? "anthropic",
+          model: modelName,
+        },
+      });
+
+      log.info(`Model switched to ${modelName} for agent ${ctx.agentId} by ${ctx.username}`);
+      return { response: `✅ Model switched to \`${modelName}\` for agent \`${ctx.agentId}\`.` };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Model switch failed for agent ${ctx.agentId}: ${msg}`);
+      return { response: `❌ Model switch failed: ${msg}` };
+    }
+  }
+}
+
+/** Set of known command names for isCommand() filtering */
+const KNOWN_COMMANDS = new Set(["status", "reload", "model"]);
+
+/** Format milliseconds as a human-readable uptime string */
+function formatUptime(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ${hours % 24}h ${minutes % 60}m`;
+  if (hours > 0) return `${hours}h ${minutes % 60}m`;
+  if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
+  return `${seconds}s`;
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -199,6 +199,8 @@ export interface DiscordConfigFile {
   allowBots?: boolean;
   /** Context management configuration */
   context?: ContextConfigFile;
+  /** Discord user IDs allowed to execute slash commands */
+  adminUsers?: string[];
 }
 
 /** Thread binding configuration in config file */

--- a/src/transports/discord-manager.ts
+++ b/src/transports/discord-manager.ts
@@ -29,6 +29,8 @@ export interface DiscordSharedConfig {
   allowBots?: boolean;
   context?: ContextConfigFile;
   usageTracker?: UsageTracker;
+  /** Discord user IDs allowed to execute slash commands */
+  adminUsers?: string[];
 }
 
 /** Configuration for the DiscordTransportManager */
@@ -78,6 +80,7 @@ export class DiscordTransportManager {
         allowBots: shared.allowBots,
         context: shared.context,
         usageTracker: shared.usageTracker,
+        adminUsers: shared.adminUsers,
       });
 
       this.transports.set(accountId, transport);

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -37,6 +37,7 @@ import { preparePromptMessages } from "../core/context.js";
 import { ChannelHistoryBuffer, buildHistoryContext } from "../core/channel-history.js";
 import { DedupeCache } from "../core/dedupe.js";
 import { InboundDebouncer } from "../core/debounce.js";
+import { SlashCommandHandler } from "../commands/slash-commands.js";
 
 const log = loggers.discord;
 
@@ -171,6 +172,8 @@ export interface DiscordTransportConfig {
   context?: ContextConfigFile;
   /** Usage tracker for per-session/global token accumulation */
   usageTracker?: UsageTracker;
+  /** Discord user IDs allowed to execute slash commands */
+  adminUsers?: string[];
 }
 
 /**
@@ -191,6 +194,7 @@ export class DiscordTransport implements Transport {
   private channelHistory: ChannelHistoryBuffer;
   private dedupe: DedupeCache;
   private debouncer: InboundDebouncer;
+  private commandHandler: SlashCommandHandler;
 
   constructor(config: DiscordTransportConfig) {
     this.config = config;
@@ -202,6 +206,7 @@ export class DiscordTransport implements Transport {
     this.debouncer = new InboundDebouncer({
       windowMs: config.context?.debounceWindowMs ?? 1500,
     });
+    this.commandHandler = new SlashCommandHandler(config.adminUsers);
     this.client = new Client({
       intents: [
         GatewayIntentBits.Guilds,
@@ -315,6 +320,20 @@ export class DiscordTransport implements Transport {
     // 4. Extract content
     let content = this.extractContent(msg);
     if (!content.trim()) return;
+
+    // 4.5. Slash command interception — handle admin commands before agent dispatch
+    if (this.commandHandler.isCommand(content)) {
+      const agentId = this.resolveAgentId(msg);
+      const result = await this.commandHandler.execute(content, {
+        agentManager: this.config.agentManager,
+        sessionStore: this.getSessionStore(agentId),
+        agentId,
+        userId: msg.author.id,
+        username: msg.author.username,
+      });
+      await (msg.channel as SendableChannel).send(result.response);
+      return;
+    }
 
     // 5. Debounce — combine rapid-fire messages from the same user (opt-in)
     if (this.config.context?.debounce) {


### PR DESCRIPTION
## Summary
- Add `/status`, `/reload`, `/model` slash commands for runtime agent management via Discord
- Commands gated by `discord.adminUsers` config field (array of Discord user IDs)
- `SlashCommandHandler` intercepts messages before agent dispatch, supports `/` and `!` prefixes
- Integrated into `DiscordTransport` with config threaded through `DiscordTransportManager`

## Config example
```yaml
discord:
  adminUsers:
    - "123456789"
  token: ...
```

## Commands
| Command | Description |
|---------|-------------|
| `/status` | Show uptime, model, agent ID, loaded agents count, active sessions |
| `/reload` | Hot-reload agent workspace (re-read SOUL.md, MEMORY.md, etc.) |
| `/model` | Show current model |
| `/model <name>` | Switch model at runtime |

## Test plan
- [x] Command parsing (`/`, `!` prefixes, args extraction, case normalization)
- [x] Admin authorization (reject non-admin, allow admin)
- [x] `/status` returns expected fields
- [x] `/reload` calls `reloadWorkspace` and reports success/failure
- [x] `/model` shows current / switches model / reports errors
- [x] Unknown commands handled gracefully
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1736 tests, 21 new)

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)