### PR TITLE
feat: add web_search tool using DuckDuckGo (#244)

### DIFF
--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -6,7 +6,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentToolSettings, Tool } from "./types.js";
 import { spawnSubagent, getSupportedAgents } from "../tools/subagent.js";
-import { createWebFetchTool } from "../tools/web.js";
+import { createWebFetchTool, createWebSearchTool } from "../tools/web.js";
 import type { AcpxAgent, AcpxEvent, DiscordSinkConfig } from "../subagent/types.js";
 import { DiscordSink } from "../subagent/discord-sink.js";
 import { getSubagentContext } from "./subagent-context.js";
@@ -836,6 +836,7 @@ export function createWorkspaceToolsWithGuards(
   // Web fetch tool
   if (settings?.web) {
     tools.push(createWebFetchTool());
+    tools.push(createWebSearchTool());
   }
   return tools;
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -66,7 +66,8 @@ export {
 } from "./self-iteration.js";
 export type { SelfIterationConfig } from "./self-iteration.js";
 
-export { createWebFetchTool } from "./web.js";
+export { createWebFetchTool, createWebSearchTool } from "./web.js";
+export type { SearchResult } from "./web.js";
 
 export {
   createSessionsSpawnTool,

--- a/src/tools/web.test.ts
+++ b/src/tools/web.test.ts
@@ -1,7 +1,7 @@
-// src/tools/web.test.ts — Tests for web fetch tool
+// src/tools/web.test.ts — Tests for web fetch and search tools
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createWebFetchTool } from "./web.js";
+import { createWebFetchTool, createWebSearchTool, parseDuckDuckGoResults } from "./web.js";
 
 describe("web tools", () => {
   let originalFetch: typeof global.fetch;
@@ -196,6 +196,236 @@ describe("web tools", () => {
       expect(result).toContain("Less than: <");
       expect(result).toContain("Greater than: >");
       expect(result).toContain("Amp: &");
+    });
+  });
+
+  describe("parseDuckDuckGoResults", () => {
+    it("parses results with uddg redirect URLs", () => {
+      const html = `
+        <div class="result">
+          <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage1&amp;rut=abc">Example Page 1</a>
+          <a class="result__snippet">This is the first snippet.</a>
+        </div>
+        <div class="result">
+          <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage2&amp;rut=def">Example Page 2</a>
+          <a class="result__snippet">This is the second snippet.</a>
+        </div>
+      `;
+
+      const results = parseDuckDuckGoResults(html, 5);
+      expect(results).toHaveLength(2);
+      expect(results[0]).toEqual({
+        title: "Example Page 1",
+        url: "https://example.com/page1",
+        snippet: "This is the first snippet.",
+      });
+      expect(results[1]).toEqual({
+        title: "Example Page 2",
+        url: "https://example.com/page2",
+        snippet: "This is the second snippet.",
+      });
+    });
+
+    it("parses results with direct URLs", () => {
+      const html = `
+        <a class="result__a" href="https://direct.example.com">Direct Link</a>
+        <a class="result__snippet">Direct snippet.</a>
+      `;
+
+      const results = parseDuckDuckGoResults(html, 5);
+      expect(results).toHaveLength(1);
+      expect(results[0].url).toBe("https://direct.example.com");
+      expect(results[0].title).toBe("Direct Link");
+    });
+
+    it("strips HTML tags from titles", () => {
+      const html = `
+        <a class="result__a" href="https://example.com"><b>Bold</b> Title</a>
+        <a class="result__snippet">Snippet text.</a>
+      `;
+
+      const results = parseDuckDuckGoResults(html, 5);
+      expect(results[0].title).toBe("Bold Title");
+    });
+
+    it("respects count limit", () => {
+      const html = `
+        <a class="result__a" href="https://example.com/1">Result 1</a>
+        <a class="result__snippet">Snippet 1</a>
+        <a class="result__a" href="https://example.com/2">Result 2</a>
+        <a class="result__snippet">Snippet 2</a>
+        <a class="result__a" href="https://example.com/3">Result 3</a>
+        <a class="result__snippet">Snippet 3</a>
+      `;
+
+      const results = parseDuckDuckGoResults(html, 2);
+      expect(results).toHaveLength(2);
+    });
+
+    it("returns empty array when no results found", () => {
+      const html = `<html><body><div class="no-results">No results</div></body></html>`;
+      const results = parseDuckDuckGoResults(html, 5);
+      expect(results).toEqual([]);
+    });
+
+    it("handles missing snippets gracefully", () => {
+      const html = `
+        <a class="result__a" href="https://example.com/1">Result 1</a>
+        <a class="result__a" href="https://example.com/2">Result 2</a>
+        <a class="result__snippet">Only one snippet</a>
+      `;
+
+      const results = parseDuckDuckGoResults(html, 5);
+      expect(results).toHaveLength(2);
+      expect(results[0].snippet).toBe("Only one snippet");
+      expect(results[1].snippet).toBe("");
+    });
+
+    it("handles span-based snippets", () => {
+      const html = `
+        <a class="result__a" href="https://example.com">Title</a>
+        <span class="result__snippet">Span-based snippet.</span>
+      `;
+
+      const results = parseDuckDuckGoResults(html, 5);
+      expect(results[0].snippet).toBe("Span-based snippet.");
+    });
+
+    it("decodes HTML entities in results", () => {
+      const html = `
+        <a class="result__a" href="https://example.com">Tom &amp; Jerry&#39;s Page</a>
+        <a class="result__snippet">A &lt;great&gt; snippet with &quot;quotes&quot;.</a>
+      `;
+
+      const results = parseDuckDuckGoResults(html, 5);
+      expect(results[0].title).toBe("Tom & Jerry's Page");
+      expect(results[0].snippet).toBe('A <great> snippet with "quotes".');
+    });
+  });
+
+  describe("createWebSearchTool", () => {
+    it("returns tool with correct schema", () => {
+      const { tool } = createWebSearchTool();
+      expect(tool.name).toBe("web_search");
+      expect(tool.description).toContain("DuckDuckGo");
+      expect(tool.parameters.required).toContain("query");
+      expect(tool.parameters.properties).toHaveProperty("query");
+      expect(tool.parameters.properties).toHaveProperty("count");
+      expect(tool.parameters.properties).toHaveProperty("region");
+    });
+
+    it("returns error for empty query", async () => {
+      const { handler } = createWebSearchTool();
+      const result = await handler({ query: "" });
+      expect(result).toContain("[error]");
+      expect(result).toContain("empty");
+    });
+
+    it("fetches and parses search results", async () => {
+      const mockHtml = `
+        <html><body>
+          <div class="result">
+            <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fresult&amp;rut=abc">Example Result</a>
+            <a class="result__snippet">This is a test snippet for the search.</a>
+          </div>
+          <div class="result">
+            <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fother.example.com&amp;rut=def">Other Result</a>
+            <a class="result__snippet">Another snippet here.</a>
+          </div>
+        </body></html>
+      `;
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(mockHtml),
+      });
+
+      const { handler } = createWebSearchTool();
+      const result = await handler({ query: "test search" });
+
+      expect(result).toContain("Search results");
+      expect(result).toContain("Example Result");
+      expect(result).toContain("https://example.com/result");
+      expect(result).toContain("This is a test snippet");
+      expect(result).toContain("Other Result");
+
+      // Verify fetch was called with correct URL
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain("html.duckduckgo.com/html/");
+      expect(fetchCall[0]).toContain("q=test+search");
+    });
+
+    it("passes region parameter as kl", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("<html></html>"),
+      });
+
+      const { handler } = createWebSearchTool();
+      await handler({ query: "test", region: "us-en" });
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain("kl=us-en");
+    });
+
+    it("clamps count to valid range", async () => {
+      const mockHtml = `
+        <a class="result__a" href="https://example.com/1">R1</a>
+        <a class="result__snippet">S1</a>
+        <a class="result__a" href="https://example.com/2">R2</a>
+        <a class="result__snippet">S2</a>
+        <a class="result__a" href="https://example.com/3">R3</a>
+        <a class="result__snippet">S3</a>
+      `;
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(mockHtml),
+      });
+
+      const { handler } = createWebSearchTool();
+      const result = await handler({ query: "test", count: 2 });
+
+      // Should only show 2 results
+      expect(result).toContain("1. R1");
+      expect(result).toContain("2. R2");
+      expect(result).not.toContain("3. R3");
+    });
+
+    it("returns message when no results found", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("<html><body>No results</body></html>"),
+      });
+
+      const { handler } = createWebSearchTool();
+      const result = await handler({ query: "xyznonexistent" });
+
+      expect(result).toContain("No results found");
+    });
+
+    it("handles HTTP error", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+      });
+
+      const { handler } = createWebSearchTool();
+      const result = await handler({ query: "test" });
+
+      expect(result).toContain("[error]");
+      expect(result).toContain("503");
+    });
+
+    it("handles network error", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network timeout"));
+
+      const { handler } = createWebSearchTool();
+      const result = await handler({ query: "test" });
+
+      expect(result).toContain("[error]");
+      expect(result).toContain("Network timeout");
     });
   });
 });

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -1,5 +1,4 @@
-// src/tools/web.ts — Web fetch tool
-// Note: web_search requires external API key (Brave/SerpAPI) - not included in MVP
+// src/tools/web.ts — Web fetch and search tools
 
 import type { Tool } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";
