### PR TITLE
fix(#199): wire reply/react tools into runtime + channel_id optimization

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import {
 } from "./core/tools.js";
 import { createSelfIterationTools } from "./tools/self-iteration.js";
 import { createIterateCodebaseTool } from "./tools/iterate-codebase.js";
+import { createReplyReactTools, LazyTransportContext } from "./tools/reply-react.js";
 import {
   getConfigPath,
   getIsotopesHome,
@@ -286,6 +287,7 @@ async function main() {
 
   // Create agents with workspace tools
   const agentWorkspaces = new Map<string, string>();
+  const transportContexts = new Map<string, LazyTransportContext>();
   const isSingleAgent = config.agents.length === 1;
 
   for (const agentFile of config.agents) {
@@ -354,6 +356,13 @@ async function main() {
         allowedWorkspaces: agentAllowedWorkspaces,
       });
       toolRegistry.register(iterTool, iterHandler);
+    }
+
+    // Register reply/react tools (transport is bound lazily after Discord starts)
+    const transportCtx = new LazyTransportContext();
+    transportContexts.set(agentConfig.id, transportCtx);
+    for (const { tool, handler } of createReplyReactTools(transportCtx)) {
+      toolRegistry.register(tool, handler);
     }
 
     // Build tool guard prompt and store it for hot-reload persistence (M11.4)
@@ -580,6 +589,15 @@ async function main() {
 
       await discordManager.start();
       logger.info(`Discord transport started (${discordManager.size} account(s))`);
+
+      // Bind the first Discord transport to reply/react tools for each agent
+      const firstTransport = discordManager.getAll().values().next().value;
+      if (firstTransport) {
+        for (const [agentId, ctx] of transportContexts) {
+          ctx.setTransport(firstTransport);
+          logger.debug(`Bound Discord transport for reply/react tools (agent: ${agentId})`);
+        }
+      }
     }
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -387,8 +387,8 @@ export type CronActionConfig =
 export interface Transport {
   start(): Promise<void>;
   stop(): Promise<void>;
-  /** Reply to a specific message by ID. */
-  reply?(messageId: string, content: string): Promise<{ messageId: string }>;
-  /** Add a reaction emoji to a specific message by ID. */
-  react?(messageId: string, emoji: string): Promise<void>;
+  /** Reply to a specific message by ID. If channelId is provided, skip O(n) channel scan. */
+  reply?(messageId: string, content: string, channelId?: string): Promise<{ messageId: string }>;
+  /** Add a reaction emoji to a specific message by ID. If channelId is provided, skip O(n) channel scan. */
+  react?(messageId: string, emoji: string, channelId?: string): Promise<void>;
 }

--- a/src/tools/reply-react.test.ts
+++ b/src/tools/reply-react.test.ts
@@ -5,6 +5,7 @@ import {
   createMessageReplyTool,
   createMessageReactTool,
   createReplyReactTools,
+  LazyTransportContext,
   type ReplyReactToolContext,
 } from "./reply-react.js";
 import type { Transport } from "../core/types.js";
@@ -19,13 +20,17 @@ function createMockTransport(overrides: Partial<Transport> = {}): Transport {
   };
 }
 
+function wrapTransport(transport: Transport): ReplyReactToolContext {
+  return { getTransport: () => transport };
+}
+
 describe("message_reply tool", () => {
   let ctx: ReplyReactToolContext;
   let transport: Transport;
 
   beforeEach(() => {
     transport = createMockTransport();
-    ctx = { transport };
+    ctx = wrapTransport(transport);
   });
 
   it("sends a reply and returns the reply message ID", async () => {
@@ -33,7 +38,16 @@ describe("message_reply tool", () => {
     const result = JSON.parse(await handler({ message_id: "msg-123", content: "Thanks!" }));
     expect(result.success).toBe(true);
     expect(result.reply_message_id).toBe("reply-456");
-    expect(transport.reply).toHaveBeenCalledWith("msg-123", "Thanks!");
+    expect(transport.reply).toHaveBeenCalledWith("msg-123", "Thanks!", undefined);
+  });
+
+  it("passes channel_id to transport when provided", async () => {
+    const { handler } = createMessageReplyTool(ctx);
+    const result = JSON.parse(
+      await handler({ message_id: "msg-123", channel_id: "ch-1", content: "Thanks!" }),
+    );
+    expect(result.success).toBe(true);
+    expect(transport.reply).toHaveBeenCalledWith("msg-123", "Thanks!", "ch-1");
   });
 
   it("returns error for empty message_id", async () => {
@@ -48,9 +62,15 @@ describe("message_reply tool", () => {
     expect(result.error).toBe("content must not be empty");
   });
 
+  it("returns error when transport is not available", async () => {
+    const { handler } = createMessageReplyTool({ getTransport: () => undefined });
+    const result = JSON.parse(await handler({ message_id: "msg-1", content: "hi" }));
+    expect(result.error).toBe("Transport not available");
+  });
+
   it("returns error when transport does not support replies", async () => {
     const noReplyTransport = createMockTransport({ reply: undefined });
-    const { handler } = createMessageReplyTool({ transport: noReplyTransport });
+    const { handler } = createMessageReplyTool(wrapTransport(noReplyTransport));
     const result = JSON.parse(await handler({ message_id: "msg-1", content: "hi" }));
     expect(result.error).toBe("Transport does not support replies");
   });
@@ -59,7 +79,7 @@ describe("message_reply tool", () => {
     const failingTransport = createMockTransport({
       reply: vi.fn().mockRejectedValue(new Error("Message not found: msg-999")),
     });
-    const { handler } = createMessageReplyTool({ transport: failingTransport });
+    const { handler } = createMessageReplyTool(wrapTransport(failingTransport));
     const result = JSON.parse(await handler({ message_id: "msg-999", content: "hi" }));
     expect(result.error).toBe("Message not found: msg-999");
   });
@@ -71,19 +91,28 @@ describe("message_react tool", () => {
 
   beforeEach(() => {
     transport = createMockTransport();
-    ctx = { transport };
+    ctx = wrapTransport(transport);
   });
 
   it("adds a reaction successfully", async () => {
     const { handler } = createMessageReactTool(ctx);
-    const result = JSON.parse(await handler({ message_id: "msg-123", emoji: "👍" }));
+    const result = JSON.parse(await handler({ message_id: "msg-123", emoji: "\u{1F44D}" }));
     expect(result.success).toBe(true);
-    expect(transport.react).toHaveBeenCalledWith("msg-123", "👍");
+    expect(transport.react).toHaveBeenCalledWith("msg-123", "\u{1F44D}", undefined);
+  });
+
+  it("passes channel_id to transport when provided", async () => {
+    const { handler } = createMessageReactTool(ctx);
+    const result = JSON.parse(
+      await handler({ message_id: "msg-123", channel_id: "ch-2", emoji: "\u{1F44D}" }),
+    );
+    expect(result.success).toBe(true);
+    expect(transport.react).toHaveBeenCalledWith("msg-123", "\u{1F44D}", "ch-2");
   });
 
   it("returns error for empty message_id", async () => {
     const { handler } = createMessageReactTool(ctx);
-    const result = JSON.parse(await handler({ message_id: "", emoji: "👍" }));
+    const result = JSON.parse(await handler({ message_id: "", emoji: "\u{1F44D}" }));
     expect(result.error).toBe("message_id must not be empty");
   });
 
@@ -93,10 +122,16 @@ describe("message_react tool", () => {
     expect(result.error).toBe("emoji must not be empty");
   });
 
+  it("returns error when transport is not available", async () => {
+    const { handler } = createMessageReactTool({ getTransport: () => undefined });
+    const result = JSON.parse(await handler({ message_id: "msg-1", emoji: "\u{1F44D}" }));
+    expect(result.error).toBe("Transport not available");
+  });
+
   it("returns error when transport does not support reactions", async () => {
     const noReactTransport = createMockTransport({ react: undefined });
-    const { handler } = createMessageReactTool({ transport: noReactTransport });
-    const result = JSON.parse(await handler({ message_id: "msg-1", emoji: "👍" }));
+    const { handler } = createMessageReactTool(wrapTransport(noReactTransport));
+    const result = JSON.parse(await handler({ message_id: "msg-1", emoji: "\u{1F44D}" }));
     expect(result.error).toBe("Transport does not support reactions");
   });
 
@@ -104,16 +139,45 @@ describe("message_react tool", () => {
     const failingTransport = createMockTransport({
       react: vi.fn().mockRejectedValue(new Error("Unknown Emoji")),
     });
-    const { handler } = createMessageReactTool({ transport: failingTransport });
+    const { handler } = createMessageReactTool(wrapTransport(failingTransport));
     const result = JSON.parse(await handler({ message_id: "msg-1", emoji: "nope" }));
     expect(result.error).toBe("Unknown Emoji");
+  });
+});
+
+describe("LazyTransportContext", () => {
+  it("returns undefined before transport is set", () => {
+    const ctx = new LazyTransportContext();
+    expect(ctx.getTransport()).toBeUndefined();
+  });
+
+  it("returns transport after setTransport is called", () => {
+    const ctx = new LazyTransportContext();
+    const transport = createMockTransport();
+    ctx.setTransport(transport);
+    expect(ctx.getTransport()).toBe(transport);
+  });
+
+  it("works end-to-end with tool handlers", async () => {
+    const ctx = new LazyTransportContext();
+    const { handler: replyHandler } = createMessageReplyTool(ctx);
+
+    // Before transport is set → error
+    const before = JSON.parse(await replyHandler({ message_id: "m1", content: "hi" }));
+    expect(before.error).toBe("Transport not available");
+
+    // After transport is set → success
+    const transport = createMockTransport();
+    ctx.setTransport(transport);
+    const after = JSON.parse(await replyHandler({ message_id: "m1", content: "hi" }));
+    expect(after.success).toBe(true);
   });
 });
 
 describe("createReplyReactTools", () => {
   it("returns both tools", () => {
     const transport = createMockTransport();
-    const tools = createReplyReactTools({ transport });
+    const tools = createReplyReactTools(wrapTransport(transport));
     expect(tools).toHaveLength(2);
     expect(tools.map((t) => t.tool.name)).toEqual(["message_reply", "message_react"]);
   });

--- a/src/tools/reply-react.ts
+++ b/src/tools/reply-react.ts
@@ -12,7 +12,24 @@ const log = createLogger("tools:reply-react");
 
 /** Runtime context required by reply/react tools. */
 export interface ReplyReactToolContext {
-  transport: Transport;
+  getTransport: () => Transport | undefined;
+}
+
+/**
+ * Lazy transport context — holds a mutable reference to a Transport that can
+ * be set after tool registration.  This allows cli.ts to register reply/react
+ * tools eagerly and bind the real transport once Discord starts.
+ */
+export class LazyTransportContext implements ReplyReactToolContext {
+  private _transport: Transport | undefined;
+
+  setTransport(transport: Transport): void {
+    this._transport = transport;
+  }
+
+  getTransport(): Transport | undefined {
+    return this._transport;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -32,13 +49,20 @@ export function createMessageReplyTool(
       name: "message_reply",
       description:
         "Reply to a specific message by its ID. The reply is threaded / linked " +
-        "to the original message in the transport (e.g. Discord reply).",
+        "to the original message in the transport (e.g. Discord reply). " +
+        "Pass channel_id when known to avoid an expensive channel scan.",
       parameters: {
         type: "object",
         properties: {
           message_id: {
             type: "string",
             description: "ID of the message to reply to",
+          },
+          channel_id: {
+            type: "string",
+            description:
+              "ID of the channel containing the message. " +
+              "Optional but recommended — avoids O(n) channel scan.",
           },
           content: {
             type: "string",
@@ -49,8 +73,9 @@ export function createMessageReplyTool(
       },
     },
     handler: async (args) => {
-      const { message_id, content } = args as {
+      const { message_id, channel_id, content } = args as {
         message_id: string;
+        channel_id?: string;
         content: string;
       };
 
@@ -60,12 +85,17 @@ export function createMessageReplyTool(
       if (!content || !content.trim()) {
         return JSON.stringify({ error: "content must not be empty" });
       }
-      if (!ctx.transport.reply) {
+
+      const transport = ctx.getTransport();
+      if (!transport) {
+        return JSON.stringify({ error: "Transport not available" });
+      }
+      if (!transport.reply) {
         return JSON.stringify({ error: "Transport does not support replies" });
       }
 
       try {
-        const result = await ctx.transport.reply(message_id, content);
+        const result = await transport.reply(message_id, content, channel_id);
 
         log.info("Message reply sent", {
           targetMessageId: message_id,
@@ -102,13 +132,20 @@ export function createMessageReactTool(
       name: "message_react",
       description:
         "Add an emoji reaction to a specific message by its ID. " +
-        "Use standard Unicode emoji (e.g. \"\u{1F44D}\") or platform-specific emoji identifiers.",
+        "Use standard Unicode emoji (e.g. \"\u{1F44D}\") or platform-specific emoji identifiers. " +
+        "Pass channel_id when known to avoid an expensive channel scan.",
       parameters: {
         type: "object",
         properties: {
           message_id: {
             type: "string",
             description: "ID of the message to react to",
+          },
+          channel_id: {
+            type: "string",
+            description:
+              "ID of the channel containing the message. " +
+              "Optional but recommended — avoids O(n) channel scan.",
           },
           emoji: {
             type: "string",
@@ -119,8 +156,9 @@ export function createMessageReactTool(
       },
     },
     handler: async (args) => {
-      const { message_id, emoji } = args as {
+      const { message_id, channel_id, emoji } = args as {
         message_id: string;
+        channel_id?: string;
         emoji: string;
       };
 
@@ -130,12 +168,17 @@ export function createMessageReactTool(
       if (!emoji || !emoji.trim()) {
         return JSON.stringify({ error: "emoji must not be empty" });
       }
-      if (!ctx.transport.react) {
+
+      const transport = ctx.getTransport();
+      if (!transport) {
+        return JSON.stringify({ error: "Transport not available" });
+      }
+      if (!transport.react) {
         return JSON.stringify({ error: "Transport does not support reactions" });
       }
 
       try {
-        await ctx.transport.react(message_id, emoji);
+        await transport.react(message_id, emoji, channel_id);
 
         log.info("Reaction added", {
           messageId: message_id,

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -684,10 +684,24 @@ export class DiscordTransport implements Transport {
   // Reply & reaction
   // ---------------------------------------------------------------------------
 
-  async reply(messageId: string, content: string): Promise<{ messageId: string }> {
+  async reply(messageId: string, content: string, channelId?: string): Promise<{ messageId: string }> {
     if (!this.ready) throw new Error("Discord transport not ready");
 
-    // Search all channels the bot can see for the message
+    // Fast path: fetch the channel directly when channelId is provided
+    if (channelId) {
+      try {
+        const channel = await this.client.channels.fetch(channelId);
+        if (channel && "messages" in channel) {
+          const target = await (channel as SendableChannel).messages.fetch(messageId);
+          const sent = await target.reply(content);
+          return { messageId: sent.id };
+        }
+      } catch {
+        // Fall through to slow path if channel fetch fails
+      }
+    }
+
+    // Slow path: search all cached channels for the message
     const channels = this.client.channels.cache.values();
     for (const ch of channels) {
       if (!("messages" in ch)) continue;
@@ -705,9 +719,24 @@ export class DiscordTransport implements Transport {
     throw new Error(`Message not found: ${messageId}`);
   }
 
-  async react(messageId: string, emoji: string): Promise<void> {
+  async react(messageId: string, emoji: string, channelId?: string): Promise<void> {
     if (!this.ready) throw new Error("Discord transport not ready");
 
+    // Fast path: fetch the channel directly when channelId is provided
+    if (channelId) {
+      try {
+        const channel = await this.client.channels.fetch(channelId);
+        if (channel && "messages" in channel) {
+          const target = await (channel as SendableChannel).messages.fetch(messageId);
+          await target.react(emoji);
+          return;
+        }
+      } catch {
+        // Fall through to slow path if channel fetch fails
+      }
+    }
+
+    // Slow path: search all cached channels for the message
     const channels = this.client.channels.cache.values();
     for (const ch of channels) {
       if (!("messages" in ch)) continue;


### PR DESCRIPTION
Follow-up to #236 — the original PR was merged before the review fixes landed.

## Changes
- **`channel_id` parameter**: Both `message_reply` and `message_react` tools now accept `channel_id` for O(1) direct channel lookup instead of O(n) cache scan
- **`LazyTransportContext`**: Tools use lazy transport binding so they can be registered eagerly and bound after Discord starts
- **Runtime wiring**: `cli.ts` now registers reply/react tools in each agent's `ToolRegistry` and binds the Discord transport after startup
- **Updated tests**: 18 tests covering new signatures, lazy binding, channel_id passthrough, and error paths

## Review items addressed
1. ✅ Tools were dead code (not wired into runtime) → now wired via `cli.ts`
2. ✅ O(n) channel scan → O(1) direct lookup when `channel_id` provided, with fallback

Closes review feedback from #236.