### PR TITLE
fix(subagent): only treat stderr as error when exit code is non-zero

### DIFF
--- a/src/subagent/acpx-backend.ts
+++ b/src/subagent/acpx-backend.ts
@@ -609,9 +609,10 @@ export class AcpxBackend {
         }
       }
 
-      // Emit stderr as error event if present (but only if it looks like an error)
+      // Emit stderr as error event only if process actually failed (non-zero exit)
+      // acpx may log warnings like "Error handling notification" to stderr even on success
       const stderr = stderrBuffer.trim();
-      if (stderr && (stderr.toLowerCase().includes("error") || code !== 0)) {
+      if (stderr && code !== 0) {
         enqueue({ type: "error", error: stderr });
       }
 


### PR DESCRIPTION
acpx logs warnings like `Error handling notification` to stderr even on success. Previous logic treated any stderr containing 'error' as failure → false negatives on every successful acpx spawn.

Now we only emit error events when exit code != 0.

Found during acpx smoke test.