### PR TITLE
fix(api): add Discord session store fallback to /api/sessions/:id/messages

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -291,6 +291,26 @@ addRoute("GET", "/api/sessions/:id/messages", async (req, res, deps) => {
     }
   }
 
+  // Try Discord per-agent session stores
+  if (deps.discordSessionStores) {
+    for (const store of deps.discordSessionStores.values()) {
+      const discordSession = await store.get(req.params.id);
+      if (discordSession) {
+        const messages = await store.getMessages(req.params.id);
+        sendJson(res, 200, {
+          messages: messages.map((m) => ({
+            role: m.role,
+            content: Array.isArray(m.content)
+              ? m.content.map((b) => (typeof b === "string" ? b : (b as { text?: string }).text ?? JSON.stringify(b))).join("")
+              : String(m.content),
+            timestamp: m.timestamp ? new Date(m.timestamp).toISOString() : undefined,
+          })),
+        });
+        return;
+      }
+    }
+  }
+
   sendError(res, 404, `Session "${req.params.id}" not found`);
 });
 


### PR DESCRIPTION
The `/api/sessions/:id/messages` endpoint was missing Discord `DefaultSessionStore` fallback. PR #255 fixed `/api/sessions` (list) and `/api/sessions/:id` (detail) but missed the messages endpoint.

**Result:** Chat page sidebar shows Discord sessions but clicking them → 404.

**Fix:** Add same fallback pattern (ACP → chat → Discord stores) to the messages endpoint.

Fixes remaining part of #253.