### PR TITLE
feat(acp): session persistence across restarts (#195)

### DIFF
--- a/src/acp/index.ts
+++ b/src/acp/index.ts
@@ -1,9 +1,11 @@
 // src/acp/index.ts — Barrel exports for the ACP module
 
 export { AcpSessionManager } from "./session-manager.js";
+export { AcpSessionPersistence } from "./persistence.js";
 export type {
   AcpConfig,
   AcpBackend,
+  AcpPersistenceConfig,
   AcpSession,
   AcpSessionStatus,
   AcpMessage,

--- a/src/acp/persistence.test.ts
+++ b/src/acp/persistence.test.ts
@@ -1,0 +1,419 @@
+// src/acp/persistence.test.ts — Unit tests for ACP session persistence (#195)
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { AcpSessionPersistence } from "./persistence.js";
+import { AcpSessionManager } from "./session-manager.js";
+import type {
+  AcpConfig,
+  AcpPersistenceConfig,
+  AcpSession,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+async function makeTmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "acp-persist-test-"));
+}
+
+function makePersistenceConfig(overrides?: Partial<AcpPersistenceConfig>): AcpPersistenceConfig {
+  return {
+    enabled: true,
+    dataDir: tmpDir,
+    ttl: 86_400,
+    cleanupInterval: 3_600,
+    ...overrides,
+  };
+}
+
+function makeAcpConfig(overrides?: Partial<AcpConfig>): AcpConfig {
+  return {
+    enabled: true,
+    backend: "acpx",
+    defaultAgent: "claude",
+    allowedAgents: ["claude", "codex"],
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  tmpDir = await makeTmpDir();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// AcpSessionPersistence (low-level)
+// ---------------------------------------------------------------------------
+
+describe("AcpSessionPersistence", () => {
+  let persistence: AcpSessionPersistence;
+
+  beforeEach(async () => {
+    persistence = new AcpSessionPersistence(makePersistenceConfig());
+    await persistence.init();
+  });
+
+  afterEach(() => {
+    persistence.destroy();
+  });
+
+  describe("persistIndex + loadAll", () => {
+    it("persists sessions to disk and restores them", async () => {
+      const sessions = new Map<string, AcpSession>();
+      const threadIndex = new Map<string, string>();
+
+      const now = new Date();
+      const session: AcpSession = {
+        id: "session-1",
+        agentId: "claude",
+        threadId: "thread-1",
+        status: "active",
+        createdAt: now,
+        lastActivityAt: now,
+        history: [],
+      };
+      sessions.set(session.id, session);
+      threadIndex.set("thread-1", "session-1");
+
+      await persistence.persistIndex(sessions, threadIndex);
+
+      // Verify file exists
+      const indexPath = path.join(tmpDir, "acp-sessions.json");
+      const stat = await fs.stat(indexPath);
+      expect(stat.isFile()).toBe(true);
+
+      // Load and verify
+      const loaded = await persistence.loadAll();
+      expect(loaded.sessions.size).toBe(1);
+      expect(loaded.threadIndex.size).toBe(1);
+
+      const restored = loaded.sessions.get("session-1")!;
+      expect(restored.agentId).toBe("claude");
+      expect(restored.threadId).toBe("thread-1");
+      expect(restored.status).toBe("active");
+      expect(restored.createdAt).toBeInstanceOf(Date);
+      expect(restored.lastActivityAt).toBeInstanceOf(Date);
+      expect(restored.history).toEqual([]);
+
+      expect(loaded.threadIndex.get("thread-1")).toBe("session-1");
+    });
+
+    it("returns empty maps when no index file exists", async () => {
+      const loaded = await persistence.loadAll();
+      expect(loaded.sessions.size).toBe(0);
+      expect(loaded.threadIndex.size).toBe(0);
+    });
+
+    it("handles corrupted index file gracefully", async () => {
+      const indexPath = path.join(tmpDir, "acp-sessions.json");
+      await fs.writeFile(indexPath, "NOT VALID JSON{{{");
+
+      const loaded = await persistence.loadAll();
+      expect(loaded.sessions.size).toBe(0);
+      expect(loaded.threadIndex.size).toBe(0);
+    });
+
+    it("skips thread index entries for non-existent sessions", async () => {
+      const indexPath = path.join(tmpDir, "acp-sessions.json");
+      await fs.writeFile(indexPath, JSON.stringify({
+        sessions: {},
+        threadIndex: { "thread-orphan": "nonexistent-session" },
+      }));
+
+      const loaded = await persistence.loadAll();
+      expect(loaded.threadIndex.size).toBe(0);
+    });
+  });
+
+  describe("appendMessage + loadMessages", () => {
+    it("persists messages to JSONL and loads them back", async () => {
+      const ts = new Date("2025-01-15T10:00:00Z");
+      await persistence.appendMessage("session-1", {
+        role: "user",
+        content: "Hello",
+        timestamp: ts,
+      });
+      await persistence.appendMessage("session-1", {
+        role: "assistant",
+        content: "Hi there!",
+        timestamp: new Date("2025-01-15T10:00:01Z"),
+      });
+
+      const messages = await persistence.loadMessages("session-1");
+      expect(messages).toHaveLength(2);
+      expect(messages[0].role).toBe("user");
+      expect(messages[0].content).toBe("Hello");
+      expect(messages[0].timestamp).toBeInstanceOf(Date);
+      expect(messages[1].role).toBe("assistant");
+      expect(messages[1].content).toBe("Hi there!");
+    });
+
+    it("returns empty array for non-existent session", async () => {
+      const messages = await persistence.loadMessages("nonexistent");
+      expect(messages).toEqual([]);
+    });
+
+    it("skips malformed lines in transcript", async () => {
+      const file = path.join(tmpDir, "session-bad.jsonl");
+      const goodLine = JSON.stringify({
+        type: "message",
+        role: "user",
+        content: "Good",
+        timestamp: new Date().toISOString(),
+      });
+      await fs.writeFile(file, `${goodLine}\nNOT JSON\n${goodLine}\n`);
+
+      const messages = await persistence.loadMessages("session-bad");
+      expect(messages).toHaveLength(2);
+      expect(messages[0].content).toBe("Good");
+    });
+  });
+
+  describe("findStaleSessions", () => {
+    it("marks sessions older than TTL as stale", () => {
+      const sessions = new Map<string, AcpSession>();
+      const oldDate = new Date(Date.now() - 100_000 * 1_000); // 100k seconds ago
+
+      sessions.set("old-session", {
+        id: "old-session",
+        agentId: "claude",
+        status: "active",
+        createdAt: oldDate,
+        lastActivityAt: oldDate,
+        history: [],
+      });
+      sessions.set("fresh-session", {
+        id: "fresh-session",
+        agentId: "claude",
+        status: "active",
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+        history: [],
+      });
+
+      const stale = persistence.findStaleSessions(sessions);
+      expect(stale).toContain("old-session");
+      expect(stale).not.toContain("fresh-session");
+    });
+
+    it("always considers terminated sessions as stale", () => {
+      const sessions = new Map<string, AcpSession>();
+
+      sessions.set("terminated-session", {
+        id: "terminated-session",
+        agentId: "claude",
+        status: "terminated",
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+        history: [],
+      });
+
+      const stale = persistence.findStaleSessions(sessions);
+      expect(stale).toContain("terminated-session");
+    });
+  });
+
+  describe("deleteTranscript", () => {
+    it("removes transcript file", async () => {
+      await persistence.appendMessage("session-del", {
+        role: "user",
+        content: "Delete me",
+        timestamp: new Date(),
+      });
+
+      const file = path.join(tmpDir, "session-del.jsonl");
+      await expect(fs.stat(file)).resolves.toBeDefined();
+
+      await persistence.deleteTranscript("session-del");
+      await expect(fs.stat(file)).rejects.toThrow();
+    });
+
+    it("does not throw for non-existent transcript", async () => {
+      await expect(
+        persistence.deleteTranscript("nonexistent"),
+      ).resolves.not.toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AcpSessionManager with persistence (integration)
+// ---------------------------------------------------------------------------
+
+describe("AcpSessionManager with persistence", () => {
+  let manager: AcpSessionManager;
+
+  afterEach(() => {
+    manager?.destroy();
+  });
+
+  it("persists sessions to disk on creation", async () => {
+    manager = new AcpSessionManager(makeAcpConfig());
+    await manager.init(makePersistenceConfig());
+
+    manager.createSession("claude", "thread-1");
+    manager.createSession("codex");
+
+    // Allow debounced writes to flush
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify index file was written
+    const indexPath = path.join(tmpDir, "acp-sessions.json");
+    const raw = await fs.readFile(indexPath, "utf-8");
+    const index = JSON.parse(raw);
+    expect(Object.keys(index.sessions)).toHaveLength(2);
+    expect(index.threadIndex["thread-1"]).toBeDefined();
+  });
+
+  it("restores sessions on init from persisted data", async () => {
+    // Create and persist sessions
+    const manager1 = new AcpSessionManager(makeAcpConfig());
+    await manager1.init(makePersistenceConfig());
+
+    const s1 = manager1.createSession("claude", "thread-abc");
+    manager1.addMessage(s1.id, { role: "user", content: "Hello" });
+    manager1.addMessage(s1.id, { role: "assistant", content: "Hi!" });
+
+    // Allow writes to flush
+    await new Promise((r) => setTimeout(r, 100));
+    manager1.destroy();
+
+    // Create a new manager and init — should restore
+    manager = new AcpSessionManager(makeAcpConfig());
+    await manager.init(makePersistenceConfig());
+
+    const restored = manager.getSession(s1.id);
+    expect(restored).toBeDefined();
+    expect(restored!.agentId).toBe("claude");
+    expect(restored!.threadId).toBe("thread-abc");
+    expect(restored!.status).toBe("active");
+    expect(restored!.history).toHaveLength(2);
+    expect(restored!.history[0].content).toBe("Hello");
+    expect(restored!.history[1].content).toBe("Hi!");
+
+    // Thread index should be restored
+    const byThread = manager.getSessionByThread("thread-abc");
+    expect(byThread).toBeDefined();
+    expect(byThread!.id).toBe(s1.id);
+  });
+
+  it("persists session updates (status, threadId)", async () => {
+    manager = new AcpSessionManager(makeAcpConfig());
+    await manager.init(makePersistenceConfig());
+
+    const s = manager.createSession("claude");
+    manager.updateSession(s.id, { status: "paused", threadId: "thread-new" });
+
+    // Allow writes to flush
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Re-load
+    const manager2 = new AcpSessionManager(makeAcpConfig());
+    await manager2.init(makePersistenceConfig());
+
+    const restored = manager2.getSession(s.id);
+    expect(restored!.status).toBe("paused");
+    expect(restored!.threadId).toBe("thread-new");
+    manager2.destroy();
+  });
+
+  it("persists termination", async () => {
+    manager = new AcpSessionManager(makeAcpConfig());
+    await manager.init(makePersistenceConfig());
+
+    const s = manager.createSession("claude");
+    manager.terminateSession(s.id);
+
+    // Allow writes to flush
+    await new Promise((r) => setTimeout(r, 50));
+
+    const manager2 = new AcpSessionManager(makeAcpConfig());
+    await manager2.init(makePersistenceConfig());
+
+    const restored = manager2.getSession(s.id);
+    expect(restored!.status).toBe("terminated");
+    manager2.destroy();
+  });
+
+  it("cleans up stale sessions based on TTL", async () => {
+    manager = new AcpSessionManager(makeAcpConfig());
+    // Very short TTL for testing
+    await manager.init(makePersistenceConfig({ ttl: 0.001 }));
+
+    const s = manager.createSession("claude");
+    manager.addMessage(s.id, { role: "user", content: "Hello" });
+
+    // Wait for session to become stale
+    await new Promise((r) => setTimeout(r, 50));
+
+    const cleaned = await manager.cleanupStaleSessions();
+    expect(cleaned).toContain(s.id);
+    expect(manager.getSession(s.id)).toBeUndefined();
+  });
+
+  it("works without persistence (backwards compatible)", async () => {
+    manager = new AcpSessionManager(makeAcpConfig());
+    // Do NOT call init — no persistence
+
+    const s = manager.createSession("claude");
+    manager.addMessage(s.id, { role: "user", content: "Hello" });
+
+    expect(manager.getSession(s.id)!.history).toHaveLength(1);
+    expect(manager.listSessions()).toHaveLength(1);
+  });
+
+  it("purgeTerminated removes persisted transcripts", async () => {
+    manager = new AcpSessionManager(makeAcpConfig());
+    await manager.init(makePersistenceConfig());
+
+    const s = manager.createSession("claude");
+    manager.addMessage(s.id, { role: "user", content: "Hello" });
+    manager.terminateSession(s.id);
+
+    // Allow writes to flush
+    await new Promise((r) => setTimeout(r, 50));
+
+    const purged = manager.purgeTerminated();
+    expect(purged).toBe(1);
+    expect(manager.getSession(s.id)).toBeUndefined();
+
+    // Allow delete to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Transcript file should be gone
+    const transcriptPath = path.join(tmpDir, `${s.id}.jsonl`);
+    await expect(fs.stat(transcriptPath)).rejects.toThrow();
+  });
+
+  it("handles multiple sessions with different agents", async () => {
+    manager = new AcpSessionManager(makeAcpConfig());
+    await manager.init(makePersistenceConfig());
+
+    const s1 = manager.createSession("claude", "t1");
+    const s2 = manager.createSession("codex", "t2");
+    manager.addMessage(s1.id, { role: "user", content: "Msg to claude" });
+    manager.addMessage(s2.id, { role: "user", content: "Msg to codex" });
+
+    await new Promise((r) => setTimeout(r, 100));
+    manager.destroy();
+
+    const manager2 = new AcpSessionManager(makeAcpConfig());
+    await manager2.init(makePersistenceConfig());
+
+    expect(manager2.listSessions()).toHaveLength(2);
+    expect(manager2.getSessionByThread("t1")!.agentId).toBe("claude");
+    expect(manager2.getSessionByThread("t2")!.agentId).toBe("codex");
+    expect(manager2.getSession(s1.id)!.history[0].content).toBe("Msg to claude");
+    expect(manager2.getSession(s2.id)!.history[0].content).toBe("Msg to codex");
+    manager2.destroy();
+  });
+});

--- a/src/acp/persistence.ts
+++ b/src/acp/persistence.ts
@@ -1,0 +1,306 @@
+// src/acp/persistence.ts — ACP session persistence to disk (#195)
+// Persists ACP sessions as a JSON index + per-session JSONL message transcripts.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createLogger } from "../core/logger.js";
+import type {
+  AcpMessage,
+  AcpPersistenceConfig,
+  AcpSession,
+  AcpSessionStatus,
+} from "./types.js";
+
+const log = createLogger("acp-persistence");
+
+// ---------------------------------------------------------------------------
+// Persisted record types
+// ---------------------------------------------------------------------------
+
+interface PersistedSessionRecord {
+  id: string;
+  agentId: string;
+  threadId?: string;
+  status: AcpSessionStatus;
+  createdAt: string; // ISO 8601
+  lastActivityAt: string; // ISO 8601
+}
+
+interface PersistedSessionIndex {
+  sessions: Record<string, PersistedSessionRecord>;
+  threadIndex: Record<string, string>; // threadId → sessionId
+}
+
+interface PersistedMessageRecord {
+  type: "message";
+  role: AcpMessage["role"];
+  content: string;
+  timestamp: string; // ISO 8601
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Debounce interval for index writes triggered by addMessage (ms) */
+const INDEX_DEBOUNCE_MS = 1_000;
+
+// ---------------------------------------------------------------------------
+// AcpSessionPersistence
+// ---------------------------------------------------------------------------
+
+/**
+ * AcpSessionPersistence — durable storage layer for ACP sessions.
+ *
+ * Layout on disk:
+ * - `{dataDir}/acp-sessions.json`  — session index (metadata + thread index)
+ * - `{dataDir}/{sessionId}.jsonl`  — per-session message transcript
+ *
+ * Follows the same patterns as DefaultSessionStore:
+ * - Atomic index rewrites on session create/update/terminate
+ * - Append-only JSONL for message transcripts
+ * - Debounced index persistence on message additions
+ * - Lazy message loading from transcripts
+ * - TTL-based stale session cleanup
+ */
+export class AcpSessionPersistence {
+  private indexDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private config: AcpPersistenceConfig) {}
+
+  // -------------------------------------------------------------------------
+  // Initialization
+  // -------------------------------------------------------------------------
+
+  /** Create the data directory if it does not exist. */
+  async init(): Promise<void> {
+    await fs.mkdir(this.config.dataDir, { recursive: true });
+  }
+
+  // -------------------------------------------------------------------------
+  // Persistence — write
+  // -------------------------------------------------------------------------
+
+  /** Persist the full session index to disk. */
+  async persistIndex(
+    sessions: Map<string, AcpSession>,
+    threadIndex: Map<string, string>,
+  ): Promise<void> {
+    const index: PersistedSessionIndex = {
+      sessions: {},
+      threadIndex: Object.fromEntries(threadIndex),
+    };
+
+    for (const [id, session] of sessions) {
+      index.sessions[id] = {
+        id: session.id,
+        agentId: session.agentId,
+        ...(session.threadId !== undefined && { threadId: session.threadId }),
+        status: session.status,
+        createdAt: session.createdAt.toISOString(),
+        lastActivityAt: session.lastActivityAt.toISOString(),
+      };
+    }
+
+    await fs.writeFile(this.indexFile(), JSON.stringify(index, null, 2));
+  }
+
+  /**
+   * Debounced index persistence — coalesces rapid writes (e.g. during
+   * message bursts) into a single disk write.
+   */
+  debouncedPersistIndex(
+    sessions: Map<string, AcpSession>,
+    threadIndex: Map<string, string>,
+  ): void {
+    if (this.indexDebounceTimer) {
+      clearTimeout(this.indexDebounceTimer);
+    }
+    this.indexDebounceTimer = setTimeout(() => {
+      this.indexDebounceTimer = null;
+      void this.persistIndex(sessions, threadIndex);
+    }, INDEX_DEBOUNCE_MS);
+  }
+
+  /** Append a message to a session's JSONL transcript file. */
+  async appendMessage(sessionId: string, message: AcpMessage): Promise<void> {
+    const record: PersistedMessageRecord = {
+      type: "message",
+      role: message.role,
+      content: message.content,
+      timestamp: message.timestamp.toISOString(),
+    };
+    const line = JSON.stringify(record) + "\n";
+    await fs.appendFile(this.transcriptFile(sessionId), line);
+  }
+
+  // -------------------------------------------------------------------------
+  // Persistence — read
+  // -------------------------------------------------------------------------
+
+  /**
+   * Load all persisted sessions from the index file.
+   * Returns the sessions map and thread index, or empty maps if no index exists.
+   * Message histories are NOT loaded — use loadMessages() for lazy loading.
+   */
+  async loadAll(): Promise<{
+    sessions: Map<string, AcpSession>;
+    threadIndex: Map<string, string>;
+  }> {
+    const sessions = new Map<string, AcpSession>();
+    const threadIndex = new Map<string, string>();
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.indexFile(), "utf-8");
+    } catch {
+      log.debug("No ACP session index found (first run or empty store)");
+      return { sessions, threadIndex };
+    }
+
+    let index: PersistedSessionIndex;
+    try {
+      index = JSON.parse(raw) as PersistedSessionIndex;
+    } catch (err) {
+      log.warn("Corrupted ACP session index — starting fresh", err);
+      return { sessions, threadIndex };
+    }
+
+    for (const record of Object.values(index.sessions ?? {})) {
+      const session: AcpSession = {
+        id: record.id,
+        agentId: record.agentId,
+        threadId: record.threadId,
+        status: record.status,
+        createdAt: new Date(record.createdAt),
+        lastActivityAt: new Date(record.lastActivityAt),
+        history: [], // lazy-loaded
+      };
+      sessions.set(session.id, session);
+    }
+
+    for (const [threadId, sessionId] of Object.entries(index.threadIndex ?? {})) {
+      if (sessions.has(sessionId)) {
+        threadIndex.set(threadId, sessionId);
+      }
+    }
+
+    log.info(`Loaded ${sessions.size} persisted ACP session(s)`);
+    return { sessions, threadIndex };
+  }
+
+  /**
+   * Load message history for a single session from its JSONL transcript.
+   * Returns an empty array if the file does not exist or is unreadable.
+   */
+  async loadMessages(sessionId: string): Promise<AcpMessage[]> {
+    try {
+      const content = await fs.readFile(this.transcriptFile(sessionId), "utf-8");
+      const messages: AcpMessage[] = [];
+
+      for (const line of content.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const record = JSON.parse(line) as PersistedMessageRecord;
+          if (record.type !== "message") continue;
+          messages.push({
+            role: record.role,
+            content: record.content,
+            timestamp: new Date(record.timestamp),
+          });
+        } catch {
+          log.debug(`Skipping malformed transcript line in session ${sessionId}`);
+        }
+      }
+
+      return messages;
+    } catch {
+      log.debug(`No transcript file for session ${sessionId}`);
+      return [];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  /**
+   * Find sessions that are stale (older than TTL).
+   * Terminated sessions are always considered stale.
+   */
+  findStaleSessions(sessions: Map<string, AcpSession>): string[] {
+    const now = Date.now();
+    const stale: string[] = [];
+
+    for (const [id, session] of sessions) {
+      if (session.status === "terminated") {
+        stale.push(id);
+        continue;
+      }
+      const ageSeconds = (now - session.lastActivityAt.getTime()) / 1_000;
+      if (ageSeconds > this.config.ttl) {
+        stale.push(id);
+      }
+    }
+
+    return stale;
+  }
+
+  /** Delete the transcript file for a session. */
+  async deleteTranscript(sessionId: string): Promise<void> {
+    try {
+      await fs.rm(this.transcriptFile(sessionId), { force: true });
+    } catch (err) {
+      log.debug(`Could not remove transcript for session ${sessionId}`, err);
+    }
+  }
+
+  /**
+   * Start the periodic cleanup timer.
+   * Calls the provided cleanup function every `cleanupInterval` seconds.
+   */
+  startCleanupTimer(cleanupFn: () => Promise<void>): void {
+    this.stopCleanupTimer();
+    const intervalMs = this.config.cleanupInterval * 1_000;
+    this.cleanupTimer = setInterval(() => {
+      void cleanupFn();
+    }, intervalMs);
+    if (this.cleanupTimer && typeof this.cleanupTimer === "object" && "unref" in this.cleanupTimer) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  /** Stop the periodic cleanup timer. */
+  stopCleanupTimer(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Teardown
+  // -------------------------------------------------------------------------
+
+  /** Release all timers. */
+  destroy(): void {
+    this.stopCleanupTimer();
+    if (this.indexDebounceTimer) {
+      clearTimeout(this.indexDebounceTimer);
+      this.indexDebounceTimer = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Path helpers
+  // -------------------------------------------------------------------------
+
+  private indexFile(): string {
+    return path.join(this.config.dataDir, "acp-sessions.json");
+  }
+
+  private transcriptFile(sessionId: string): string {
+    return path.join(this.config.dataDir, `${sessionId}.jsonl`);
+  }
+}

--- a/src/acp/session-manager.ts
+++ b/src/acp/session-manager.ts
@@ -1,14 +1,20 @@
 // src/acp/session-manager.ts — ACP session lifecycle management
 // In-memory session store for ACP agent sessions with event notification.
+// Supports optional disk persistence for surviving restarts (#195).
 
 import { randomUUID } from "node:crypto";
+import { createLogger } from "../core/logger.js";
+import { AcpSessionPersistence } from "./persistence.js";
 import type {
   AcpConfig,
   AcpMessage,
+  AcpPersistenceConfig,
   AcpSession,
   AcpSessionCallback,
   AcpSessionStatus,
 } from "./types.js";
+
+const log = createLogger("acp-session");
 
 /**
  * AcpSessionManager — manages the lifecycle of ACP agent sessions.
@@ -18,22 +24,58 @@ import type {
  * - Maintain message history per session
  * - Thread ↔ session lookup
  * - Emit lifecycle events for downstream consumers
- *
- * Storage is in-memory for now; persistence can be added later.
+ * - Optionally persist sessions to disk for restart survival (#195)
  */
 export class AcpSessionManager {
   private sessions: Map<string, AcpSession> = new Map();
   private threadIndex: Map<string, string> = new Map(); // threadId → sessionId
   private listeners: AcpSessionCallback[] = [];
+  private persistence: AcpSessionPersistence | null = null;
 
   constructor(private config: AcpConfig) {}
+
+  // -------------------------------------------------------------------------
+  // Initialization (#195)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Initialize the manager with optional persistence.
+   * When persistence is configured, restores sessions from disk.
+   * Call this before using the manager if persistence is desired.
+   */
+  async init(persistenceConfig?: AcpPersistenceConfig): Promise<void> {
+    if (!persistenceConfig?.enabled) return;
+
+    this.persistence = new AcpSessionPersistence(persistenceConfig);
+    await this.persistence.init();
+
+    // Restore sessions from disk
+    const { sessions, threadIndex } = await this.persistence.loadAll();
+    this.sessions = sessions;
+    this.threadIndex = threadIndex;
+
+    // Lazily load message histories for restored sessions
+    for (const session of this.sessions.values()) {
+      if (session.history.length === 0) {
+        session.history = await this.persistence.loadMessages(session.id);
+      }
+    }
+
+    // Start periodic stale session cleanup
+    this.persistence.startCleanupTimer(async () => { await this.cleanupStaleSessions(); });
+
+    log.info(
+      `Initialized with persistence (${this.sessions.size} session(s) restored, ` +
+      `TTL=${persistenceConfig.ttl}s)`,
+    );
+  }
 
   // -------------------------------------------------------------------------
   // Cleanup
   // -------------------------------------------------------------------------
 
   /**
-   * Remove terminated sessions from memory.
+   * Remove terminated sessions from memory (and disk if persistence is enabled).
    * Returns the number of sessions removed.
    */
   purgeTerminated(): number {
@@ -42,10 +84,41 @@ export class AcpSessionManager {
       if (session.status === "terminated") {
         if (session.threadId) this.threadIndex.delete(session.threadId);
         this.sessions.delete(id);
+        if (this.persistence) {
+          void this.persistence.deleteTranscript(id);
+        }
         count++;
       }
     }
+    if (count > 0 && this.persistence) {
+      void this.persistence.persistIndex(this.sessions, this.threadIndex);
+    }
     return count;
+  }
+
+  /**
+   * Remove stale sessions (TTL-expired or terminated).
+   * Returns the IDs of removed sessions.
+   */
+  async cleanupStaleSessions(): Promise<string[]> {
+    if (!this.persistence) return [];
+
+    const staleIds = this.persistence.findStaleSessions(this.sessions);
+    if (staleIds.length === 0) return [];
+
+    for (const id of staleIds) {
+      const session = this.sessions.get(id);
+      if (session?.threadId) this.threadIndex.delete(session.threadId);
+      this.sessions.delete(id);
+    }
+
+    await this.persistence.persistIndex(this.sessions, this.threadIndex);
+    await Promise.allSettled(
+      staleIds.map((id) => this.persistence!.deleteTranscript(id)),
+    );
+
+    log.info(`Cleaned up ${staleIds.length} stale ACP session(s)`);
+    return staleIds;
   }
 
   // -------------------------------------------------------------------------
@@ -91,6 +164,10 @@ export class AcpSessionManager {
     if (threadId) this.threadIndex.set(threadId, session.id);
     this.notify(session, "created");
 
+    if (this.persistence) {
+      void this.persistence.persistIndex(this.sessions, this.threadIndex);
+    }
+
     return session;
   }
 
@@ -127,6 +204,11 @@ export class AcpSessionManager {
     session.lastActivityAt = new Date();
 
     this.notify(session, "updated");
+
+    if (this.persistence) {
+      void this.persistence.persistIndex(this.sessions, this.threadIndex);
+    }
+
     return session;
   }
 
@@ -141,6 +223,10 @@ export class AcpSessionManager {
     session.status = "terminated";
     session.lastActivityAt = new Date();
     this.notify(session, "terminated");
+
+    if (this.persistence) {
+      void this.persistence.persistIndex(this.sessions, this.threadIndex);
+    }
 
     return true;
   }
@@ -174,13 +260,20 @@ export class AcpSessionManager {
     if (!session) return false;
 
     const now = new Date();
-    session.history.push({
+    const fullMessage: AcpMessage = {
       ...message,
       timestamp: now,
-    });
+    };
+    session.history.push(fullMessage);
     session.lastActivityAt = now;
 
     this.notify(session, "updated");
+
+    if (this.persistence) {
+      void this.persistence.appendMessage(sessionId, fullMessage);
+      this.persistence.debouncedPersistIndex(this.sessions, this.threadIndex);
+    }
+
     return true;
   }
 
@@ -198,6 +291,17 @@ export class AcpSessionManager {
       const idx = this.listeners.indexOf(callback);
       if (idx !== -1) this.listeners.splice(idx, 1);
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // Teardown
+  // -------------------------------------------------------------------------
+
+  /** Release persistence timers and resources. */
+  destroy(): void {
+    if (this.persistence) {
+      this.persistence.destroy();
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/acp/types.ts
+++ b/src/acp/types.ts
@@ -8,6 +8,18 @@
 /** Supported ACP backend types */
 export type AcpBackend = "acpx" | "claude-code" | "codex";
 
+/** ACP session persistence configuration */
+export interface AcpPersistenceConfig {
+  /** Whether session persistence is enabled. Default: false */
+  enabled: boolean;
+  /** Directory to store persisted session data */
+  dataDir: string;
+  /** Session TTL in seconds. Sessions older than this are considered stale. Default: 86400 (24h) */
+  ttl: number;
+  /** Cleanup interval in seconds. How often to check for stale sessions. Default: 3600 (1h) */
+  cleanupInterval: number;
+}
+
 /** ACP configuration (root-level `acp` section in config) */
 export interface AcpConfig {
   /** Whether ACP is enabled */
@@ -18,6 +30,8 @@ export interface AcpConfig {
   defaultAgent: string;
   /** Agent IDs allowed to participate in ACP sessions */
   allowedAgents?: string[];
+  /** Session persistence configuration */
+  persistence?: AcpPersistenceConfig;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -17,7 +17,7 @@ import type {
   ProviderConfig,
   SessionConfig,
 } from "./types.js";
-import type { AcpConfig } from "../acp/types.js";
+import type { AcpConfig, AcpPersistenceConfig } from "../acp/types.js";
 import { resolveSandboxConfig, type SandboxConfig } from "../sandbox/config.js";
 import { createLogger } from "./logger.js";
 
@@ -291,6 +291,18 @@ export interface ResolvedSubagentConfig {
   showToolCalls: boolean;
 }
 
+/** ACP session persistence configuration in config file */
+export interface AcpPersistenceConfigFile {
+  /** Whether session persistence is enabled. Default: false */
+  enabled?: boolean;
+  /** Directory to store persisted session data. Default: $ISOTOPES_HOME/acp-sessions */
+  dataDir?: string;
+  /** Session TTL in seconds. Default: 86400 (24h) */
+  ttl?: number;
+  /** Cleanup interval in seconds. Default: 3600 (1h) */
+  cleanupInterval?: number;
+}
+
 /** ACP (Agent Communication Protocol) configuration in config file */
 export interface AcpConfigFile {
   /** Whether ACP is enabled. Default: false */
@@ -303,6 +315,8 @@ export interface AcpConfigFile {
   allowedAgents?: string[];
   /** Sub-agent execution settings (M7/M8) */
   subagent?: SubagentConfigFile;
+  /** Session persistence settings (#195) */
+  persistence?: AcpPersistenceConfigFile;
 }
 
 /** Cron job configuration in config file */
@@ -448,11 +462,30 @@ export function resolveAcpConfig(
     throw new Error("acp.defaultAgent is required when ACP is enabled");
   }
 
+  let persistence: AcpPersistenceConfig | undefined;
+  if (acpConfig.persistence?.enabled) {
+    if (acpConfig.persistence.ttl !== undefined) {
+      assertPositiveNumber(acpConfig.persistence.ttl, "acp.persistence.ttl");
+    }
+    if (acpConfig.persistence.cleanupInterval !== undefined) {
+      assertPositiveNumber(acpConfig.persistence.cleanupInterval, "acp.persistence.cleanupInterval");
+    }
+
+    const home = process.env.ISOTOPES_HOME ?? path.join(process.env.HOME ?? "~", ".isotopes");
+    persistence = {
+      enabled: true,
+      dataDir: acpConfig.persistence.dataDir ?? path.join(home, "acp-sessions"),
+      ttl: acpConfig.persistence.ttl ?? 86_400,
+      cleanupInterval: acpConfig.persistence.cleanupInterval ?? 3_600,
+    };
+  }
+
   return {
     enabled: true,
     backend,
     defaultAgent: acpConfig.defaultAgent,
     allowedAgents: acpConfig.allowedAgents,
+    persistence,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `AcpSessionPersistence` class for durable session storage using JSON index + JSONL message transcripts, following established `DefaultSessionStore` patterns
- Integrate optional persistence into `AcpSessionManager` via `init()` — fully backward compatible when persistence is not configured
- Add `acp.persistence` config section with `enabled`, `dataDir`, `ttl`, and `cleanupInterval` options
- Comprehensive test coverage: persistence round-trips, restore on init, stale session TTL cleanup, corrupted file handling, and full manager integration

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — all 1766 tests pass (74 files), including new persistence tests
- [x] Verify sessions persist to disk on creation
- [x] Verify sessions restore on manager init from persisted data
- [x] Verify stale session cleanup based on TTL
- [x] Verify graceful handling of corrupted session files
- [x] Verify backward compatibility (no persistence when not configured)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)