### PR TITLE
feat(workspace): add context loader and memory manager (#196)

### DIFF
--- a/src/core/agent-manager.ts
+++ b/src/core/agent-manager.ts
@@ -13,6 +13,7 @@ import {
   loadWorkspaceContext,
   type WorkspaceContext,
 } from "./workspace.js";
+import { WorkspaceContextLoader } from "../workspace/context-loader.js";
 
 /** Options for creating an agent with workspace awareness. */
 export interface AgentCreateOptions {
@@ -22,6 +23,8 @@ export interface AgentCreateOptions {
   toolGuardPrompt?: string;
   /** Base system prompt before workspace assembly (for hot-reload rebuild) */
   baseSystemPrompt?: string;
+  /** Class-based context loader for hot-reload (if provided, used instead of functional API) */
+  contextLoader?: WorkspaceContextLoader;
 }
 
 /** Internal entry combining config, instance, and workspace */
@@ -35,6 +38,8 @@ interface AgentEntry {
   workspacePath?: string;
   /** Tool guard prompt section (re-appended on hot-reload) */
   toolGuardPrompt?: string;
+  /** Class-based context loader (for hot-reload via refresh) */
+  contextLoader?: WorkspaceContextLoader;
 }
 
 /**
@@ -70,6 +75,7 @@ export class DefaultAgentManager implements AgentManager {
       baseSystemPrompt: options?.baseSystemPrompt ?? config.systemPrompt,
       workspacePath: options?.workspacePath,
       toolGuardPrompt: options?.toolGuardPrompt,
+      contextLoader: options?.contextLoader,
     });
     return instance;
   }
@@ -132,6 +138,9 @@ export class DefaultAgentManager implements AgentManager {
   /**
    * Reload workspace context for an agent (hot-reload support).
    *
+   * If a {@link WorkspaceContextLoader} was provided at creation, uses its
+   * refresh() method. Otherwise falls back to the functional API.
+   *
    * Re-reads workspace files from disk, rebuilds the system prompt from
    * the base prompt + fresh workspace context + stored tool guard prompt.
    */
@@ -145,27 +154,31 @@ export class DefaultAgentManager implements AgentManager {
       return; // No workspace to reload
     }
 
-    // Re-load workspace from disk
     await ensureWorkspaceStructure(entry.workspacePath);
-    const workspace = await loadWorkspaceContext(entry.workspacePath);
 
-    // Rebuild system prompt: base + workspace context + tool guards
-    // We use a stored "base" prompt that doesn't include old workspace content
-    // to avoid double-appending. The base prompt is the original systemPrompt
-    // from config (before any workspace assembly).
-    //
-    // However, cli.ts pre-assembles the full prompt. So we need to extract
-    // the base prompt from the original config. We stored it in baseSystemPrompt.
-    let systemPrompt = buildSystemPrompt(entry.baseSystemPrompt, workspace);
+    // Use class-based loader if available, otherwise functional API
+    let systemPrompt: string;
+    if (entry.contextLoader) {
+      const ctx = await entry.contextLoader.refresh();
+      systemPrompt = entry.contextLoader.buildSystemPrompt(entry.baseSystemPrompt);
+
+      // Store workspace reference as a WorkspaceContext-compatible shape
+      entry.workspace = {
+        systemPromptAdditions: ctx.systemPromptAdditions,
+        memory: ctx.memory,
+        workspacePath: ctx.workspacePath,
+        skillsPrompt: ctx.skillsPrompt,
+      };
+    } else {
+      const workspace = await loadWorkspaceContext(entry.workspacePath);
+      systemPrompt = buildSystemPrompt(entry.baseSystemPrompt, workspace);
+      entry.workspace = workspace;
+    }
+
     if (entry.toolGuardPrompt) {
       systemPrompt = [systemPrompt, entry.toolGuardPrompt].filter(Boolean).join("\n\n---\n\n");
     }
 
     await this.update(id, { systemPrompt });
-    // Update workspace reference on the entry
-    const updatedEntry = this.agents.get(id);
-    if (updatedEntry) {
-      updatedEntry.workspace = workspace;
-    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,9 @@ export {
   writeWorkspaceState,
   isSetupComplete,
   reconcileWorkspaceState,
+  WorkspaceContextLoader,
+  CONTEXT_FILES,
+  MemoryManager,
 } from "./workspace/index.js";
 export type {
   WatcherConfig,
@@ -307,6 +310,9 @@ export type {
   ReloadEventHandler,
   WorkspaceTemplate,
   WorkspaceState,
+  LoadedContext,
+  MemoryManagerOptions,
+  MemoryWriteResult,
 } from "./workspace/index.js";
 
 // ---------------------------------------------------------------------------

--- a/src/workspace/context-loader.test.ts
+++ b/src/workspace/context-loader.test.ts
@@ -1,0 +1,273 @@
+// src/workspace/context-loader.test.ts — Tests for WorkspaceContextLoader
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { WorkspaceContextLoader, CONTEXT_FILES, MEMORY_FILES } from "./context-loader.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("CONTEXT_FILES", () => {
+  it("includes standard workspace files", () => {
+    expect(CONTEXT_FILES).toContain("SOUL.md");
+    expect(CONTEXT_FILES).toContain("IDENTITY.md");
+    expect(CONTEXT_FILES).toContain("USER.md");
+    expect(CONTEXT_FILES).toContain("TOOLS.md");
+    expect(CONTEXT_FILES).toContain("AGENTS.md");
+    expect(CONTEXT_FILES).toContain("BOOTSTRAP.md");
+  });
+});
+
+describe("MEMORY_FILES", () => {
+  it("includes MEMORY.md", () => {
+    expect(MEMORY_FILES).toContain("MEMORY.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkspaceContextLoader
+// ---------------------------------------------------------------------------
+
+describe("WorkspaceContextLoader", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "ctx-loader-"));
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("load", () => {
+    it("returns empty context for empty workspace", async () => {
+      const loader = new WorkspaceContextLoader(tempDir);
+      const ctx = await loader.load();
+
+      expect(ctx.systemPromptAdditions).toBe("");
+      expect(ctx.memory).toBeNull();
+      expect(ctx.workspacePath).toBe(tempDir);
+      expect(ctx.files.size).toBe(0);
+      expect(ctx.loadedAt).toBeInstanceOf(Date);
+    });
+
+    it("loads SOUL.md into systemPromptAdditions", async () => {
+      await fsp.writeFile(path.join(tempDir, "SOUL.md"), "# My Soul");
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      const ctx = await loader.load();
+
+      expect(ctx.systemPromptAdditions).toContain("## SOUL.md");
+      expect(ctx.systemPromptAdditions).toContain("# My Soul");
+      expect(ctx.files.get("SOUL.md")).toBe("# My Soul");
+    });
+
+    it("loads multiple workspace files", async () => {
+      await fsp.writeFile(path.join(tempDir, "SOUL.md"), "soul content");
+      await fsp.writeFile(path.join(tempDir, "IDENTITY.md"), "identity content");
+      await fsp.writeFile(path.join(tempDir, "TOOLS.md"), "tools content");
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      const ctx = await loader.load();
+
+      expect(ctx.systemPromptAdditions).toContain("## SOUL.md");
+      expect(ctx.systemPromptAdditions).toContain("## IDENTITY.md");
+      expect(ctx.systemPromptAdditions).toContain("## TOOLS.md");
+      expect(ctx.files.size).toBe(3);
+    });
+
+    it("loads MEMORY.md into memory field", async () => {
+      await fsp.writeFile(path.join(tempDir, "MEMORY.md"), "remembered things");
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      const ctx = await loader.load();
+
+      expect(ctx.memory).toBe("remembered things");
+      expect(ctx.files.get("MEMORY.md")).toBe("remembered things");
+      // MEMORY.md should NOT be in systemPromptAdditions
+      expect(ctx.systemPromptAdditions).not.toContain("MEMORY.md");
+    });
+
+    it("loads daily note and merges with MEMORY.md", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-12T10:00:00Z"));
+
+      await fsp.writeFile(path.join(tempDir, "MEMORY.md"), "long-term memory");
+      await fsp.mkdir(path.join(tempDir, "memory"), { recursive: true });
+      await fsp.writeFile(
+        path.join(tempDir, "memory/2026-04-12.md"),
+        "today's notes",
+      );
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      const ctx = await loader.load();
+
+      expect(ctx.memory).toContain("long-term memory");
+      expect(ctx.memory).toContain("Today's Notes");
+      expect(ctx.memory).toContain("today's notes");
+    });
+
+    it("loads daily note alone when no MEMORY.md", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-12T10:00:00Z"));
+
+      await fsp.mkdir(path.join(tempDir, "memory"), { recursive: true });
+      await fsp.writeFile(
+        path.join(tempDir, "memory/2026-04-12.md"),
+        "standalone daily note",
+      );
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      const ctx = await loader.load();
+
+      expect(ctx.memory).toBe("standalone daily note");
+    });
+
+    it("ignores daily notes from other dates", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-12T10:00:00Z"));
+
+      await fsp.mkdir(path.join(tempDir, "memory"), { recursive: true });
+      await fsp.writeFile(
+        path.join(tempDir, "memory/2026-04-11.md"),
+        "yesterday's notes",
+      );
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      const ctx = await loader.load();
+
+      expect(ctx.memory).toBeNull();
+    });
+  });
+
+  describe("refresh", () => {
+    it("re-reads files from disk", async () => {
+      await fsp.writeFile(path.join(tempDir, "SOUL.md"), "version 1");
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      await loader.load();
+
+      expect(loader.getFile("SOUL.md")).toBe("version 1");
+
+      // Update file on disk
+      await fsp.writeFile(path.join(tempDir, "SOUL.md"), "version 2");
+
+      const ctx = await loader.refresh();
+
+      expect(ctx.files.get("SOUL.md")).toBe("version 2");
+      expect(loader.getFile("SOUL.md")).toBe("version 2");
+    });
+
+    it("picks up newly created files", async () => {
+      const loader = new WorkspaceContextLoader(tempDir);
+      await loader.load();
+
+      expect(loader.getFile("SOUL.md")).toBeNull();
+
+      await fsp.writeFile(path.join(tempDir, "SOUL.md"), "new soul");
+      await loader.refresh();
+
+      expect(loader.getFile("SOUL.md")).toBe("new soul");
+    });
+
+    it("detects deleted files", async () => {
+      await fsp.writeFile(path.join(tempDir, "SOUL.md"), "soul content");
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      await loader.load();
+
+      expect(loader.getFile("SOUL.md")).toBe("soul content");
+
+      await fsp.unlink(path.join(tempDir, "SOUL.md"));
+      await loader.refresh();
+
+      expect(loader.getFile("SOUL.md")).toBeNull();
+    });
+  });
+
+  describe("getContext", () => {
+    it("returns null before load", () => {
+      const loader = new WorkspaceContextLoader(tempDir);
+      expect(loader.getContext()).toBeNull();
+    });
+
+    it("returns cached context after load", async () => {
+      const loader = new WorkspaceContextLoader(tempDir);
+      const ctx = await loader.load();
+
+      expect(loader.getContext()).toBe(ctx);
+    });
+  });
+
+  describe("getFile", () => {
+    it("returns null before load", () => {
+      const loader = new WorkspaceContextLoader(tempDir);
+      expect(loader.getFile("SOUL.md")).toBeNull();
+    });
+
+    it("returns null for non-existent file", async () => {
+      const loader = new WorkspaceContextLoader(tempDir);
+      await loader.load();
+
+      expect(loader.getFile("NONEXISTENT.md")).toBeNull();
+    });
+  });
+
+  describe("buildSystemPrompt", () => {
+    it("returns base prompt when context not loaded", () => {
+      const loader = new WorkspaceContextLoader(tempDir);
+      const result = loader.buildSystemPrompt("base prompt");
+
+      expect(result).toBe("base prompt");
+    });
+
+    it("combines base prompt with workspace context", async () => {
+      await fsp.writeFile(path.join(tempDir, "SOUL.md"), "soul content");
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      await loader.load();
+
+      const result = loader.buildSystemPrompt("You are an agent.");
+
+      expect(result).toContain("You are an agent.");
+      expect(result).toContain("# Workspace");
+      expect(result).toContain(tempDir);
+      expect(result).toContain("# Workspace Context");
+      expect(result).toContain("soul content");
+    });
+
+    it("includes memory section when MEMORY.md exists", async () => {
+      await fsp.writeFile(path.join(tempDir, "MEMORY.md"), "my memory");
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      await loader.load();
+
+      const result = loader.buildSystemPrompt("base");
+
+      expect(result).toContain("# Memory");
+      expect(result).toContain("my memory");
+    });
+
+    it("uses --- separators between sections", async () => {
+      await fsp.writeFile(path.join(tempDir, "SOUL.md"), "soul");
+
+      const loader = new WorkspaceContextLoader(tempDir);
+      await loader.load();
+
+      const result = loader.buildSystemPrompt("base");
+
+      expect(result).toContain("\n\n---\n\n");
+    });
+  });
+
+  describe("getWorkspacePath", () => {
+    it("returns the configured workspace path", () => {
+      const loader = new WorkspaceContextLoader("/my/workspace");
+      expect(loader.getWorkspacePath()).toBe("/my/workspace");
+    });
+  });
+});

--- a/src/workspace/context-loader.ts
+++ b/src/workspace/context-loader.ts
@@ -1,0 +1,193 @@
+// src/workspace/context-loader.ts — Class-based workspace context loader
+// Loads and caches workspace context files, supports refresh for hot-reload.
+
+import path from "node:path";
+import fs from "node:fs/promises";
+import { createLogger } from "../core/logger.js";
+import { SkillLoader } from "../skills/index.js";
+
+const log = createLogger("workspace:context-loader");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Standard workspace files that contribute to system prompt. */
+export const CONTEXT_FILES = [
+  "SOUL.md",
+  "IDENTITY.md",
+  "USER.md",
+  "TOOLS.md",
+  "AGENTS.md",
+  "BOOTSTRAP.md",
+] as const;
+
+/** Memory-related files loaded separately. */
+export const MEMORY_FILES = [
+  "MEMORY.md",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Loaded workspace context ready for system prompt injection. */
+export interface LoadedContext {
+  /** Combined content from workspace files (SOUL.md, USER.md, etc.) */
+  systemPromptAdditions: string;
+  /** Content from MEMORY.md (+ today's daily note) if present */
+  memory: string | null;
+  /** Skills prompt block (XML format) */
+  skillsPrompt: string;
+  /** Workspace directory path */
+  workspacePath: string;
+  /** Individual file contents, keyed by filename */
+  files: Map<string, string>;
+  /** When the context was last loaded */
+  loadedAt: Date;
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceContextLoader
+// ---------------------------------------------------------------------------
+
+/**
+ * WorkspaceContextLoader — loads and caches workspace context files.
+ *
+ * Reads standard workspace files (SOUL.md, MEMORY.md, IDENTITY.md, etc.)
+ * on startup and provides a combined context string for system prompt
+ * injection. Call {@link refresh} to re-read files from disk (hot-reload).
+ */
+export class WorkspaceContextLoader {
+  private context: LoadedContext | null = null;
+
+  constructor(private workspacePath: string) {}
+
+  /**
+   * Load workspace context from disk.
+   * Reads all standard files and caches the result.
+   * Safe to call multiple times — subsequent calls refresh the cache.
+   */
+  async load(): Promise<LoadedContext> {
+    const files = new Map<string, string>();
+    const additions: string[] = [];
+
+    // Load standard workspace files
+    for (const filename of CONTEXT_FILES) {
+      const content = await this.readFileIfExists(filename);
+      if (content !== null) {
+        files.set(filename, content);
+        additions.push(`## ${filename}\n\n${content}`);
+      }
+    }
+
+    // Load MEMORY.md
+    let memory: string | null = null;
+    const memoryContent = await this.readFileIfExists("MEMORY.md");
+    if (memoryContent !== null) {
+      files.set("MEMORY.md", memoryContent);
+      memory = memoryContent;
+    }
+
+    // Load today's daily note if it exists
+    const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+    const dailyFilename = `memory/${today}.md`;
+    const dailyContent = await this.readFileIfExists(dailyFilename);
+    if (dailyContent !== null) {
+      files.set(dailyFilename, dailyContent);
+      memory = memory
+        ? `${memory}\n\n## Today's Notes\n\n${dailyContent}`
+        : dailyContent;
+    }
+
+    // Load skills
+    const skillLoader = new SkillLoader({ workspacePath: this.workspacePath });
+    const skillsPrompt = await skillLoader.generatePrompt();
+
+    this.context = {
+      systemPromptAdditions: additions.join("\n\n"),
+      memory,
+      skillsPrompt,
+      workspacePath: this.workspacePath,
+      files,
+      loadedAt: new Date(),
+    };
+
+    log.info(`Loaded workspace context (${files.size} file(s)) from ${this.workspacePath}`);
+    return this.context;
+  }
+
+  /**
+   * Refresh context by re-reading all files from disk.
+   * Alias for {@link load} — provided for hot-reload semantics.
+   */
+  async refresh(): Promise<LoadedContext> {
+    log.debug(`Refreshing workspace context for ${this.workspacePath}`);
+    return this.load();
+  }
+
+  /**
+   * Get the cached context. Returns null if {@link load} hasn't been called.
+   */
+  getContext(): LoadedContext | null {
+    return this.context;
+  }
+
+  /**
+   * Get a specific file's content from the cache.
+   * Returns null if the file wasn't found during the last load.
+   */
+  getFile(filename: string): string | null {
+    return this.context?.files.get(filename) ?? null;
+  }
+
+  /**
+   * Build a complete system prompt by combining a base prompt with the loaded context.
+   * Returns the base prompt unchanged if context hasn't been loaded.
+   */
+  buildSystemPrompt(basePrompt: string): string {
+    if (!this.context) {
+      return basePrompt;
+    }
+
+    const parts = [basePrompt];
+
+    parts.push(`# Workspace\n\nYour working directory is: ${this.context.workspacePath}`);
+
+    if (this.context.systemPromptAdditions) {
+      parts.push("# Workspace Context\n\n" + this.context.systemPromptAdditions);
+    }
+
+    if (this.context.skillsPrompt) {
+      parts.push(this.context.skillsPrompt);
+    }
+
+    if (this.context.memory) {
+      parts.push("# Memory\n\n" + this.context.memory);
+    }
+
+    return parts.join("\n\n---\n\n");
+  }
+
+  /**
+   * Get the workspace path this loader is configured for.
+   */
+  getWorkspacePath(): string {
+    return this.workspacePath;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  private async readFileIfExists(filename: string): Promise<string | null> {
+    try {
+      return await fs.readFile(
+        path.join(this.workspacePath, filename),
+        "utf-8",
+      );
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -35,3 +35,15 @@ export {
   reconcileWorkspaceState,
 } from "./state.js";
 export type { WorkspaceState } from "./state.js";
+
+export {
+  WorkspaceContextLoader,
+  CONTEXT_FILES,
+} from "./context-loader.js";
+export type { LoadedContext } from "./context-loader.js";
+
+export { MemoryManager } from "./memory-manager.js";
+export type {
+  MemoryManagerOptions,
+  MemoryWriteResult,
+} from "./memory-manager.js";

--- a/src/workspace/memory-manager.test.ts
+++ b/src/workspace/memory-manager.test.ts
@@ -1,0 +1,278 @@
+// src/workspace/memory-manager.test.ts — Tests for MemoryManager
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { MemoryManager } from "./memory-manager.js";
+
+describe("MemoryManager", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "memory-mgr-"));
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // appendMemory
+  // -------------------------------------------------------------------------
+
+  describe("appendMemory", () => {
+    it("creates MEMORY.md if it does not exist", async () => {
+      const mgr = new MemoryManager(tempDir);
+      const result = await mgr.appendMemory("first entry");
+
+      expect(result.success).toBe(true);
+      expect(result.filePath).toBe(path.join(tempDir, "MEMORY.md"));
+
+      const content = await fsp.readFile(path.join(tempDir, "MEMORY.md"), "utf-8");
+      expect(content).toContain("first entry");
+      // Should include timestamp
+      expect(content).toMatch(/^- \[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it("appends to existing MEMORY.md", async () => {
+      await fsp.writeFile(path.join(tempDir, "MEMORY.md"), "- existing entry");
+
+      const mgr = new MemoryManager(tempDir);
+      const result = await mgr.appendMemory("new entry");
+
+      expect(result.success).toBe(true);
+
+      const content = await fsp.readFile(path.join(tempDir, "MEMORY.md"), "utf-8");
+      expect(content).toContain("- existing entry");
+      expect(content).toContain("new entry");
+    });
+
+    it("creates backup when appending to existing file", async () => {
+      await fsp.writeFile(path.join(tempDir, "MEMORY.md"), "original");
+
+      const mgr = new MemoryManager(tempDir);
+      const result = await mgr.appendMemory("addition");
+
+      expect(result.backupPath).toBe(path.join(tempDir, "MEMORY.md.bak"));
+
+      const backup = await fsp.readFile(result.backupPath!, "utf-8");
+      expect(backup).toBe("original");
+    });
+
+    it("skips backup when disabled", async () => {
+      await fsp.writeFile(path.join(tempDir, "MEMORY.md"), "original");
+
+      const mgr = new MemoryManager(tempDir, { backup: false });
+      const result = await mgr.appendMemory("addition");
+
+      expect(result.success).toBe(true);
+      expect(result.backupPath).toBeUndefined();
+
+      await expect(
+        fsp.stat(path.join(tempDir, "MEMORY.md.bak")),
+      ).rejects.toThrow();
+    });
+
+    it("does not create backup for new files", async () => {
+      const mgr = new MemoryManager(tempDir);
+      const result = await mgr.appendMemory("first");
+
+      expect(result.success).toBe(true);
+      expect(result.backupPath).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // appendDailyNote
+  // -------------------------------------------------------------------------
+
+  describe("appendDailyNote", () => {
+    it("creates memory directory and daily note file", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-12T14:30:00Z"));
+
+      const mgr = new MemoryManager(tempDir);
+      const result = await mgr.appendDailyNote("daily observation");
+
+      expect(result.success).toBe(true);
+      expect(result.filePath).toBe(
+        path.join(tempDir, "memory", "2026-04-12.md"),
+      );
+
+      const content = await fsp.readFile(result.filePath, "utf-8");
+      expect(content).toContain("daily observation");
+      // Should have time-only timestamp
+      expect(content).toMatch(/^- \[\d{2}:\d{2}:\d{2}/);
+    });
+
+    it("appends to existing daily note", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-12T10:00:00Z"));
+
+      await fsp.mkdir(path.join(tempDir, "memory"), { recursive: true });
+      await fsp.writeFile(
+        path.join(tempDir, "memory/2026-04-12.md"),
+        "- [10:00:00.000] morning note",
+      );
+
+      vi.setSystemTime(new Date("2026-04-12T14:30:00Z"));
+
+      const mgr = new MemoryManager(tempDir);
+      const result = await mgr.appendDailyNote("afternoon note");
+
+      expect(result.success).toBe(true);
+
+      const content = await fsp.readFile(
+        path.join(tempDir, "memory/2026-04-12.md"),
+        "utf-8",
+      );
+      expect(content).toContain("morning note");
+      expect(content).toContain("afternoon note");
+    });
+
+    it("creates backup when appending to existing note", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-12T14:00:00Z"));
+
+      await fsp.mkdir(path.join(tempDir, "memory"), { recursive: true });
+      await fsp.writeFile(
+        path.join(tempDir, "memory/2026-04-12.md"),
+        "original",
+      );
+
+      const mgr = new MemoryManager(tempDir);
+      const result = await mgr.appendDailyNote("addition");
+
+      expect(result.backupPath).toBe(
+        path.join(tempDir, "memory/2026-04-12.md.bak"),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // readMemory
+  // -------------------------------------------------------------------------
+
+  describe("readMemory", () => {
+    it("returns null when MEMORY.md does not exist", async () => {
+      const mgr = new MemoryManager(tempDir);
+      expect(await mgr.readMemory()).toBeNull();
+    });
+
+    it("returns content of MEMORY.md", async () => {
+      await fsp.writeFile(path.join(tempDir, "MEMORY.md"), "my memories");
+
+      const mgr = new MemoryManager(tempDir);
+      expect(await mgr.readMemory()).toBe("my memories");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // readDailyNote
+  // -------------------------------------------------------------------------
+
+  describe("readDailyNote", () => {
+    it("returns null when note does not exist", async () => {
+      const mgr = new MemoryManager(tempDir);
+      expect(await mgr.readDailyNote("2026-04-12")).toBeNull();
+    });
+
+    it("reads note by date string", async () => {
+      await fsp.mkdir(path.join(tempDir, "memory"), { recursive: true });
+      await fsp.writeFile(
+        path.join(tempDir, "memory/2026-04-12.md"),
+        "today's content",
+      );
+
+      const mgr = new MemoryManager(tempDir);
+      expect(await mgr.readDailyNote("2026-04-12")).toBe("today's content");
+    });
+
+    it("reads note by Date object", async () => {
+      await fsp.mkdir(path.join(tempDir, "memory"), { recursive: true });
+      await fsp.writeFile(
+        path.join(tempDir, "memory/2026-04-12.md"),
+        "date object note",
+      );
+
+      const mgr = new MemoryManager(tempDir);
+      const result = await mgr.readDailyNote(new Date("2026-04-12T12:00:00Z"));
+      expect(result).toBe("date object note");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listDailyNotes
+  // -------------------------------------------------------------------------
+
+  describe("listDailyNotes", () => {
+    it("returns empty array when memory directory does not exist", async () => {
+      const mgr = new MemoryManager(tempDir);
+      expect(await mgr.listDailyNotes()).toEqual([]);
+    });
+
+    it("returns sorted daily note filenames", async () => {
+      const memDir = path.join(tempDir, "memory");
+      await fsp.mkdir(memDir, { recursive: true });
+      await fsp.writeFile(path.join(memDir, "2026-04-12.md"), "a");
+      await fsp.writeFile(path.join(memDir, "2026-04-10.md"), "b");
+      await fsp.writeFile(path.join(memDir, "2026-04-11.md"), "c");
+
+      const mgr = new MemoryManager(tempDir);
+      const notes = await mgr.listDailyNotes();
+
+      expect(notes).toEqual([
+        "2026-04-10.md",
+        "2026-04-11.md",
+        "2026-04-12.md",
+      ]);
+    });
+
+    it("filters out non-date files", async () => {
+      const memDir = path.join(tempDir, "memory");
+      await fsp.mkdir(memDir, { recursive: true });
+      await fsp.writeFile(path.join(memDir, "2026-04-12.md"), "note");
+      await fsp.writeFile(path.join(memDir, "random.md"), "not a daily note");
+      await fsp.writeFile(path.join(memDir, "MEMORY.md.bak"), "backup");
+
+      const mgr = new MemoryManager(tempDir);
+      const notes = await mgr.listDailyNotes();
+
+      expect(notes).toEqual(["2026-04-12.md"]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ensureMemoryDir
+  // -------------------------------------------------------------------------
+
+  describe("ensureMemoryDir", () => {
+    it("creates memory directory", async () => {
+      const mgr = new MemoryManager(tempDir);
+      await mgr.ensureMemoryDir();
+
+      const stat = await fsp.stat(path.join(tempDir, "memory"));
+      expect(stat.isDirectory()).toBe(true);
+    });
+
+    it("does not throw if directory already exists", async () => {
+      await fsp.mkdir(path.join(tempDir, "memory"), { recursive: true });
+
+      const mgr = new MemoryManager(tempDir);
+      await expect(mgr.ensureMemoryDir()).resolves.not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getWorkspacePath
+  // -------------------------------------------------------------------------
+
+  describe("getWorkspacePath", () => {
+    it("returns the configured workspace path", () => {
+      const mgr = new MemoryManager("/my/workspace");
+      expect(mgr.getWorkspacePath()).toBe("/my/workspace");
+    });
+  });
+});

--- a/src/workspace/memory-manager.ts
+++ b/src/workspace/memory-manager.ts
@@ -1,0 +1,200 @@
+// src/workspace/memory-manager.ts — Memory management for agent workspaces
+// Provides a class-based API for appending to MEMORY.md and daily notes.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createLogger } from "../core/logger.js";
+
+const log = createLogger("workspace:memory");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for the MemoryManager. */
+export interface MemoryManagerOptions {
+  /** Whether to create .bak backups before modifying files. Default: true */
+  backup?: boolean;
+}
+
+/** Result of a memory write operation. */
+export interface MemoryWriteResult {
+  success: boolean;
+  /** Path to the file that was written */
+  filePath: string;
+  /** Path to the backup file, if one was created */
+  backupPath?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// MemoryManager
+// ---------------------------------------------------------------------------
+
+/**
+ * MemoryManager — manages MEMORY.md and daily notes for an agent workspace.
+ *
+ * Provides:
+ * - {@link appendMemory} — append a timestamped entry to MEMORY.md
+ * - {@link appendDailyNote} — append to memory/YYYY-MM-DD.md
+ * - {@link readMemory} — read current MEMORY.md content
+ * - {@link readDailyNote} — read a specific daily note
+ * - {@link listDailyNotes} — list available daily notes
+ *
+ * Automatically creates the memory/ directory if needed.
+ */
+export class MemoryManager {
+  private backup: boolean;
+
+  constructor(
+    private workspacePath: string,
+    options?: MemoryManagerOptions,
+  ) {
+    this.backup = options?.backup ?? true;
+  }
+
+  /**
+   * Append a timestamped entry to MEMORY.md.
+   * Creates the file if it doesn't exist.
+   */
+  async appendMemory(entry: string): Promise<MemoryWriteResult> {
+    const filePath = path.join(this.workspacePath, "MEMORY.md");
+    const timestamp = new Date().toISOString();
+    const timestamped = `- [${timestamp}] ${entry}`;
+
+    return this.appendToFile(filePath, timestamped);
+  }
+
+  /**
+   * Append a timestamped entry to today's daily note (memory/YYYY-MM-DD.md).
+   * Creates the file and memory/ directory if they don't exist.
+   */
+  async appendDailyNote(entry: string): Promise<MemoryWriteResult> {
+    const memoryDir = path.join(this.workspacePath, "memory");
+    await fs.mkdir(memoryDir, { recursive: true });
+
+    const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+    const filePath = path.join(memoryDir, `${today}.md`);
+    const timestamp = new Date().toISOString().split("T")[1].replace("Z", ""); // HH:MM:SS.sss
+    const timestamped = `- [${timestamp}] ${entry}`;
+
+    return this.appendToFile(filePath, timestamped);
+  }
+
+  /**
+   * Read the current contents of MEMORY.md.
+   * Returns null if the file doesn't exist.
+   */
+  async readMemory(): Promise<string | null> {
+    try {
+      return await fs.readFile(
+        path.join(this.workspacePath, "MEMORY.md"),
+        "utf-8",
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Read a specific daily note.
+   * @param date — Date string in YYYY-MM-DD format, or a Date object.
+   * Returns null if the file doesn't exist.
+   */
+  async readDailyNote(date: string | Date): Promise<string | null> {
+    const dateStr = date instanceof Date
+      ? date.toISOString().split("T")[0]
+      : date;
+
+    try {
+      return await fs.readFile(
+        path.join(this.workspacePath, "memory", `${dateStr}.md`),
+        "utf-8",
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * List available daily notes (filenames only, e.g. ["2026-04-10.md", "2026-04-11.md"]).
+   * Returns empty array if memory/ directory doesn't exist.
+   */
+  async listDailyNotes(): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(
+        path.join(this.workspacePath, "memory"),
+      );
+      return entries
+        .filter((e) => /^\d{4}-\d{2}-\d{2}\.md$/.test(e))
+        .sort();
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Ensure the memory/ directory exists within the workspace.
+   */
+  async ensureMemoryDir(): Promise<void> {
+    await fs.mkdir(path.join(this.workspacePath, "memory"), { recursive: true });
+  }
+
+  /**
+   * Get the workspace path this manager is configured for.
+   */
+  getWorkspacePath(): string {
+    return this.workspacePath;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  private async appendToFile(
+    filePath: string,
+    content: string,
+  ): Promise<MemoryWriteResult> {
+    try {
+      let existing = "";
+      let fileExists = false;
+
+      try {
+        existing = await fs.readFile(filePath, "utf-8");
+        fileExists = true;
+      } catch {
+        // File doesn't exist — will create
+      }
+
+      // Create backup if file exists and backup is enabled
+      let backupPath: string | undefined;
+      if (fileExists && this.backup) {
+        backupPath = `${filePath}.bak`;
+        await fs.copyFile(filePath, backupPath);
+        log.debug(`Created backup: ${backupPath}`);
+      }
+
+      // Append with newline separator
+      const newContent = existing
+        ? `${existing}\n${content}`
+        : content;
+
+      await fs.writeFile(filePath, newContent, "utf-8");
+      log.info(`Appended to ${path.basename(filePath)}`);
+
+      return {
+        success: true,
+        filePath,
+        backupPath,
+      };
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.error(`Failed to append to ${filePath}:`, err);
+      return {
+        success: false,
+        filePath,
+        error: errorMessage,
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `WorkspaceContextLoader` class (`src/workspace/context-loader.ts`) that loads and caches workspace context files (SOUL.md, IDENTITY.md, USER.md, TOOLS.md, AGENTS.md, BOOTSTRAP.md, MEMORY.md, daily notes) with `refresh()` for hot-reload and `buildSystemPrompt()` for system prompt injection
- Add `MemoryManager` class (`src/workspace/memory-manager.ts`) with `appendMemory()` (timestamped MEMORY.md entries) and `appendDailyNote()` (timestamped memory/YYYY-MM-DD.md entries), plus `readMemory()`, `readDailyNote()`, and `listDailyNotes()` for retrieval
- Integrate `WorkspaceContextLoader` into `DefaultAgentManager` — when a context loader is provided at agent creation, `reloadWorkspace()` uses its `refresh()` method instead of the functional API
- Export new classes and types from workspace barrel (`src/workspace/index.ts`) and public API (`src/index.ts`)
- 40 new tests covering context loading, memory operations, daily notes, hot-reload refresh, and system prompt building

Closes #196

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — all new tests pass (40/40); 3 pre-existing failures in `src/acp/persistence.test.ts` are unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)