### PR TITLE
feat(tools): implement read_file tool #243

### DIFF
--- a/src/core/tools.test.ts
+++ b/src/core/tools.test.ts
@@ -298,6 +298,123 @@ describe("Built-in tools", () => {
         await fs.rm(outsideFile, { force: true });
       }
     });
+
+    it("reads file with offset", async () => {
+      const testFile = path.join(tempDir, "lines.txt");
+      await fs.writeFile(testFile, "line0\nline1\nline2\nline3\nline4");
+
+      const { handler } = createReadFileTool({ basePath: tempDir });
+      const result = await handler({ path: "lines.txt", offset: 2 });
+
+      expect(result).toContain("line2");
+      expect(result).toContain("line3");
+      expect(result).toContain("line4");
+      expect(result).not.toContain("line0");
+      expect(result).not.toContain("line1\n");
+    });
+
+    it("reads file with limit", async () => {
+      const testFile = path.join(tempDir, "lines.txt");
+      await fs.writeFile(testFile, "line0\nline1\nline2\nline3\nline4");
+
+      const { handler } = createReadFileTool({ basePath: tempDir });
+      const result = await handler({ path: "lines.txt", limit: 2 });
+
+      expect(result).toContain("line0");
+      expect(result).toContain("line1");
+      expect(result).toContain("[truncated]");
+      expect(result).toContain("[lines 1-2 of 5]");
+    });
+
+    it("reads file with offset and limit", async () => {
+      const testFile = path.join(tempDir, "lines.txt");
+      await fs.writeFile(testFile, "line0\nline1\nline2\nline3\nline4");
+
+      const { handler } = createReadFileTool({ basePath: tempDir });
+      const result = await handler({ path: "lines.txt", offset: 1, limit: 2 });
+
+      expect(result).toContain("[lines 2-3 of 5]");
+      expect(result).toContain("line1");
+      expect(result).toContain("line2");
+      expect(result).toContain("[truncated]");
+    });
+
+    it("truncates large files to 2000 lines by default", async () => {
+      const testFile = path.join(tempDir, "big.txt");
+      const lines = Array.from({ length: 3000 }, (_, i) => `line ${i}`);
+      await fs.writeFile(testFile, lines.join("\n"));
+
+      const { handler } = createReadFileTool({ basePath: tempDir, maxReadSize: 1024 * 1024 });
+      const result = await handler({ path: "big.txt" });
+
+      expect(result).toContain("[lines 1-2000 of 3000]");
+      expect(result).toContain("[truncated]");
+      expect(result).toContain("line 0");
+      expect(result).toContain("line 1999");
+      expect(result).not.toContain("line 2000\n");
+    });
+
+    it("returns error for files exceeding maxReadSize without offset/limit", async () => {
+      const testFile = path.join(tempDir, "huge.txt");
+      // Write more than default 50KB
+      await fs.writeFile(testFile, "x".repeat(60 * 1024));
+
+      const { handler } = createReadFileTool({ basePath: tempDir });
+      const result = await handler({ path: "huge.txt" });
+
+      expect(result).toContain("[error]");
+      expect(result).toContain("File too large");
+      expect(result).toContain("offset and limit");
+    });
+
+    it("reads image file as base64 JSON", async () => {
+      const testFile = path.join(tempDir, "test.png");
+      const fakeImageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]); // PNG magic bytes
+      await fs.writeFile(testFile, fakeImageData);
+
+      const { handler } = createReadFileTool({ basePath: tempDir });
+      const result = await handler({ path: "test.png" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.type).toBe("image");
+      expect(parsed.encoding).toBe("base64");
+      expect(parsed.mime_type).toBe("image/png");
+      expect(parsed.data).toBe(fakeImageData.toString("base64"));
+    });
+
+    it("reads jpg image with correct mime type", async () => {
+      const testFile = path.join(tempDir, "photo.jpg");
+      await fs.writeFile(testFile, Buffer.from([0xff, 0xd8, 0xff]));
+
+      const { handler } = createReadFileTool({ basePath: tempDir });
+      const result = await handler({ path: "photo.jpg" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.mime_type).toBe("image/jpeg");
+    });
+
+    it("reads svg image with correct mime type", async () => {
+      const testFile = path.join(tempDir, "icon.svg");
+      await fs.writeFile(testFile, "<svg></svg>");
+
+      const { handler } = createReadFileTool({ basePath: tempDir });
+      const result = await handler({ path: "icon.svg" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.mime_type).toBe("image/svg+xml");
+    });
+
+    it("allows reading large files when offset/limit is specified", async () => {
+      const testFile = path.join(tempDir, "huge-with-offset.txt");
+      await fs.writeFile(testFile, "x".repeat(60 * 1024));
+
+      const { handler } = createReadFileTool({ basePath: tempDir });
+      // Should not error — offset/limit bypasses the size check
+      const result = await handler({ path: "huge-with-offset.txt", offset: 0, limit: 10 });
+
+      expect(result).not.toContain("[error]");
+      expect(result).toContain("[lines");
+    });
   });
 
   describe("createWriteFileTool", () => {

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -474,15 +474,32 @@ async function resolveWorkspaceConstrainedPath(
   }
   return realTargetPath;
 }
+const IMAGE_EXTENSIONS = new Set([
+  ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg", ".ico", ".tiff", ".tif",
+]);
+
+const DEFAULT_MAX_LINES = 2000;
+const DEFAULT_MAX_READ_SIZE = 50 * 1024; // 50 KB for text files
+
 /**
  * Create a file read tool.
+ *
+ * Supports text files (with optional offset/limit for pagination) and image
+ * files (returned as base64-encoded strings). Text files are truncated at
+ * `maxLines` (default 2000) when neither offset nor limit is specified.
  */
 export function createReadFileTool(options: FileToolOptions = {}): { tool: Tool; handler: ToolHandler } {
-  const { basePath, maxReadSize = 1024 * 1024, constrainToWorkspace = true, allowedWorkspaces = [] } = options;
+  const {
+    basePath,
+    maxReadSize = DEFAULT_MAX_READ_SIZE,
+    constrainToWorkspace = true,
+    allowedWorkspaces = [],
+  } = options;
   return {
     tool: {
       name: "read_file",
-      description: "Read the contents of a file. Returns the file content as text.",
+      description:
+        "Read the contents of a file. Returns text content (with optional line offset/limit for large files) or base64-encoded data for image files.",
       parameters: {
         type: "object",
         properties: {
@@ -490,19 +507,66 @@ export function createReadFileTool(options: FileToolOptions = {}): { tool: Tool;
             type: "string",
             description: "Path to the file to read (relative to workspace or absolute)",
           },
+          offset: {
+            type: "number",
+            description: "Line number to start reading from (0-based). Only applies to text files.",
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of lines to return. Only applies to text files.",
+          },
         },
         required: ["path"],
       },
     },
     handler: async (args) => {
-      const { path: filePath } = args as { path: string };
+      const { path: filePath, offset, limit } = args as {
+        path: string;
+        offset?: number;
+        limit?: number;
+      };
       try {
-        const resolvedPath = await resolveWorkspaceConstrainedPath(filePath, basePath, "read", constrainToWorkspace, allowedWorkspaces);
+        const resolvedPath = await resolveWorkspaceConstrainedPath(
+          filePath,
+          basePath,
+          "read",
+          constrainToWorkspace,
+          allowedWorkspaces,
+        );
         const stats = await fs.stat(resolvedPath);
-        if (stats.size > maxReadSize) {
-          return `[error] File too large (${stats.size} bytes, max ${maxReadSize})`;
+
+        // Image files — return base64
+        const ext = path.extname(resolvedPath).toLowerCase();
+        if (IMAGE_EXTENSIONS.has(ext)) {
+          const buf = await fs.readFile(resolvedPath);
+          const mimeType = ext === ".svg" ? "image/svg+xml" : `image/${ext.slice(1).replace("jpg", "jpeg")}`;
+          return JSON.stringify({
+            type: "image",
+            encoding: "base64",
+            mime_type: mimeType,
+            data: buf.toString("base64"),
+          });
+        }
+
+        // Text files
+        if (stats.size > maxReadSize && offset == null && limit == null) {
+          return `[error] File too large (${stats.size} bytes, max ${maxReadSize}). Use offset and limit to read in chunks.`;
         }
         const content = await fs.readFile(resolvedPath, "utf-8");
+        const allLines = content.split("\n");
+        const totalLines = allLines.length;
+
+        const startLine = offset ?? 0;
+        const maxLines = limit ?? DEFAULT_MAX_LINES;
+        const selectedLines = allLines.slice(startLine, startLine + maxLines);
+        const truncated = startLine + maxLines < totalLines;
+
+        if (offset != null || limit != null || truncated) {
+          const result = selectedLines.join("\n");
+          const meta = `[lines ${startLine + 1}-${startLine + selectedLines.length} of ${totalLines}]`;
+          return truncated ? `${meta}\n${result}\n[truncated]` : `${meta}\n${result}`;
+        }
+
         return content;
       } catch (error) {
         const err = error as { code?: string; message?: string };


### PR DESCRIPTION
## Summary

Implements #243 — enhances the `read_file` tool with full file reading capabilities:

- **Offset/limit pagination**: `offset` (0-based line number) and `limit` parameters for reading large text files in chunks
- **Auto-truncation**: Text files are truncated to 2000 lines by default with a `[truncated]` indicator and line metadata (`[lines 1-2000 of 5000]`)
- **Image support**: Image files (png, jpg, gif, svg, webp, bmp, ico, tiff) are returned as base64-encoded JSON with MIME type
- **Size guard with bypass**: Default 50KB max for text files without offset/limit; specifying offset/limit bypasses the size check for chunked reading
- **Workspace guards**: Respects `allowedWorkspaces` and `constrainToWorkspace` for all file types

## Test plan

- [x] Text file reading (basic, offset, limit, offset+limit)
- [x] Auto-truncation at 2000 lines
- [x] Large file error without offset/limit
- [x] Large file allowed with offset/limit
- [x] Image file base64 encoding (png, jpg, svg)
- [x] File not found error
- [x] Workspace escape rejection
- [x] `constrainToWorkspace: false` allows outside paths
- [x] TypeScript typecheck passes
- [x] All 64 tool tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)