### PR TITLE
fix(discord): refresh session metadata on every message

### DIFF
--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -463,14 +463,12 @@ export class DiscordTransport implements Transport {
     // Try to find existing session by key
     const existing = await sessionStore.findByKey(sessionKey);
     if (existing) {
-      // Backfill channel/guild name if missing
-      if (existing.metadata && !existing.metadata.channelName) {
+      // Refresh channel/guild name on every message (handles renames)
+      if (existing.metadata) {
         const channelName = "name" in msg.channel ? (msg.channel as { name?: string }).name : undefined;
         const guildName = msg.guild?.name;
-        if (channelName) {
-          existing.metadata.channelName = channelName;
-          if (guildName) existing.metadata.guildName = guildName;
-        }
+        if (channelName) existing.metadata.channelName = channelName;
+        if (guildName) existing.metadata.guildName = guildName;
       }
       return existing;
     }


### PR DESCRIPTION
Refresh channelName/guildName on every inbound message instead of only backfilling when missing. Handles Discord channel renames correctly, matching OpenClaw's behavior.