### PR TITLE
feat(dashboard): show Discord channel names in session list

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -131,6 +131,8 @@ addRoute("GET", "/api/sessions", async (_req, res, deps) => {
     key?: string;
     agentId: string;
     threadId: string | undefined;
+    channelName?: string;
+    guildName?: string;
     status: string;
     createdAt: string;
     lastActivityAt: string;
@@ -163,6 +165,8 @@ addRoute("GET", "/api/sessions", async (_req, res, deps) => {
           key: s.metadata?.key,
           agentId: s.agentId || agentId,
           threadId: s.metadata?.threadId,
+          channelName: s.metadata?.channelName,
+          guildName: s.metadata?.guildName,
           status: "active",
           createdAt: s.lastActiveAt.toISOString(),
           lastActivityAt: s.lastActiveAt.toISOString(),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -211,6 +211,8 @@ export interface SessionMetadata {
   key?: string;                        // Unique key for session lookup (e.g., discord:{botId}:channel:{id}:{agentId})
   transport: 'discord' | 'feishu' | 'web';
   channelId?: string;
+  channelName?: string;
+  guildName?: string;
   threadId?: string;
   /** If true, session is exempt from TTL-based cleanup */
   persistent?: boolean;

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -463,14 +463,27 @@ export class DiscordTransport implements Transport {
     // Try to find existing session by key
     const existing = await sessionStore.findByKey(sessionKey);
     if (existing) {
+      // Backfill channel/guild name if missing
+      if (existing.metadata && !existing.metadata.channelName) {
+        const channelName = "name" in msg.channel ? (msg.channel as { name?: string }).name : undefined;
+        const guildName = msg.guild?.name;
+        if (channelName) {
+          existing.metadata.channelName = channelName;
+          if (guildName) existing.metadata.guildName = guildName;
+        }
+      }
       return existing;
     }
 
     // Create new session with key
+    const channelName = "name" in msg.channel ? (msg.channel as { name?: string }).name : undefined;
+    const guildName = msg.guild?.name;
     const session = await sessionStore.create(agentId, {
       key: sessionKey,
       transport: "discord",
       channelId: msg.channelId,
+      channelName: channelName ?? undefined,
+      guildName: guildName ?? undefined,
       threadId: msg.thread?.id,
     });
     return session;

--- a/web/chat/app.js
+++ b/web/chat/app.js
@@ -77,6 +77,10 @@ function formatTime(isoString) {
 }
 
 function sessionDisplayName(session) {
+  // Use channel name if available
+  if (session.channelName) {
+    return `#${session.channelName}`;
+  }
   if (session.key) {
     // Discord keys: "discord:{botId}:channel:{channelId}:{agentId}"
     const discordMatch = session.key.match(/^discord:\d+:channel:(\d+):(.+)$/);


### PR DESCRIPTION
Session sidebar showed `#729035 (main)` — meaningless IDs. Now shows `#epoch-02-autonomy` etc.

**Changes:**
- `SessionMetadata`: add `channelName` + `guildName` fields
- `discord.ts`: store channel/guild name on session create, backfill on existing sessions
- `routes.ts`: return `channelName`/`guildName` from `/api/sessions`
- `chat/app.js`: prefer `channelName` for display, fallback to ID-based name

**Backfill:** Existing sessions get channel name populated on next message (in-memory update, persisted on next `addMessage`).