### PR TITLE
feat(workspace): per-agent workspace path configuration

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,9 +34,11 @@ import {
   getIsotopesHome,
   getLogsDir,
   ensureDirectories,
+  ensureExplicitWorkspaceDir,
   ensureWorkspaceDir,
   getSessionsDir,
   getThreadBindingsPath,
+  resolveExplicitWorkspacePath,
 } from "./core/paths.js";
 import {
   loadWorkspaceContext,
@@ -293,11 +295,19 @@ async function main() {
   for (const agentFile of config.agents) {
     const agentConfig = toAgentConfig(agentFile, config.agentDefaults, config.provider, config.tools, config.compaction, config.sandbox);
 
-    // Workspace layout (mirrors OpenClaw):
-    //   Single agent:    ~/.isotopes/workspace/
-    //   Multiple agents: ~/.isotopes/workspace-{agentId}/
-    const workspaceKey = isSingleAgent ? "default" : agentConfig.id;
-    const workspacePath = await ensureWorkspaceDir(workspaceKey);
+    // Workspace layout:
+    //   Explicit config:  agent.workspace (absolute or relative to ISOTOPES_HOME)
+    //   Single agent:     ~/.isotopes/workspace/
+    //   Multiple agents:  ~/.isotopes/workspace-{agentId}/
+    let workspacePath: string;
+    if (agentFile.workspace) {
+      const resolved = resolveExplicitWorkspacePath(agentFile.workspace);
+      workspacePath = await ensureExplicitWorkspaceDir(resolved);
+      logger.info(`Using explicit workspace for ${agentConfig.id}: ${workspacePath}`);
+    } else {
+      const workspaceKey = isSingleAgent ? "default" : agentConfig.id;
+      workspacePath = await ensureWorkspaceDir(workspaceKey);
+    }
     agentWorkspaces.set(agentConfig.id, workspacePath);
 
     // Seed workspace templates on first creation (M11.2)

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -228,6 +228,26 @@ agents:
 
       await expect(loadConfig(configPath)).rejects.toThrow();
     });
+    it("loads agent workspace path from config", async () => {
+      const configPath = path.join(tempDir, "workspace.yaml");
+      await fs.writeFile(
+        configPath,
+        `
+agents:
+  - id: major
+    workspace: /custom/major-workspace
+  - id: tachikoma
+    workspace: ./tachikoma-ws
+  - id: default-agent
+`,
+      );
+
+      const config = await loadConfig(configPath);
+
+      expect(config.agents[0].workspace).toBe("/custom/major-workspace");
+      expect(config.agents[1].workspace).toBe("./tachikoma-ws");
+      expect(config.agents[2].workspace).toBeUndefined();
+    });
   });
 
   describe("toAgentConfig", () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -74,6 +74,12 @@ export interface CronTaskConfigFile {
 /** Agent configuration in config file */
 export interface AgentConfigFile {
   id: string;
+  /**
+   * Explicit workspace directory for this agent (#214).
+   * Absolute paths are used as-is; relative paths resolve from ISOTOPES_HOME.
+   * When omitted, the default derivation (single → "workspace/", multi → "workspace-{id}/") is used.
+   */
+  workspace?: string;
   tools?: AgentToolsConfigFile;
   provider?: ProviderConfigFile;
   compaction?: CompactionConfigFile;

--- a/src/core/paths.test.ts
+++ b/src/core/paths.test.ts
@@ -9,6 +9,7 @@ import {
   getWorkspacePath,
   getSessionsDir,
   getConfigPath,
+  resolveExplicitWorkspacePath,
 } from "./paths.js";
 
 describe("paths", () => {
@@ -72,6 +73,31 @@ describe("paths", () => {
     it("respects ISOTOPES_HOME", () => {
       vi.stubEnv("ISOTOPES_HOME", "/custom");
       expect(getConfigPath()).toBe("/custom/isotopes.yaml");
+    });
+  });
+
+  describe("resolveExplicitWorkspacePath", () => {
+    it("returns absolute paths as-is", () => {
+      expect(resolveExplicitWorkspacePath("/Users/foo/workspace")).toBe("/Users/foo/workspace");
+    });
+
+    it("resolves relative paths from ISOTOPES_HOME", () => {
+      vi.stubEnv("ISOTOPES_HOME", "/custom/home");
+      expect(resolveExplicitWorkspacePath("./my-workspace")).toBe(
+        path.resolve("/custom/home", "./my-workspace"),
+      );
+    });
+
+    it("resolves bare relative paths from ISOTOPES_HOME", () => {
+      vi.stubEnv("ISOTOPES_HOME", "/custom/home");
+      expect(resolveExplicitWorkspacePath("agents/major")).toBe(
+        path.resolve("/custom/home", "agents/major"),
+      );
+    });
+
+    it("resolves relative paths from default home when ISOTOPES_HOME is unset", () => {
+      const expected = path.resolve(path.join(os.homedir(), ".isotopes"), "my-workspace");
+      expect(resolveExplicitWorkspacePath("my-workspace")).toBe(expected);
     });
   });
 });

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -91,6 +91,17 @@ export async function ensureDirectories(): Promise<void> {
 }
 
 /**
+ * Resolve an explicit workspace path (#214).
+ * Absolute paths are returned as-is; relative paths resolve from ISOTOPES_HOME.
+ */
+export function resolveExplicitWorkspacePath(workspacePath: string): string {
+  if (path.isAbsolute(workspacePath)) {
+    return workspacePath;
+  }
+  return path.resolve(getIsotopesHome(), workspacePath);
+}
+
+/**
  * Ensure workspace directory exists for an agent.
  */
 export async function ensureWorkspaceDir(agentId: string): Promise<string> {
@@ -98,5 +109,15 @@ export async function ensureWorkspaceDir(agentId: string): Promise<string> {
   await fs.mkdir(workspacePath, { recursive: true });
   await fs.mkdir(getSessionsDir(agentId), { recursive: true });
   return workspacePath;
+}
+
+/**
+ * Ensure an explicit workspace directory exists (#214).
+ * Creates the workspace and a sessions/ subdirectory.
+ */
+export async function ensureExplicitWorkspaceDir(resolvedPath: string): Promise<string> {
+  await fs.mkdir(resolvedPath, { recursive: true });
+  await fs.mkdir(path.join(resolvedPath, "sessions"), { recursive: true });
+  return resolvedPath;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,8 @@ export {
   getSessionsDir as getAgentSessionsDir,
   ensureDirectories,
   ensureWorkspaceDir,
+  resolveExplicitWorkspacePath,
+  ensureExplicitWorkspaceDir,
 } from "./core/paths.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #214

## Summary
- Add `workspace` field to `AgentConfigFile` for explicit workspace directory configuration
- Support absolute paths (e.g., `/Users/foo/workspace`) and relative paths (e.g., `./my-workspace`) resolving from `ISOTOPES_HOME`
- Preserve default derivation (`workspace/` for single agent, `workspace-{id}/` for multi-agent) when `workspace` is not configured
- Export `resolveExplicitWorkspacePath` and `ensureExplicitWorkspaceDir` from public API

## Test plan
- [x] `resolveExplicitWorkspacePath` returns absolute paths as-is
- [x] `resolveExplicitWorkspacePath` resolves relative paths from ISOTOPES_HOME
- [x] `resolveExplicitWorkspacePath` resolves relative paths from default home (~/.isotopes)
- [x] Config loading preserves explicit workspace paths from YAML
- [x] Unconfigured agents still get default workspace derivation
- [x] Full test suite passes (1858 tests, 0 failures)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)