### PR TITLE
feat(tools): add session_status tool (#213)

### DIFF
--- a/src/tools/sessions.test.ts
+++ b/src/tools/sessions.test.ts
@@ -16,6 +16,7 @@ import {
 import { AcpSessionManager } from "../acp/session-manager.js";
 import { AgentMessageBus } from "../acp/message-bus.js";
 import type { AcpConfig } from "../acp/types.js";
+import type { AgentManager } from "../core/types.js";
 
 function createTestContext(overrides?: Partial<SessionsToolContext>): SessionsToolContext {
   const config: AcpConfig = {
@@ -220,7 +221,7 @@ describe("createSessionTools", () => {
     expect(names).toContain("sessions_history");
     expect(names).toContain("sessions_yield");
     expect(names).toContain("sessions_kill");
-    expect(names).toContain("sessions_status");
+    expect(names).toContain("session_status");
     expect(tools).toHaveLength(8);
   });
 });
@@ -979,7 +980,7 @@ describe("sessions_kill", () => {
   });
 });
 
-describe("sessions_status", () => {
+describe("session_status", () => {
   let ctx: SessionsToolContext;
 
   beforeEach(() => {
@@ -988,26 +989,72 @@ describe("sessions_status", () => {
 
   it("returns tool with correct schema", () => {
     const { tool } = createSessionsStatusTool(ctx);
-    expect(tool.name).toBe("sessions_status");
-    expect(tool.parameters.required).toContain("session_id");
+    expect(tool.name).toBe("session_status");
+    // No required params — defaults to current session
+    expect(tool.parameters.properties).toHaveProperty("session_id");
+    expect(tool.parameters.properties).toHaveProperty("sessionKey");
+    expect(tool.parameters.properties).toHaveProperty("model");
   });
 
-  it("returns correct fields for active session", async () => {
+  it("returns enhanced fields for active session", async () => {
     const session = ctx.sessionManager.createSession("agent-a");
     ctx.sessionManager.addMessage(session.id, { role: "user", content: "hello" });
     ctx.sessionManager.addMessage(session.id, { role: "assistant", content: "hi" });
 
-    const { handler } = createSessionsStatusTool(ctx);
+    const statusCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      currentSessionId: session.id,
+    });
+
+    const { handler } = createSessionsStatusTool(statusCtx);
     const result = JSON.parse(await handler({ session_id: session.id }));
 
     expect(result.session_id).toBe(session.id);
     expect(result.agent_id).toBe("agent-a");
     expect(result.status).toBe("active");
-    expect(result.message_count).toBe(2);
     expect(result.thread_id).toBeNull();
+    // Usage stats
+    expect(result.usage.message_count).toBe(2);
+    expect(result.usage.user_messages).toBe(1);
+    expect(result.usage.assistant_messages).toBe(1);
+    expect(result.usage.system_messages).toBe(0);
+    // Session age
+    expect(result.session_age_ms).toBeGreaterThanOrEqual(0);
     // Verify timestamps are valid ISO strings
     expect(new Date(result.created_at).toISOString()).toBe(result.created_at);
     expect(new Date(result.last_activity).toISOString()).toBe(result.last_activity);
+    // Model/provider null without agentManager
+    expect(result.model).toBeNull();
+    expect(result.model_override).toBeNull();
+    expect(result.provider).toBeNull();
+    // Uptime null without startedAt
+    expect(result.uptime_ms).toBeNull();
+    // Linked context null without agentManager
+    expect(result.linked_context).toBeNull();
+  });
+
+  it("defaults to current session when no session_id provided", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    const statusCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      currentSessionId: session.id,
+    });
+
+    const { handler } = createSessionsStatusTool(statusCtx);
+    const result = JSON.parse(await handler({}));
+
+    expect(result.session_id).toBe(session.id);
+    expect(result.agent_id).toBe("agent-a");
+  });
+
+  it("returns error when no session_id and no current session", async () => {
+    const noSessionCtx = createTestContext({ currentSessionId: undefined });
+    const { handler } = createSessionsStatusTool(noSessionCtx);
+    const result = JSON.parse(await handler({}));
+
+    expect(result.error).toContain("No session_id or sessionKey provided");
   });
 
   it("returns thread_id when session is bound to a thread", async () => {
@@ -1037,7 +1084,6 @@ describe("sessions_status", () => {
   });
 
   it("allows status of allowed agent's session", async () => {
-    // agent-b is in allowedAgents
     const session = ctx.sessionManager.createSession("agent-b");
 
     const { handler } = createSessionsStatusTool(ctx);
@@ -1068,12 +1114,162 @@ describe("sessions_status", () => {
     expect(result.error).toContain("Access denied");
   });
 
-  it("returns zero message_count for empty session", async () => {
+  it("returns zero message counts for empty session", async () => {
     const session = ctx.sessionManager.createSession("agent-a");
 
     const { handler } = createSessionsStatusTool(ctx);
     const result = JSON.parse(await handler({ session_id: session.id }));
 
-    expect(result.message_count).toBe(0);
+    expect(result.usage.message_count).toBe(0);
+    expect(result.usage.user_messages).toBe(0);
+    expect(result.usage.assistant_messages).toBe(0);
+    expect(result.usage.system_messages).toBe(0);
+  });
+
+  it("returns uptime when startedAt is provided", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    const startedAt = new Date(Date.now() - 60_000); // started 60s ago
+
+    const uptimeCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      startedAt,
+    });
+
+    const { handler } = createSessionsStatusTool(uptimeCtx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.uptime_ms).toBeGreaterThanOrEqual(59_000);
+    expect(result.uptime_ms).toBeLessThanOrEqual(62_000);
+  });
+
+  it("looks up session by sessionKey (thread ID)", async () => {
+    const session = ctx.sessionManager.createSession("agent-a", "thread-789");
+
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ sessionKey: "thread-789" }));
+
+    expect(result.session_id).toBe(session.id);
+    expect(result.thread_id).toBe("thread-789");
+  });
+
+  it("looks up session by sessionKey (session ID)", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ sessionKey: session.id }));
+
+    expect(result.session_id).toBe(session.id);
+  });
+
+  it("returns error for unknown sessionKey", async () => {
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ sessionKey: "unknown-key" }));
+
+    expect(result.error).toContain("No session found for key");
+  });
+
+  it("sets model override", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    const overrides = new Map<string, string>();
+    const overrideCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      modelOverrides: overrides,
+    });
+
+    const { handler } = createSessionsStatusTool(overrideCtx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, model: "claude-sonnet-4-6" }),
+    );
+
+    expect(result.model_override).toBe("claude-sonnet-4-6");
+    expect(result.model).toBe("claude-sonnet-4-6");
+    expect(overrides.get(session.id)).toBe("claude-sonnet-4-6");
+  });
+
+  it("resets model override with model=default", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    const overrides = new Map<string, string>([[session.id, "claude-sonnet-4-6"]]);
+    const overrideCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      modelOverrides: overrides,
+    });
+
+    const { handler } = createSessionsStatusTool(overrideCtx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, model: "default" }),
+    );
+
+    expect(result.model_override).toBeNull();
+    expect(result.model).toBeNull(); // No agentManager, so falls back to null
+    expect(overrides.has(session.id)).toBe(false);
+  });
+
+  it("returns error when model param used without modelOverrides support", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+
+    // Default ctx has no modelOverrides
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(
+      await handler({ session_id: session.id, model: "claude-sonnet-4-6" }),
+    );
+
+    expect(result.error).toContain("Model overrides not supported");
+  });
+
+  it("returns model and provider from agentManager", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+
+    const mockAgentManager: AgentManager = {
+      create: async () => { throw new Error("not implemented"); },
+      get: () => undefined,
+      list: () => [
+        {
+          id: "agent-a",
+          systemPrompt: "test",
+          provider: {
+            type: "anthropic" as const,
+            model: "claude-opus-4-6",
+            baseUrl: "https://api.anthropic.com",
+          },
+        },
+      ],
+      update: async () => { throw new Error("not implemented"); },
+      delete: async () => {},
+      getPrompt: async () => "",
+      updatePrompt: async () => {},
+      reloadWorkspace: async () => {},
+    };
+
+    const managerCtx = createTestContext({
+      sessionManager: ctx.sessionManager,
+      messageBus: ctx.messageBus,
+      agentManager: mockAgentManager,
+    });
+
+    const { handler } = createSessionsStatusTool(managerCtx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.model).toBe("claude-opus-4-6");
+    expect(result.provider).toBe("anthropic");
+    expect(result.provider_base_url).toBe("https://api.anthropic.com");
+  });
+
+  it("counts system messages in usage stats", async () => {
+    const session = ctx.sessionManager.createSession("agent-a");
+    ctx.sessionManager.addMessage(session.id, { role: "user", content: "q1" });
+    ctx.sessionManager.addMessage(session.id, { role: "assistant", content: "a1" });
+    ctx.sessionManager.addMessage(session.id, { role: "system", content: "sys" });
+    ctx.sessionManager.addMessage(session.id, { role: "user", content: "q2" });
+
+    const { handler } = createSessionsStatusTool(ctx);
+    const result = JSON.parse(await handler({ session_id: session.id }));
+
+    expect(result.usage.message_count).toBe(4);
+    expect(result.usage.user_messages).toBe(2);
+    expect(result.usage.assistant_messages).toBe(1);
+    expect(result.usage.system_messages).toBe(1);
   });
 });

