### PR TITLE
fix(subagent): move --model/--max-turns/--timeout to acpx global flags

### DIFF
--- a/src/subagent/acpx-backend.ts
+++ b/src/subagent/acpx-backend.ts
@@ -396,9 +396,8 @@ export class AcpxBackend {
       postAgentArgs.push("--model", options.model);
     }
 
-    if (options.maxTurns !== undefined) {
-      postAgentArgs.push("--max-turns", String(options.maxTurns));
-    }
+    // Note: acpx exec does not support --max-turns (unlike claude -p)
+    // maxTurns is only used in buildLegacyArgs() for fallback
 
     return { preAgentArgs, postAgentArgs };
   }

--- a/src/subagent/acpx-backend.ts
+++ b/src/subagent/acpx-backend.ts
@@ -390,14 +390,20 @@ export class AcpxBackend {
         break;
     }
 
-    const postAgentArgs: string[] = ["exec", "--file", "-"];
-
+    // --model, --max-turns, --timeout are global flags — must go BEFORE agent subcommand
     if (options.model) {
-      postAgentArgs.push("--model", options.model);
+      preAgentArgs.push("--model", options.model);
     }
 
-    // Note: acpx exec does not support --max-turns (unlike claude -p)
-    // maxTurns is only used in buildLegacyArgs() for fallback
+    if (options.maxTurns !== undefined) {
+      preAgentArgs.push("--max-turns", String(options.maxTurns));
+    }
+
+    if (options.timeout !== undefined) {
+      preAgentArgs.push("--timeout", String(options.timeout));
+    }
+
+    const postAgentArgs: string[] = ["exec", "--file", "-"];
 
     return { preAgentArgs, postAgentArgs };
   }

--- a/tests/subagent-security.test.ts
+++ b/tests/subagent-security.test.ts
@@ -469,15 +469,24 @@ describe("buildAcpxArgs", () => {
   it("includes model flag when specified", () => {
     const backend = new AcpxBackend({ permissionMode: "skip" });
     const result = backend.buildAcpxArgs({ agent: "claude", prompt: "test", cwd: "/tmp", model: "claude-opus" });
-    expect(result.postAgentArgs).toContain("--model");
-    expect(result.postAgentArgs).toContain("claude-opus");
+    expect(result.preAgentArgs).toContain("--model");
+    expect(result.preAgentArgs).toContain("claude-opus");
+    expect(result.postAgentArgs).toEqual(["exec", "--file", "-"]);
   });
 
   it("includes max-turns flag when specified", () => {
     const backend = new AcpxBackend({ permissionMode: "skip" });
     const result = backend.buildAcpxArgs({ agent: "claude", prompt: "test", cwd: "/tmp", maxTurns: 10 });
-    expect(result.postAgentArgs).toContain("--max-turns");
-    expect(result.postAgentArgs).toContain("10");
+    expect(result.preAgentArgs).toContain("--max-turns");
+    expect(result.preAgentArgs).toContain("10");
+    expect(result.postAgentArgs).toEqual(["exec", "--file", "-"]);
+  });
+
+  it("includes timeout flag when specified", () => {
+    const backend = new AcpxBackend({ permissionMode: "skip" });
+    const result = backend.buildAcpxArgs({ agent: "claude", prompt: "test", cwd: "/tmp", timeout: 300 });
+    expect(result.preAgentArgs).toContain("--timeout");
+    expect(result.preAgentArgs).toContain("300");
   });
 
   it("skips --approve-all for non-skip permission modes", () => {


### PR DESCRIPTION
acpx exec subcommand does not accept --model or --max-turns. They must be global flags before the agent name. This caused exit code 1 on every subagent spawn with maxTurns configured (which is always, since config sets maxTurns: 100).

Also adds --timeout support.

Found via smoke test after #264 merge.