### PR TITLE
fix(subagent): only treat stderr as error when exit code is non-zero

### DIFF
--- a/src/subagent/acpx-backend.ts
+++ b/src/subagent/acpx-backend.ts
@@ -609,9 +609,10 @@ export class AcpxBackend {
         }
       }
 
-      // Emit stderr as error event if present (but only if it looks like an error)
+      // Emit stderr as error event only if process actually failed (non-zero exit)
+      // acpx may log warnings like "Error handling notification" to stderr even on success
       const stderr = stderrBuffer.trim();
-      if (stderr && (stderr.toLowerCase().includes("error") || code !== 0)) {
+      if (stderr && code !== 0) {
         enqueue({ type: "error", error: stderr });
       }
 


### PR DESCRIPTION
acpx may log warnings to stderr (like 'Error handling notification' for usage_update schema issues) even when completing successfully.

Previously we treated any stderr containing 'error' as a failure, causing false negatives.

Now we only emit error events when the process actually fails (exit code != 0).

Fixes #261