--- a/src/tools/sessions.ts
+++ b/src/tools/sessions.ts
@@ -2,7 +2,7 @@
 // Exposes AcpSessionManager and AgentMessageBus to agents as callable tools.
 
 import { createLogger } from "../core/logger.js";
-import type { Tool } from "../core/types.js";
+import type { AgentManager, Tool } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";
 import type { AcpSessionManager } from "../acp/session-manager.js";
 import type { AgentMessageBus, AgentMessage } from "../acp/message-bus.js";
@@ -22,6 +22,12 @@ export interface SessionsToolContext {
   currentAgentId: string;
   /** Session ID of the calling agent's current session */
   currentSessionId?: string;
+  /** Agent manager for model/provider/workspace lookups (used by session_status) */
+  agentManager?: AgentManager;
+  /** Timestamp when the process started (used by session_status for uptime) */
+  startedAt?: Date;
+  /** Per-session model overrides, keyed by session ID */
+  modelOverrides?: Map<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -845,40 +851,87 @@ export function createSessionsKillTool(
 }
 
 // ---------------------------------------------------------------------------
-// sessions_status
+// session_status
 // ---------------------------------------------------------------------------
 
+/** Duck-typed subset of DefaultAgentManager for workspace access */
+interface AgentManagerWithWorkspace {
+  getWorkspace?: (id: string) => {
+    systemPromptAdditions?: string;
+    memory?: string | null;
+    workspacePath?: string;
+    skillsPrompt?: string;
+  } | undefined;
+}
+
 /**
- * Create the `sessions_status` tool.
+ * Create the `session_status` tool.
  *
- * Returns detailed status and metadata for a specific ACP session.
- * Access control: same as sessions_kill.
+ * Returns rich session status including model, provider, usage stats, uptime,
+ * and linked workspace context. Optionally sets a per-session model override
+ * or queries another session by session key.
  */
 export function createSessionsStatusTool(
   ctx: SessionsToolContext,
 ): { tool: Tool; handler: ToolHandler } {
   return {
     tool: {
-      name: "sessions_status",
+      name: "session_status",
       description:
-        "Get the current status and metadata for a specific ACP session.",
+        "Get detailed session status including model, provider, usage stats, uptime, " +
+        "and linked context. Pass `model` to set a per-session model override " +
+        '(use model="default" to reset). Pass `sessionKey` to view another session.',
       parameters: {
         type: "object",
         properties: {
           session_id: {
             type: "string",
-            description: "Session ID to query",
+            description: "Session ID to query (defaults to current session)",
+          },
+          sessionKey: {
+            type: "string",
+            description: "Look up a session by its key instead of ID",
+          },
+          model: {
+            type: "string",
+            description:
+              'Set a per-session model override. Use "default" to reset to the agent\'s configured model.',
           },
         },
-        required: ["session_id"],
       },
     },
     handler: async (args) => {
-      const { session_id } = args as { session_id: string };
+      const { session_id, sessionKey, model } = args as {
+        session_id?: string;
+        sessionKey?: string;
+        model?: string;
+      };
 
-      const session = ctx.sessionManager.getSession(session_id);
+      // Resolve target session ID
+      let targetId = session_id ?? ctx.currentSessionId;
+
+      // sessionKey lookup via ACP sessions (match by session key or thread ID)
+      if (sessionKey) {
+        const allSessions = ctx.sessionManager.listSessions();
+        const match = allSessions.find(
+          (s) => s.id === sessionKey || s.threadId === sessionKey,
+        );
+        if (match) {
+          targetId = match.id;
+        } else {
+          return JSON.stringify({ error: `No session found for key: ${sessionKey}` });
+        }
+      }
+
+      if (!targetId) {
+        return JSON.stringify({
+          error: "No session_id or sessionKey provided and no current session",
+        });
+      }
+
+      const session = ctx.sessionManager.getSession(targetId);
       if (!session) {
-        return JSON.stringify({ error: `Session not found: ${session_id}` });
+        return JSON.stringify({ error: `Session not found: ${targetId}` });
       }
 
       // Access control: agent must own the session OR session's agent is in allowedAgents
@@ -887,10 +940,76 @@ export function createSessionsStatusTool(
       const isAllowed = allowedAgents.includes(session.agentId);
 
       if (!isOwner && !isAllowed) {
-        return JSON.stringify({
-          error: `Access denied to session: ${session_id}`,
-        });
+        return JSON.stringify({ error: `Access denied to session: ${targetId}` });
       }
+
+      // Handle model override
+      if (model !== undefined) {
+        if (!ctx.modelOverrides) {
+          return JSON.stringify({ error: "Model overrides not supported in this context" });
+        }
+        if (model === "default") {
+          ctx.modelOverrides.delete(targetId);
+          log.info("Model override reset", {
+            sessionId: targetId,
+            agentId: ctx.currentAgentId,
+          });
+        } else {
+          ctx.modelOverrides.set(targetId, model);
+          log.info("Model override set", {
+            sessionId: targetId,
+            model,
+            agentId: ctx.currentAgentId,
+          });
+        }
+      }
+
+      // Gather agent config for model/provider info
+      let agentModel: string | null = null;
+      let providerType: string | null = null;
+      let providerBaseUrl: string | null = null;
+      let workspaceFiles: string[] | null = null;
+
+      if (ctx.agentManager) {
+        const configs = ctx.agentManager.list();
+        const agentConfig = configs.find((c) => c.id === session.agentId);
+        if (agentConfig) {
+          agentModel = agentConfig.provider?.model ?? null;
+          providerType = agentConfig.provider?.type ?? null;
+          providerBaseUrl = agentConfig.provider?.baseUrl ?? null;
+        }
+
+        // Linked context: check workspace
+        const mgr = ctx.agentManager as AgentManagerWithWorkspace;
+        const workspace = mgr.getWorkspace?.(session.agentId);
+        if (workspace) {
+          workspaceFiles = [];
+          if (workspace.systemPromptAdditions) workspaceFiles.push("SOUL.md");
+          if (workspace.memory) workspaceFiles.push("MEMORY.md");
+          if (workspace.skillsPrompt) workspaceFiles.push("SKILLS");
+          if (workspace.workspacePath) workspaceFiles.push(workspace.workspacePath);
+        }
+      }
+
+      // Effective model (override takes precedence)
+      const modelOverride = ctx.modelOverrides?.get(targetId) ?? null;
+      const effectiveModel = modelOverride ?? agentModel;
+
+      // Usage stats from message history
+      const userMessages = session.history.filter((m) => m.role === "user").length;
+      const assistantMessages = session.history.filter(
+        (m) => m.role === "assistant",
+      ).length;
+      const systemMessages = session.history.filter(
+        (m) => m.role === "system",
+      ).length;
+
+      // Uptime
+      const now = new Date();
+      const uptimeMs = ctx.startedAt
+        ? now.getTime() - ctx.startedAt.getTime()
+        : null;
+      const sessionAgeMs = now.getTime() - session.createdAt.getTime();
 
       return JSON.stringify({
         session_id: session.id,
@@ -898,8 +1017,20 @@ export function createSessionsStatusTool(
         status: session.status,
         created_at: session.createdAt.toISOString(),
         last_activity: session.lastActivityAt.toISOString(),
-        message_count: session.history.length,
         thread_id: session.threadId ?? null,
+        model: effectiveModel,
+        model_override: modelOverride,
+        provider: providerType,
+        provider_base_url: providerBaseUrl ?? null,
+        usage: {
+          message_count: session.history.length,
+          user_messages: userMessages,
+          assistant_messages: assistantMessages,
+          system_messages: systemMessages,
+        },
+        uptime_ms: uptimeMs,
+        session_age_ms: sessionAgeMs,
+        linked_context: workspaceFiles,
       });
     },
   };


### PR DESCRIPTION
## Summary
- Adds new `session_status` tool (singular) that returns rich session metadata: model, provider, usage stats (per-role message counts), uptime, session age, and linked workspace context
- Extends `SessionsToolContext` with `agentManager`, `startedAt`, and `modelOverrides` fields for enhanced introspection
- Supports `sessionKey` lookup (by thread ID or session ID), and per-session model overrides via `model` parameter

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 85 session tool tests pass (`npx vitest run src/tools/sessions.test.ts`)
- [x] Tests cover: status retrieval, session not found, default-to-current-session, uptime calc, sessionKey lookup, model override set/reset, agentManager model/provider resolution, per-role usage stats

Closes #213

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>