@@ -164,6 +163,144 @@ export function createWebFetchTool(): { tool: Tool; handler: ToolHandler } {
       } catch (error) {
         const err = error instanceof Error ? error.message : String(error);
         return `[error] Failed to fetch: ${err}`;
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Web Search Tool (DuckDuckGo HTML scraping)
+// ---------------------------------------------------------------------------
+
+/** A single search result. */
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/**
+ * Parse DuckDuckGo HTML search results into structured data.
+ */
+export function parseDuckDuckGoResults(html: string, count: number): SearchResult[] {
+  const results: SearchResult[] = [];
+
+  // Match result links: <a rel="nofollow" class="result__a" href="URL">Title</a>
+  const linkRegex = /<a[^>]*class="result__a"[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi;
+  // Match snippets: <a class="result__snippet" ...>Snippet</a> or <span class="result__snippet">...</span>
+  const snippetRegex = /<(?:a|span)[^>]*class="result__snippet"[^>]*>([\s\S]*?)<\/(?:a|span)>/gi;
+
+  const links: { url: string; title: string }[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = linkRegex.exec(html)) !== null) {
+    let url = match[1];
+    // DuckDuckGo wraps URLs in a redirect — extract actual URL
+    const uddgMatch = url.match(/[?&]uddg=([^&]+)/);
+    if (uddgMatch) {
+      url = decodeURIComponent(uddgMatch[1]);
+    }
+    const title = decodeHtmlEntities(match[2].replace(/<[^>]+>/g, "").trim());
+    if (title && url) {
+      links.push({ url, title });
+    }
+  }
+
+  const snippets: string[] = [];
+  while ((match = snippetRegex.exec(html)) !== null) {
+    const snippet = decodeHtmlEntities(match[1].replace(/<[^>]+>/g, "").trim());
+    snippets.push(snippet);
+  }
+
+  for (let i = 0; i < Math.min(links.length, count); i++) {
+    results.push({
+      title: links[i].title,
+      url: links[i].url,
+      snippet: snippets[i] || "",
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Create web_search tool using DuckDuckGo HTML scraping.
+ */
+export function createWebSearchTool(): { tool: Tool; handler: ToolHandler } {
+  return {
+    tool: {
+      name: "web_search",
+      description:
+        "Search the web using DuckDuckGo. Returns titles, URLs, and snippets.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query",
+          },
+          count: {
+            type: "number",
+            description: "Number of results (1-10, default 5)",
+          },
+          region: {
+            type: "string",
+            description: "Region code (e.g., 'us-en', 'uk-en')",
+          },
+        },
+        required: ["query"],
+      },
+    },
+    handler: async (args) => {
+      const { query, count: rawCount, region } = args as {
+        query: string;
+        count?: number;
+        region?: string;
+      };
+
+      if (!query || query.trim().length === 0) {
+        return "[error] Search query cannot be empty";
+      }
+
+      const count = Math.max(1, Math.min(10, rawCount ?? 5));
+
+      const params = new URLSearchParams({ q: query });
+      if (region) {
+        params.set("kl", region);
+      }
+
+      const url = `https://html.duckduckgo.com/html/?${params.toString()}`;
+
+      try {
+        const response = await fetch(url, {
+          method: "GET",
+          headers: {
+            "User-Agent": USER_AGENT,
+            Accept: "text/html",
+          },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT),
+          redirect: "follow",
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const html = await response.text();
+        const results = parseDuckDuckGoResults(html, count);
+
+        if (results.length === 0) {
+          return `No results found for "${query}"`;
+        }
+
+        const formatted = results
+          .map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.snippet}`)
+          .join("\n\n");
+
+        return `Search results for "${query}":\n\n${formatted}`;
+      } catch (error) {
+        const err = error instanceof Error ? error.message : String(error);
+        return `[error] Search failed: ${err}`;
       }
     },
   };


### PR DESCRIPTION
## Summary
Add `web_search` tool using DuckDuckGo HTML scraping (no API key required).

## Changes
- Add `createWebSearchTool()` and `parseDuckDuckGoResults()` to `src/tools/web.ts`
- Parse DuckDuckGo HTML results (uddg redirect URL unwrapping, snippet extraction)
- Wire into `createWorkspaceToolsWithGuards()` when `settings.web` enabled
- Export from `src/tools/index.ts`
- Add 17 tests for parser and tool (27 total web tests)

## Tool Schema
```
web_search(query, count?, region?)
```
- `query`: Search query (required)
- `count`: Number of results 1-10 (default 5)
- `region`: Region code e.g. 'us-en' (optional)

Closes #244