### PR TITLE
feat(#199): Reply & reaction support

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -387,4 +387,8 @@ export type CronActionConfig =
 export interface Transport {
   start(): Promise<void>;
   stop(): Promise<void>;
+  /** Reply to a specific message by ID. */
+  reply?(messageId: string, content: string): Promise<{ messageId: string }>;
+  /** Add a reaction emoji to a specific message by ID. */
+  react?(messageId: string, emoji: string): Promise<void>;
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -89,3 +89,10 @@ export {
   createExecTools,
 } from "./exec.js";
 export type { ExecToolOptions, ProcessInfo } from "./exec.js";
+
+export {
+  createMessageReplyTool,
+  createMessageReactTool,
+  createReplyReactTools,
+} from "./reply-react.js";
+export type { ReplyReactToolContext } from "./reply-react.js";

--- a/src/tools/reply-react.test.ts
+++ b/src/tools/reply-react.test.ts
@@ -1,0 +1,120 @@
+// src/tools/reply-react.test.ts — Unit tests for message_reply and message_react tools
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createMessageReplyTool,
+  createMessageReactTool,
+  createReplyReactTools,
+  type ReplyReactToolContext,
+} from "./reply-react.js";
+import type { Transport } from "../core/types.js";
+
+function createMockTransport(overrides: Partial<Transport> = {}): Transport {
+  return {
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue({ messageId: "reply-456" }),
+    react: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("message_reply tool", () => {
+  let ctx: ReplyReactToolContext;
+  let transport: Transport;
+
+  beforeEach(() => {
+    transport = createMockTransport();
+    ctx = { transport };
+  });
+
+  it("sends a reply and returns the reply message ID", async () => {
+    const { handler } = createMessageReplyTool(ctx);
+    const result = JSON.parse(await handler({ message_id: "msg-123", content: "Thanks!" }));
+    expect(result.success).toBe(true);
+    expect(result.reply_message_id).toBe("reply-456");
+    expect(transport.reply).toHaveBeenCalledWith("msg-123", "Thanks!");
+  });
+
+  it("returns error for empty message_id", async () => {
+    const { handler } = createMessageReplyTool(ctx);
+    const result = JSON.parse(await handler({ message_id: "", content: "Hello" }));
+    expect(result.error).toBe("message_id must not be empty");
+  });
+
+  it("returns error for empty content", async () => {
+    const { handler } = createMessageReplyTool(ctx);
+    const result = JSON.parse(await handler({ message_id: "msg-1", content: "" }));
+    expect(result.error).toBe("content must not be empty");
+  });
+
+  it("returns error when transport does not support replies", async () => {
+    const noReplyTransport = createMockTransport({ reply: undefined });
+    const { handler } = createMessageReplyTool({ transport: noReplyTransport });
+    const result = JSON.parse(await handler({ message_id: "msg-1", content: "hi" }));
+    expect(result.error).toBe("Transport does not support replies");
+  });
+
+  it("returns transport error on failure", async () => {
+    const failingTransport = createMockTransport({
+      reply: vi.fn().mockRejectedValue(new Error("Message not found: msg-999")),
+    });
+    const { handler } = createMessageReplyTool({ transport: failingTransport });
+    const result = JSON.parse(await handler({ message_id: "msg-999", content: "hi" }));
+    expect(result.error).toBe("Message not found: msg-999");
+  });
+});
+
+describe("message_react tool", () => {
+  let ctx: ReplyReactToolContext;
+  let transport: Transport;
+
+  beforeEach(() => {
+    transport = createMockTransport();
+    ctx = { transport };
+  });
+
+  it("adds a reaction successfully", async () => {
+    const { handler } = createMessageReactTool(ctx);
+    const result = JSON.parse(await handler({ message_id: "msg-123", emoji: "👍" }));
+    expect(result.success).toBe(true);
+    expect(transport.react).toHaveBeenCalledWith("msg-123", "👍");
+  });
+
+  it("returns error for empty message_id", async () => {
+    const { handler } = createMessageReactTool(ctx);
+    const result = JSON.parse(await handler({ message_id: "", emoji: "👍" }));
+    expect(result.error).toBe("message_id must not be empty");
+  });
+
+  it("returns error for empty emoji", async () => {
+    const { handler } = createMessageReactTool(ctx);
+    const result = JSON.parse(await handler({ message_id: "msg-1", emoji: "" }));
+    expect(result.error).toBe("emoji must not be empty");
+  });
+
+  it("returns error when transport does not support reactions", async () => {
+    const noReactTransport = createMockTransport({ react: undefined });
+    const { handler } = createMessageReactTool({ transport: noReactTransport });
+    const result = JSON.parse(await handler({ message_id: "msg-1", emoji: "👍" }));
+    expect(result.error).toBe("Transport does not support reactions");
+  });
+
+  it("returns transport error on failure", async () => {
+    const failingTransport = createMockTransport({
+      react: vi.fn().mockRejectedValue(new Error("Unknown Emoji")),
+    });
+    const { handler } = createMessageReactTool({ transport: failingTransport });
+    const result = JSON.parse(await handler({ message_id: "msg-1", emoji: "nope" }));
+    expect(result.error).toBe("Unknown Emoji");
+  });
+});
+
+describe("createReplyReactTools", () => {
+  it("returns both tools", () => {
+    const transport = createMockTransport();
+    const tools = createReplyReactTools({ transport });
+    expect(tools).toHaveLength(2);
+    expect(tools.map((t) => t.tool.name)).toEqual(["message_reply", "message_react"]);
+  });
+});

--- a/src/tools/reply-react.ts
+++ b/src/tools/reply-react.ts
@@ -1,0 +1,170 @@
+// src/tools/reply-react.ts — message_reply and message_react tools
+
+import { createLogger } from "../core/logger.js";
+import type { Tool, Transport } from "../core/types.js";
+import type { ToolHandler } from "../core/tools.js";
+
+const log = createLogger("tools:reply-react");
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+/** Runtime context required by reply/react tools. */
+export interface ReplyReactToolContext {
+  transport: Transport;
+}
+
+// ---------------------------------------------------------------------------
+// message_reply
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `message_reply` tool.
+ *
+ * Replies to a specific message by its ID via the current transport.
+ */
+export function createMessageReplyTool(
+  ctx: ReplyReactToolContext,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "message_reply",
+      description:
+        "Reply to a specific message by its ID. The reply is threaded / linked " +
+        "to the original message in the transport (e.g. Discord reply).",
+      parameters: {
+        type: "object",
+        properties: {
+          message_id: {
+            type: "string",
+            description: "ID of the message to reply to",
+          },
+          content: {
+            type: "string",
+            description: "Reply text content",
+          },
+        },
+        required: ["message_id", "content"],
+      },
+    },
+    handler: async (args) => {
+      const { message_id, content } = args as {
+        message_id: string;
+        content: string;
+      };
+
+      if (!message_id || !message_id.trim()) {
+        return JSON.stringify({ error: "message_id must not be empty" });
+      }
+      if (!content || !content.trim()) {
+        return JSON.stringify({ error: "content must not be empty" });
+      }
+      if (!ctx.transport.reply) {
+        return JSON.stringify({ error: "Transport does not support replies" });
+      }
+
+      try {
+        const result = await ctx.transport.reply(message_id, content);
+
+        log.info("Message reply sent", {
+          targetMessageId: message_id,
+          replyMessageId: result.messageId,
+        });
+
+        return JSON.stringify({
+          success: true,
+          reply_message_id: result.messageId,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("Message reply failed", { messageId: message_id, error: message });
+        return JSON.stringify({ error: message });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// message_react
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `message_react` tool.
+ *
+ * Adds an emoji reaction to a specific message by its ID via the current transport.
+ */
+export function createMessageReactTool(
+  ctx: ReplyReactToolContext,
+): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "message_react",
+      description:
+        "Add an emoji reaction to a specific message by its ID. " +
+        "Use standard Unicode emoji (e.g. \"\u{1F44D}\") or platform-specific emoji identifiers.",
+      parameters: {
+        type: "object",
+        properties: {
+          message_id: {
+            type: "string",
+            description: "ID of the message to react to",
+          },
+          emoji: {
+            type: "string",
+            description: "Emoji to react with (Unicode emoji or custom emoji identifier)",
+          },
+        },
+        required: ["message_id", "emoji"],
+      },
+    },
+    handler: async (args) => {
+      const { message_id, emoji } = args as {
+        message_id: string;
+        emoji: string;
+      };
+
+      if (!message_id || !message_id.trim()) {
+        return JSON.stringify({ error: "message_id must not be empty" });
+      }
+      if (!emoji || !emoji.trim()) {
+        return JSON.stringify({ error: "emoji must not be empty" });
+      }
+      if (!ctx.transport.react) {
+        return JSON.stringify({ error: "Transport does not support reactions" });
+      }
+
+      try {
+        await ctx.transport.react(message_id, emoji);
+
+        log.info("Reaction added", {
+          messageId: message_id,
+          emoji,
+        });
+
+        return JSON.stringify({ success: true });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("Reaction failed", { messageId: message_id, emoji, error: message });
+        return JSON.stringify({ error: message });
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create both reply and react tools with shared context.
+ * Returns an array of tool+handler pairs ready for registration.
+ */
+export function createReplyReactTools(
+  ctx: ReplyReactToolContext,
+): { tool: Tool; handler: ToolHandler }[] {
+  return [
+    createMessageReplyTool(ctx),
+    createMessageReactTool(ctx),
+  ];
+}

--- a/src/transports/cli.test.ts
+++ b/src/transports/cli.test.ts
@@ -1,0 +1,46 @@
+// src/transports/cli.test.ts — Unit tests for CliTransport
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { CliTransport } from "./cli.js";
+
+describe("CliTransport", () => {
+  let transport: CliTransport;
+
+  beforeEach(() => {
+    transport = new CliTransport();
+  });
+
+  describe("start/stop", () => {
+    it("starts and stops without error", async () => {
+      await transport.start();
+      await transport.stop();
+    });
+  });
+
+  describe("reply", () => {
+    it("returns a reply message ID", async () => {
+      await transport.start();
+      const result = await transport.reply("msg-123", "Hello back!");
+      expect(result.messageId).toMatch(/^cli-reply-\d+$/);
+    });
+
+    it("throws when transport is not started", async () => {
+      await expect(transport.reply("msg-123", "Hello")).rejects.toThrow(
+        "CLI transport not started",
+      );
+    });
+  });
+
+  describe("react", () => {
+    it("completes without error", async () => {
+      await transport.start();
+      await expect(transport.react("msg-123", "👍")).resolves.toBeUndefined();
+    });
+
+    it("throws when transport is not started", async () => {
+      await expect(transport.react("msg-123", "👍")).rejects.toThrow(
+        "CLI transport not started",
+      );
+    });
+  });
+});

--- a/src/transports/cli.ts
+++ b/src/transports/cli.ts
@@ -1,0 +1,38 @@
+// src/transports/cli.ts — CLI transport with simulated reply & reaction support
+
+import type { Transport } from "../core/types.js";
+import { createLogger } from "../core/logger.js";
+
+const log = createLogger("transport:cli");
+
+/**
+ * CliTransport — a minimal transport for local/testing use.
+ *
+ * Implements reply() and react() by printing simulated output to the console
+ * rather than sending to an external service.
+ */
+export class CliTransport implements Transport {
+  private started = false;
+
+  async start(): Promise<void> {
+    this.started = true;
+    log.info("CLI transport started");
+  }
+
+  async stop(): Promise<void> {
+    this.started = false;
+    log.info("CLI transport stopped");
+  }
+
+  async reply(messageId: string, content: string): Promise<{ messageId: string }> {
+    if (!this.started) throw new Error("CLI transport not started");
+    const replyId = `cli-reply-${Date.now()}`;
+    log.info(`[Reply to ${messageId}] ${content}`);
+    return { messageId: replyId };
+  }
+
+  async react(messageId: string, emoji: string): Promise<void> {
+    if (!this.started) throw new Error("CLI transport not started");
+    log.info(`[React to ${messageId}] ${emoji}`);
+  }
+}

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -680,6 +680,51 @@ export class DiscordTransport implements Transport {
       .trim();
   }
 
+  // ---------------------------------------------------------------------------
+  // Reply & reaction
+  // ---------------------------------------------------------------------------
+
+  async reply(messageId: string, content: string): Promise<{ messageId: string }> {
+    if (!this.ready) throw new Error("Discord transport not ready");
+
+    // Search all channels the bot can see for the message
+    const channels = this.client.channels.cache.values();
+    for (const ch of channels) {
+      if (!("messages" in ch)) continue;
+      try {
+        const target = await (ch as SendableChannel).messages.fetch(messageId);
+        if (target) {
+          const sent = await target.reply(content);
+          return { messageId: sent.id };
+        }
+      } catch {
+        // Message not in this channel, continue searching
+      }
+    }
+
+    throw new Error(`Message not found: ${messageId}`);
+  }
+
+  async react(messageId: string, emoji: string): Promise<void> {
+    if (!this.ready) throw new Error("Discord transport not ready");
+
+    const channels = this.client.channels.cache.values();
+    for (const ch of channels) {
+      if (!("messages" in ch)) continue;
+      try {
+        const target = await (ch as SendableChannel).messages.fetch(messageId);
+        if (target) {
+          await target.react(emoji);
+          return;
+        }
+      } catch {
+        // Message not in this channel, continue searching
+      }
+    }
+
+    throw new Error(`Message not found: ${messageId}`);
+  }
+
   private startTyping(channel: SendableChannel): { stop: () => void } {
     let active = true;
 


### PR DESCRIPTION
## Summary
- Add optional `reply(messageId, content)` and `react(messageId, emoji)` methods to the `Transport` interface
- Implement in `DiscordTransport` using Discord.js message references and reactions API (searches channel cache for target message)
- Create new `CliTransport` with simulated console output for local/testing use
- Add `message_reply` and `message_react` agent tools with input validation, transport-capability checks, and error handling (message not found, invalid emoji, permission denied)
- Export new tools and types from `src/tools/index.ts` barrel

## Test plan
- [x] New unit tests for `CliTransport` (start/stop, reply, react, error when not started)
- [x] New unit tests for `message_reply` tool (success, empty message_id, empty content, unsupported transport, transport errors)
- [x] New unit tests for `message_react` tool (success, empty message_id, empty emoji, unsupported transport, transport errors)
- [x] `createReplyReactTools` factory returns both tools
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 1846 tests pass (79 test files including 2 new)

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)