### PR TITLE
docs: PRDs for isotopes-1.0 remaining items (#223, #260, #261, #262)

### DIFF
--- a/docs/prd/PRD-223-slash-commands.md
+++ b/docs/prd/PRD-223-slash-commands.md
@@ -1,0 +1,127 @@
+# PRD-223: Slash Commands — /new, /reset, /compact + Daily Reset
+
+## Issue
+
+<https://github.com/GhostComplex/isotopes/issues/223>
+
+## Problem
+
+长期运行的 agent session 会累积大量历史，导致 context 膨胀、token 消耗增加、响应质量下降。用户需要能够手动或自动重置 session。
+
+当前 Isotopes 只有 `/status`、`/reload`、`/model` 三个 slash command，缺少 session 生命周期管理命令。
+
+## Goal
+
+用户可以通过 chat 命令管理 session，daemon 支持按时间自动重置。
+
+## Requirements
+
+### P0 — Core Commands
+
+1. **`/new`**
+   - 清空当前 session 历史，开始新对话
+   - 保留 session key 和 metadata（不创建新 session ID）
+   - 回复确认：`✅ Session reset. Starting fresh.`
+
+2. **`/reset`**
+   - `/new` 的别名，行为相同
+   - 用户习惯不同，两个都支持
+
+3. **`/compact`**
+   - 立即触发 context compaction（不等 safeguard 阈值）
+   - 显示压缩前后 message 数量和估算 token 数
+   - 回复示例：`✅ Compacted: 42 messages → 8 (est. 12k → 3k tokens)`
+
+### P1 — Daily Reset
+
+4. **Config 级别 daily reset**
+   ```yaml
+   agents:
+     - id: fairy
+       session:
+         dailyReset:
+           enabled: true
+           time: "04:00"        # UTC or local (configurable timezone)
+           timezone: "Asia/Shanghai"
+   ```
+   - 每天在指定时间自动清空所有活跃 session
+   - 清空前保存最后 N 条 message 到 `memory/` 目录（可选）
+   - 日志记录：`[session] Daily reset: cleared 3 sessions for agent fairy`
+
+5. **`/sessions`**
+   - 列出当前 agent 的所有活跃 session
+   - 格式：
+     ```
+     Active sessions for fairy:
+     • discord:fairy:guild:1234:chan:5678 — 15 msgs, last active 2m ago
+     • feishu:fairy:group:abc — 3 msgs, last active 1h ago
+     ```
+
+### P2 — Advanced
+
+6. **`/forget <n>`**
+   - 删除最近 N 条 message（不做全量 reset）
+   - 用于撤回误操作或清除错误上下文
+
+7. **Session TTL**
+   ```yaml
+   session:
+     ttl: 24h   # Auto-expire idle sessions
+   ```
+
+## Implementation Notes
+
+### Slash Command 注册
+
+扩展现有 `SlashCommandHandler`（`src/commands/slash-commands.ts`）：
+
+```typescript
+const KNOWN_COMMANDS = new Set([
+  "status", "reload", "model",
+  // New:
+  "new", "reset", "compact", "sessions", "forget",
+]);
+```
+
+### Session Reset 实现
+
+```typescript
+// SessionStore 需要新增方法：
+interface SessionStore {
+  // 现有
+  get(id: string): Promise<Session | null>;
+  list(): Promise<Session[]>;
+  // 新增
+  clearMessages(id: string): Promise<void>;
+  compact(id: string): Promise<CompactionResult>;
+}
+```
+
+### Daily Reset 实现
+
+利用现有 `CronScheduler` 注册内部 cron job：
+
+```typescript
+// 在 agent 启动时，如果配置了 dailyReset：
+cronScheduler.register({
+  name: `daily-reset-${agentId}`,
+  expression: cronExprFromTime(config.dailyReset.time),
+  agentId,
+  action: { type: "session_reset" },
+  internal: true,  // 不暴露给用户
+});
+```
+
+## Acceptance Criteria
+
+- [ ] `/new` 和 `/reset` 清空当前 session 历史
+- [ ] `/compact` 立即触发 compaction 并返回统计
+- [ ] `/sessions` 列出活跃 session
+- [ ] daily reset 按配置时间执行
+- [ ] 所有命令需要 admin 权限检查
+- [ ] 单元测试覆盖各命令
+
+## Dependencies
+
+- 无外部依赖
+- 基于现有 `SlashCommandHandler` + `SessionStore` + `CronScheduler`

--- a/docs/prd/PRD-260-npm-package-release.md
+++ b/docs/prd/PRD-260-npm-package-release.md
@@ -1,0 +1,99 @@
+# PRD-260: npm Package Release & CLI Install
+
+## Issue
+
+<https://github.com/GhostComplex/isotopes/issues/260>
+
+## Problem
+
+用户无法通过 `npm install -g isotopes` 安装和运行 Isotopes。当前只能 clone 源码 + `npm run build`，部署门槛高，阻塞 1.0 release。
+
+## Goal
+
+`npm install -g isotopes && isotopes start` 即可运行。对标 OpenClaw 的安装体验。
+
+## Requirements
+
+### P0 — Must Have
+
+1. **npm package 发布**
+   - 包名：`isotopes`（或 `@isotopes/cli`，取决于可用性）
+   - 发布到 npm registry
+   - `bin` 入口指向编译后的 CLI
+
+2. **CLI 入口正常工作**
+   - `isotopes start` / `stop` / `restart` / `status`
+   - `isotopes service install` / `uninstall`（systemd/launchd）
+   - `isotopes --version` / `--help`
+
+3. **构建产物完整**
+   - TypeScript 编译为 JS（`dist/`）
+   - 打包 web 静态资源（dashboard + webchat）
+   - 不包含 `src/`、`test/`、`.github/` 等开发文件
+
+4. **依赖声明正确**
+   - `dependencies` vs `devDependencies` 区分清晰
+   - `postinstall` 不依赖 TypeScript 编译
+   - 运行时不需要 `tsx` / `ts-node`
+
+5. **首次运行引导**
+   - `isotopes` 无参数时，如果没有 config，提示引导创建
+   - 或提供 `isotopes init` 交互式初始化 config
+
+### P1 — Should Have
+
+6. **Config 模板生成**
+   - `isotopes init` 生成 `~/.isotopes/config.yaml` 模板
+   - 带注释说明每个字段
+   - 提示设置 API key、Discord token 等
+
+7. **版本管理**
+   - `package.json` version 与 git tag 对齐
+   - CI 自动发布（GitHub Actions → npm publish）
+
+8. **平台兼容性**
+   - macOS (arm64/x64)
+   - Linux (x64/arm64)
+   - Node.js ≥ 20
+
+### P2 — Nice to Have
+
+9. **npx 一键运行**
+   - `npx isotopes start` 无需全局安装
+
+10. **Docker image**
+    - `ghcr.io/ghostcomplex/isotopes:latest`
+
+## package.json 关键配置
+
+```json
+{
+  "name": "isotopes",
+  "bin": {
+    "isotopes": "dist/cli.js"
+  },
+  "files": [
+    "dist/",
+    "web/dist/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  }
+}
+```
+
+## 验证标准
+
+- [ ] `npm install -g isotopes` 在干净环境中成功
+- [ ] `isotopes --version` 输出版本号
+- [ ] `isotopes init` 创建初始 config
+- [ ] `isotopes start` 启动 daemon
+- [ ] `isotopes status` 正常显示状态
+- [ ] Dashboard 和 WebChat 静态资源能正常 serve
+
+## 风险
+
+- 包名 `isotopes` 在 npm 上是否可用 → 需要提前检查
+- web 静态资源打包方式需要确定（直接 include 还是单独 build step）
+- `claude` CLI 作为 subagent 后端是可选依赖，需要文档说明

--- a/docs/prd/PRD-261-acpx-migration.md
+++ b/docs/prd/PRD-261-acpx-migration.md
@@ -1,0 +1,164 @@
+# PRD-261: Migrate Subagent Backend to Real acpx ACP Protocol
+
+## Issue
+
+<https://github.com/GhostComplex/isotopes/issues/261>
+
+## Problem
+
+当前 `AcpxBackend`（`src/subagent/acpx-backend.ts`）名字有误导性 — 它直接 spawn `claude -p --output-format stream-json`，不走 ACP（Agent Client Protocol）。
+
+具体问题：
+- **只有 Claude 能用** — 虽然 `ACPX_AGENTS` 声明了 8 个 agent（claude/codex/gemini/cursor/copilot/opencode/kimi/qwen），但 spawn 时硬编码 `spawn("claude", args)`
+- **不走 ACP 协议** — 没有 `session/new`、`prompt/submit`、`session/load` 等 ACP session 管理
+- **无法 resume session** — 每次都是新进程，没有 session 持久化
+- **无法 steer** — 没有 `prompt/submit` 到已有 session 的能力
+
+## Goal
+
+用真正的 acpx binary 替换直接 spawn claude，支持多 agent + session 管理 + steer。
+
+## Background
+
+### OpenClaw 的 acpx 实现
+
+OpenClaw 内置了 `acpx` v0.5.2（`@openclaw/acpx`），每个 agent 有对应的 ACP adapter：
+
+| Agent | 启动命令 |
+| --- | --- |
+| claude | `npx @agentclientprotocol/claude-agent-acp@<ver>` |
+| codex | `npx @zed-industries/codex-acp@<ver>` |
+| gemini | `gemini --acp` |
+| cursor | `cursor-agent acp` |
+| copilot | `copilot --acp --stdio` |
+| opencode | `npx opencode-ai acp` |
+
+### 验证结果
+
+在当前机器上已验证 `acpx claude exec` 能正常工作：
+
+```
+$ acpx claude exec "reply with exactly: ACPX_CLAUDE_OK"
+[client] initialize (running)
+[client] session/new (running)
+ACPX_CLAUDE_OK
+[done] end_turn
+```
+
+## Requirements
+
+### P0 — Core Migration
+
+1. **替换 spawn 方式**
+   - 从 `spawn("claude", ["-p", "--output-format", "stream-json", ...])` 
+   - 改为 `spawn("acpx", [agent, "exec", ...])` 或使用 acpx 的 programmatic API
+   - acpx binary 可以作为 dependency 引入，或要求用户全局安装
+
+2. **多 agent 支持**
+   - 至少支持 `claude` + `codex`
+   - 根据 `ACPX_AGENTS` 配置动态选择 agent
+   - 每个 agent 的 ACP adapter 自动解析（acpx 内部处理）
+
+3. **事件流解析**
+   - ACP 协议的事件格式与 `claude -p --stream-json` 不同
+   - 需要适配 ACP 的 JSON-RPC notification（`session/update`、`prompt/progress` 等）
+   - 保持现有 `DiscordSink` streaming 能力
+
+4. **cancel/abort**
+   - 使用 ACP 的 `prompt/cancel` 替代 kill process
+   - 更优雅的取消，允许 agent 清理
+
+### P1 — Session Management
+
+5. **Session 持久化**
+   - 使用 `acpx <agent> prompt` 替代 `acpx <agent> exec` 实现 persistent session
+   - subagent 的 session 可以跨多次调用保持
+   - 支持 `acpx <agent> sessions list/new/close`
+
+6. **Steer 能力**
+   - 向正在运行的 subagent session 发送新指令
+   - 对应 OpenClaw 的 `subagents(action=steer)`
+
+7. **Session resume**
+   - daemon 重启后，能恢复之前的 subagent session
+   - 通过 `acpx <agent> sessions ensure --name <name>` 实现
+
+### P2 — Advanced
+
+8. **Agent 自动发现**
+   - 检测本机已安装的 agent（`claude --version`、`codex --version` 等）
+   - 在 config 中配置可用 agent 列表
+
+9. **Per-agent config**
+   ```yaml
+   subagent:
+     defaultAgent: claude
+     agents:
+       claude:
+         permissionMode: approve-all
+         model: claude-opus-4.6
+       codex:
+         model: codex-mini
+   ```
+
+## Implementation
+
+### 方案 A：Shell-out to acpx binary
+
+最简方案，直接调用 acpx CLI：
+
+```typescript
+// Before:
+const proc = spawn("claude", ["-p", "--output-format", "stream-json", ...]);
+
+// After:
+const proc = spawn("acpx", [agent, "exec", prompt], {
+  cwd: options.cwd,
+  env: { ...process.env },
+});
+```
+
+优点：零 adapter 代码，acpx 处理所有协议细节。
+缺点：依赖 acpx binary，事件解析需要适配。
+
+### 方案 B：引入 acpx 作为 npm dependency
+
+```json
+{
+  "dependencies": {
+    "acpx": "^0.5.0"
+  }
+}
+```
+
+直接 import acpx 的 programmatic API（如果暴露了的话）。
+
+优点：类型安全，不走 CLI 解析。
+缺点：acpx 可能没有 public programmatic API。
+
+### 推荐
+
+**方案 A**（shell-out）优先。acpx 作为 peerDependency 或 optionalDependency，文档说明安装方式。如果后续 acpx 暴露了 programmatic API，再迁移到方案 B。
+
+### 事件流适配
+
+acpx CLI 的 stdout 输出格式需要分析。初步观察：
+- 进度信息走 stderr（`[client] initialize (running)`）
+- 内容输出走 stdout（直接是 text）
+- `exec` 模式是 one-shot，没有 session 状态
+
+需要测试 `--format json` 或其他输出格式是否能拿到结构化事件。
+
+## Acceptance Criteria
+
+- [ ] `spawn_subagent` 默认使用 acpx binary
+- [ ] `spawn_subagent` 支持 `agent: "claude"` 和 `agent: "codex"`
+- [ ] DiscordSink streaming 正常工作
+- [ ] cancel/abort 通过 ACP 协议或 process kill 正常工作
+- [ ] 回退机制：如果 acpx 不可用，fallback 到直接 `claude -p`
+- [ ] 测试覆盖新旧两种 backend
+
+## Dependencies
+
+- `acpx` binary（peerDependency 或全局安装）
+- 各 agent 的 ACP adapter（由 acpx 自动解析 via npx）

--- a/docs/prd/PRD-262-tui-cli.md
+++ b/docs/prd/PRD-262-tui-cli.md
@@ -1,0 +1,274 @@
+# PRD-262: TUI — Interactive Terminal Chat + CLI Management Commands
+
+## Issue
+
+<https://github.com/GhostComplex/isotopes/issues/262>
+
+## Problem
+
+在没有 GUI 的 Linux VM（或任何 headless 环境）上，用户无法使用 WebChat 与 agent 交互。需要：
+1. **TUI** — 终端内的交互式聊天界面，对标 WebChat 的所有能力
+2. **CLI commands** — 一次性管理命令，用于运维和脚本
+
+## Goal
+
+`isotopes tui` 提供完整的终端聊天体验，`isotopes <command>` 提供所有管理操作。
+
+---
+
+## Part 1: TUI — 交互式终端聊天
+
+### 1.1 核心功能
+
+| 功能 | 说明 |
+| --- | --- |
+| 实时聊天 | 输入 prompt → streaming 输出 → 支持多轮对话 |
+| Agent 选择 | 启动时选择 agent 或 `--agent <id>` 指定 |
+| Session 管理 | 列出 / 切换 / 新建 / 删除 session |
+| Markdown 渲染 | 代码块语法高亮、表格、列表 |
+| 工具调用展示 | 显示 tool_use 状态（thinking → calling → result） |
+| 历史回看 | 加载已有 session 的历史消息 |
+
+### 1.2 布局
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 🔬 Isotopes TUI  │ Agent: fairy  │ Model: opus-4.6  │
+├──────────┬──────────────────────────────────────────┤
+│ Sessions │                                          │
+│          │  [assistant] Hello! How can I help?       │
+│ > #main  │                                          │
+│   #dev   │  [you] 看一下 PR #42 的改动              │
+│   #ops   │                                          │
+│          │  [assistant] 正在查看...                  │
+│          │  🔧 exec: gh pr view 42                  │
+│          │                                          │
+│          │  PR #42 的改动如下：                      │
+│          │  ...                                      │
+├──────────┴──────────────────────────────────────────┤
+│ > 输入消息...                              [Enter ⏎]│
+└─────────────────────────────────────────────────────┘
+```
+
+- **左侧 sidebar**：session 列表，按 agent 分组，高亮当前 session
+- **主区域**：聊天消息，支持滚动
+- **底部**：输入框，支持多行（Shift+Enter）
+- **顶部 status bar**：agent 名、model、连接状态
+
+### 1.3 快捷键
+
+| 快捷键 | 功能 |
+| --- | --- |
+| `Ctrl+N` | 新建 session |
+| `Ctrl+T` / `Tab` | 切换 session（sidebar 导航） |
+| `Ctrl+D` | 删除当前 session |
+| `Ctrl+L` | 清屏 |
+| `Ctrl+C` | 取消当前生成 / 退出 |
+| `Ctrl+K` | 命令面板（类似 VS Code） |
+| `↑` / `↓` | 历史消息滚动 |
+| `PageUp` / `PageDown` | 快速滚动 |
+
+### 1.4 内置命令（在输入框中）
+
+| 命令 | 功能 |
+| --- | --- |
+| `/new` | 新建 session |
+| `/switch <name>` | 切换 session |
+| `/sessions` | 列出 session |
+| `/model <name>` | 切换 model |
+| `/status` | 查看状态 |
+| `/compact` | 触发 compaction |
+| `/agent <id>` | 切换 agent |
+| `/quit` | 退出 TUI |
+
+### 1.5 技术选型
+
+**推荐：Ink (React for CLI)**
+
+理由：
+- TypeScript 原生支持，与 Isotopes 技术栈一致
+- 声明式 UI，组件化开发
+- 支持 flexbox 布局
+- 社区活跃，生态丰富
+- 支持 streaming 更新
+
+```json
+{
+  "dependencies": {
+    "ink": "^5.0.0",
+    "ink-text-input": "^6.0.0",
+    "ink-spinner": "^5.0.0",
+    "ink-syntax-highlight": "^2.0.0",
+    "cli-markdown": "^3.0.0"
+  }
+}
+```
+
+**备选：blessed / neo-blessed**
+- 更底层，更灵活
+- 但 API 老旧，TypeScript 支持弱
+
+### 1.6 API 接入
+
+TUI 通过 HTTP API 与 daemon 通信，复用现有 REST 端点：
+
+| TUI 功能 | API 端点 |
+| --- | --- |
+| 发送消息 | `POST /api/chat/stream`（SSE） |
+| 获取历史 | `GET /api/chat/history?sessionId=` |
+| 列出 session | `GET /api/sessions` |
+| 删除 session | `DELETE /api/sessions/:id` |
+| 查看状态 | `GET /api/status` |
+| 列出 agent | `GET /api/chat/agents` |
+| 查看日志 | `GET /api/logs` |
+| 查看 usage | `GET /api/usage` |
+
+如果 daemon 未运行，TUI 提示 `isotopes start` 先启动。
+
+---
+
+## Part 2: CLI Management Commands
+
+### 2.1 Agent 管理
+
+```bash
+isotopes agent list                    # 列出所有 agent
+isotopes agent info <id>               # 查看 agent 详情（model/workspace/bindings）
+isotopes agent add <id>                # 交互式添加 agent
+isotopes agent remove <id>             # 删除 agent（需确认）
+```
+
+实现方式：读写 `~/.isotopes/config.yaml`，调用 `PUT /api/config` 触发 hot-reload。
+
+### 2.2 Session 管理
+
+```bash
+isotopes sessions list                 # 列出所有活跃 session
+isotopes sessions show <id>            # 查看 session 详情和最近 N 条消息
+isotopes sessions delete <id>          # 删除 session
+isotopes sessions reset [--agent <id>] # 清空指定 agent 的所有 session
+```
+
+### 2.3 Model 管理
+
+```bash
+isotopes model                         # 查看当前默认 model
+isotopes model list                    # 列出所有可用 model
+isotopes model set <model>             # 切换默认 model
+isotopes model set <model> --agent <id> # 切换指定 agent 的 model
+```
+
+### 2.4 一次性聊天
+
+```bash
+isotopes chat "你的 prompt"             # 发送消息并等待回复（非交互式）
+isotopes chat --agent fairy "看下 PR"   # 指定 agent
+isotopes chat --stream "解释一下"       # streaming 输出
+isotopes chat -f prompt.md             # 从文件读取 prompt
+```
+
+用途：脚本集成、CI/CD、快速提问。
+
+### 2.5 Cron 管理
+
+```bash
+isotopes cron list                     # 列出定时任务
+isotopes cron add --name "daily" \
+  --expression "0 9 * * *" \
+  --agent fairy \
+  --action prompt \
+  --message "早间汇报"                 # 添加定时任务
+isotopes cron remove <id>              # 删除
+isotopes cron enable <id>              # 启用
+isotopes cron disable <id>             # 禁用
+```
+
+### 2.6 日志 & 调试
+
+```bash
+isotopes logs                          # tail 最近 100 行日志
+isotopes logs -f                       # follow 模式
+isotopes logs -n 500                   # 指定行数
+isotopes usage                         # token 消耗统计
+isotopes usage --agent fairy           # 指定 agent
+```
+
+### 2.7 Config 管理
+
+```bash
+isotopes config show                   # 查看当前 config（脱敏显示）
+isotopes config edit                   # 用 $EDITOR 打开 config 文件
+isotopes config validate               # 校验 config 格式
+isotopes config path                   # 显示 config 文件路径
+```
+
+### 2.8 健康检查
+
+```bash
+isotopes doctor                        # 全面检查
+```
+
+检查项：
+- Daemon 是否运行
+- API 是否可达
+- Discord bot token 是否有效（尝试连接）
+- Provider API 是否可达（发送 ping）
+- Workspace 目录是否存在
+- Config 是否合法
+- Node.js 版本是否 ≥ 20
+- 可选依赖检查（claude CLI、acpx 等）
+
+输出示例：
+```
+🔬 Isotopes Doctor
+
+✅ Daemon running (pid 12345, uptime 2d 3h)
+✅ API reachable (http://127.0.0.1:7600)
+✅ Discord connected (2 bots online)
+✅ Provider reachable (copilot-proxy)
+✅ Workspace exists (~/.isotopes/workspace/fairy)
+✅ Config valid
+✅ Node.js v24.14.0
+⚠️  claude CLI not found (subagent will not work)
+⚠️  acpx not found (ACP protocol unavailable)
+
+7/9 checks passed
+```
+
+---
+
+## Priority
+
+### P0（MVP — Linux VM 可用）
+- `isotopes tui` — 基本聊天 + streaming
+- `isotopes chat "prompt"` — 一次性聊天
+
+### P1（完整体验）
+- TUI session 切换、sidebar、快捷键
+- agent/session/model CLI 命令
+- `isotopes logs` + `isotopes doctor`
+
+### P2（锦上添花）
+- cron CLI 命令
+- config CLI 命令
+- usage 统计
+- TUI 命令面板（Ctrl+K）
+
+## Acceptance Criteria
+
+- [ ] `isotopes tui` 启动交互式界面
+- [ ] TUI 中能发送消息并看到 streaming 回复
+- [ ] TUI 中能切换 session
+- [ ] `isotopes chat "hello"` 返回回复
+- [ ] `isotopes agent list` 列出 agent
+- [ ] `isotopes sessions list` 列出 session
+- [ ] `isotopes logs` 输出日志
+- [ ] `isotopes doctor` 输出健康检查结果
+- [ ] 所有 CLI 命令支持 `--help`
+- [ ] 所有 CLI 命令支持 `--json` 输出（方便脚本使用）
+
+## Dependencies
+
+- **ink** ^5.0.0（TUI 框架）
+- 现有 REST API（`/api/chat/*`、`/api/sessions`、`/api/status` 等）
+- Node.js ≥ 20


### PR DESCRIPTION
## Summary

为 isotopes-1.0 剩余的 4 个核心 issue 创建 PRD：

### PRD 列表

| PRD | Issue | Priority | 描述 |
| --- | --- | --- | --- |
| PRD-260 | #260 | **P0** | npm package release & CLI install |
| PRD-223 | #223 | P1 | Slash commands: /new, /reset, /compact + daily reset |
| PRD-261 | #261 | P1 | Migrate subagent backend to real acpx ACP protocol |
| PRD-262 | #262 | P1 | TUI: Interactive terminal chat + CLI management commands |

### PRD-260: npm Package Release (P0)
- `npm install -g isotopes && isotopes start` 即可运行
- 构建产物完整（dist + web 静态资源）
- `isotopes init` 交互式初始化 config
- CI 自动 publish

### PRD-223: Slash Commands (P1)
- `/new` `/reset` — 清空 session 历史
- `/compact` — 立即触发 compaction
- `/sessions` — 列出活跃 session
- Daily reset — config 级别自动重置

### PRD-261: acpx Migration (P1)
- 从 `claude -p --output-format stream-json` 迁移到真正的 acpx ACP 协议
- 多 agent 支持（至少 claude + codex）
- Session 持久化 + steer 能力
- 保持 DiscordSink streaming

### PRD-262: TUI + CLI Commands (P1)
- `isotopes tui` — 交互式终端聊天界面（对标 WebChat）
- `isotopes chat "prompt"` — 一次性聊天
- agent/session/model/cron/logs/config/doctor 管理命令
- 技术选型：Ink (React for CLI)

Closes: N/A (docs only, issues remain open for implementation)