### PR TITLE
feat(commands): add /new, /reset, /compact slash commands

### DIFF
--- a/docs/design/223-slash-commands.md
+++ b/docs/design/223-slash-commands.md
@@ -1,0 +1,219 @@
+# Design: #223 Slash Commands — /new, /reset, /compact
+
+## Issue
+https://github.com/GhostComplex/isotopes/issues/223
+
+## Goal
+Add session management slash commands for user-facing session control.
+
+## Scope
+
+### This PR (P0)
+1. `/new` — Create fresh session, clear current context
+2. `/reset` — Alias for `/new`
+3. `/compact` — Manual compaction trigger with before/after stats
+4. `/compact <instructions>` — Compact with custom guidance (logged, not used yet)
+
+### Future PR (P1)
+- Daily reset (cron-based automatic session rotation)
+- `/new <model>` — Model switch on reset
+
+## Architecture Analysis
+
+### Current Flow (discord.ts lines 326-337)
+```typescript
+if (this.commandHandler.isCommand(content)) {
+  const agentId = this.resolveAgentId(msg);
+  const result = await this.commandHandler.execute(content, {
+    agentManager: this.config.agentManager,
+    sessionStore: this.getSessionStore(agentId),
+    agentId,
+    userId: msg.author.id,
+    username: msg.author.username,
+  });
+  await (msg.channel as SendableChannel).send(result.response);
+  return;
+}
+```
+
+**Problem:** Session is resolved AFTER slash command interception (line 362-363). For `/new` and `/compact`, we need the current session.
+
+### Solution
+Move session resolution BEFORE command dispatch for session-aware commands.
+
+## Implementation
+
+### 1. Extend CommandContext (slash-commands.ts)
+
+```typescript
+export interface CommandContext {
+  agentManager: AgentManager;
+  sessionStore: SessionStore;
+  agentId: string;
+  userId: string;
+  username: string;
+  // New fields for session-aware commands:
+  sessionId?: string;         // Current session ID (may be undefined)
+  sessionKey?: string;        // Session key for creating new session
+  agentInstance?: AgentInstance;  // For forceCompact()
+}
+```
+
+### 2. Add clearMessages to SessionStore
+
+**types.ts:**
+```typescript
+export interface SessionStore {
+  // ... existing methods
+  /** Clear all messages from a session (keeps session, clears history) */
+  clearMessages(sessionId: string): Promise<void>;
+}
+```
+
+**session-store.ts:**
+```typescript
+async clearMessages(sessionId: string): Promise<void> {
+  const session = this.sessions.get(sessionId);
+  if (!session) {
+    throw new Error(`Session "${sessionId}" not found`);
+  }
+  
+  // Clear in-memory messages
+  session.messages = [];
+  session.messagesLoaded = true;
+  session.lastActiveAt = new Date();
+  
+  // Truncate transcript file
+  await fs.writeFile(this.transcriptFile(sessionId), "");
+  await this.persistIndex();
+}
+```
+
+### 3. Add Commands to SlashCommandHandler
+
+```typescript
+const KNOWN_COMMANDS = new Set([
+  "status", "reload", "model",
+  "new", "reset", "compact",  // NEW
+]);
+```
+
+### 4. handleNew / handleReset
+
+```typescript
+private async handleNew(ctx: CommandContext): Promise<CommandResult> {
+  if (!ctx.sessionId) {
+    return { response: "ℹ️ No active session to reset." };
+  }
+  
+  try {
+    await ctx.sessionStore.clearMessages(ctx.sessionId);
+    ctx.agentInstance?.clearMessages?.();
+    
+    log.info(`Session reset by ${ctx.username} (${ctx.userId})`);
+    return { response: "✅ Session reset. Starting fresh." };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error(`Session reset failed: ${msg}`);
+    return { response: `❌ Reset failed: ${msg}` };
+  }
+}
+```
+
+### 5. handleCompact
+
+```typescript
+private async handleCompact(ctx: CommandContext, instructions: string): Promise<CommandResult> {
+  if (!ctx.sessionId) {
+    return { response: "ℹ️ No active session to compact." };
+  }
+  
+  if (!ctx.agentInstance?.forceCompact) {
+    return { response: "❌ Compaction not supported for this agent." };
+  }
+
+  try {
+    const messagesBefore = (await ctx.sessionStore.getMessages(ctx.sessionId)).length;
+    const compacted = await ctx.agentInstance.forceCompact();
+    
+    if (!compacted) {
+      return { response: "ℹ️ Nothing to compact (context too small)." };
+    }
+    
+    const messagesAfter = (await ctx.sessionStore.getMessages(ctx.sessionId)).length;
+    
+    return {
+      response: `✅ Compacted: ${messagesBefore} → ${messagesAfter} messages`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { response: `❌ Compaction failed: ${msg}` };
+  }
+}
+```
+
+### 6. Update Discord Transport (discord.ts)
+
+```typescript
+if (this.commandHandler.isCommand(content)) {
+  const agentId = this.resolveAgentId(msg);
+  const sessionStore = this.getSessionStore(agentId);
+  const sessionKey = this.getSessionKey(msg, agentId);
+  const session = await sessionStore.findByKey(sessionKey);
+  const agent = this.config.agentManager.get(agentId);
+  
+  const result = await this.commandHandler.execute(content, {
+    agentManager: this.config.agentManager,
+    sessionStore,
+    agentId,
+    userId: msg.author.id,
+    username: msg.author.username,
+    sessionId: session?.id,
+    sessionKey,
+    agentInstance: agent,
+  });
+  await (msg.channel as SendableChannel).send(result.response);
+  return;
+}
+```
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/core/types.ts` | Add `clearMessages()` to SessionStore interface |
+| `src/core/session-store.ts` | Implement `clearMessages()` |
+| `src/core/session-store.test.ts` | Tests for `clearMessages()` |
+| `src/commands/slash-commands.ts` | Add /new, /reset, /compact handlers |
+| `src/commands/slash-commands.test.ts` | Tests for new commands |
+| `src/transports/discord.ts` | Pass session context to CommandContext |
+
+## Test Plan
+
+### Unit Tests (slash-commands.test.ts)
+- `/new` clears session messages, returns success
+- `/reset` works as alias for `/new`
+- `/new` with no active session returns info message
+- `/compact` triggers compaction, returns stats
+- `/compact` with no active session returns info message
+- `/compact` with unsupported agent returns error
+
+### Unit Tests (session-store.test.ts)
+- `clearMessages()` clears in-memory messages
+- `clearMessages()` truncates transcript file on disk
+- `clearMessages()` on non-existent session throws
+- `clearMessages()` updates lastActiveAt
+
+## Out of Scope
+- Daily reset (requires cron integration — separate PR)
+- `/new <model>` model switch
+- `/compact <instructions>` custom guidance (logged but not used)
+- Token count display
+
+## Acceptance Criteria
+- [ ] `/new` clears current session messages
+- [ ] `/reset` works as alias for `/new`
+- [ ] `/compact` triggers manual compaction
+- [ ] Admin permission enforced
+- [ ] All unit tests pass
+- [ ] Works in Discord transport

--- a/src/commands/slash-commands.test.ts
+++ b/src/commands/slash-commands.test.ts
@@ -235,6 +235,171 @@ describe("SlashCommandHandler", () => {
   });
 
   // -----------------------------------------------------------------------
+  // /new and /reset
+  // -----------------------------------------------------------------------
+
+  describe("/new and /reset", () => {
+    it("clears session messages and returns success", async () => {
+      const sessionStore = createMockSessionStore();
+      (sessionStore.clearMessages as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+      const agentInstance = {
+        prompt: vi.fn(),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+        clearMessages: vi.fn(),
+      };
+
+      const ctx = createContext({
+        sessionStore,
+        sessionId: "session-123",
+        agentInstance,
+      });
+
+      const result = await handler.execute("/new", ctx);
+
+      expect(sessionStore.clearMessages).toHaveBeenCalledWith("session-123");
+      expect(agentInstance.clearMessages).toHaveBeenCalled();
+      expect(result.response).toContain("Session reset");
+    });
+
+    it("/reset works as alias for /new", async () => {
+      const sessionStore = createMockSessionStore();
+      (sessionStore.clearMessages as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+      const ctx = createContext({
+        sessionStore,
+        sessionId: "session-456",
+      });
+
+      const result = await handler.execute("/reset", ctx);
+
+      expect(sessionStore.clearMessages).toHaveBeenCalledWith("session-456");
+      expect(result.response).toContain("Session reset");
+    });
+
+    it("returns info message when no active session", async () => {
+      const ctx = createContext({ sessionId: undefined });
+      const result = await handler.execute("/new", ctx);
+      expect(result.response).toContain("No active session to reset");
+    });
+
+    it("reports error on clearMessages failure", async () => {
+      const sessionStore = createMockSessionStore();
+      (sessionStore.clearMessages as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("Session not found"),
+      );
+
+      const ctx = createContext({
+        sessionStore,
+        sessionId: "session-789",
+      });
+
+      const result = await handler.execute("/new", ctx);
+
+      expect(result.response).toContain("Reset failed");
+      expect(result.response).toContain("Session not found");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // /compact
+  // -----------------------------------------------------------------------
+
+  describe("/compact", () => {
+    it("triggers compaction and returns stats", async () => {
+      const sessionStore = createMockSessionStore();
+      (sessionStore.getMessages as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([1, 2, 3, 4, 5])  // before
+        .mockResolvedValueOnce([1, 2]);          // after
+
+      const agentInstance = {
+        prompt: vi.fn(),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+        forceCompact: vi.fn().mockResolvedValue(true),
+      };
+
+      const ctx = createContext({
+        sessionStore,
+        sessionId: "session-compact",
+        agentInstance,
+      });
+
+      const result = await handler.execute("/compact", ctx);
+
+      expect(agentInstance.forceCompact).toHaveBeenCalled();
+      expect(result.response).toContain("Compacted: 5 → 2 messages");
+    });
+
+    it("returns info when nothing to compact", async () => {
+      const agentInstance = {
+        prompt: vi.fn(),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+        forceCompact: vi.fn().mockResolvedValue(false),
+      };
+
+      const ctx = createContext({
+        sessionId: "session-small",
+        agentInstance,
+      });
+
+      const result = await handler.execute("/compact", ctx);
+
+      expect(result.response).toContain("Nothing to compact");
+    });
+
+    it("returns info when no active session", async () => {
+      const ctx = createContext({ sessionId: undefined });
+      const result = await handler.execute("/compact", ctx);
+      expect(result.response).toContain("No active session to compact");
+    });
+
+    it("returns error when agent does not support compaction", async () => {
+      const agentInstance = {
+        prompt: vi.fn(),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+        // No forceCompact method
+      };
+
+      const ctx = createContext({
+        sessionId: "session-no-compact",
+        agentInstance,
+      });
+
+      const result = await handler.execute("/compact", ctx);
+
+      expect(result.response).toContain("Compaction not supported");
+    });
+
+    it("reports error on compaction failure", async () => {
+      const agentInstance = {
+        prompt: vi.fn(),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+        forceCompact: vi.fn().mockRejectedValue(new Error("Model API error")),
+      };
+
+      const ctx = createContext({
+        sessionId: "session-error",
+        agentInstance,
+      });
+
+      const result = await handler.execute("/compact", ctx);
+
+      expect(result.response).toContain("Compaction failed");
+      expect(result.response).toContain("Model API error");
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Invalid input
   // -----------------------------------------------------------------------
 

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -1,7 +1,7 @@
 // src/commands/slash-commands.ts — Slash command handler for admin operations
 // Parses and dispatches /status, /reload, /model commands from chat messages.
 
-import type { AgentManager, SessionStore } from "../core/types.js";
+import type { AgentManager, SessionStore, AgentInstance } from "../core/types.js";
 import { createLogger } from "../core/logger.js";
 
 const log = createLogger("commands");
@@ -22,6 +22,12 @@ export interface CommandContext {
   userId: string;
   /** Discord username of the invoker */
   username: string;
+  /** Current session ID (if available) */
+  sessionId?: string;
+  /** Current session key (if available) */
+  sessionKey?: string;
+  /** Agent instance (if available) */
+  agentInstance?: AgentInstance;
 }
 
 /** Result of executing a slash command */
@@ -102,6 +108,11 @@ export class SlashCommandHandler {
         return this.handleReload(ctx);
       case "model":
         return this.handleModel(ctx, parsed.args);
+      case "new":
+      case "reset":
+        return this.handleNew(ctx);
+      case "compact":
+        return this.handleCompact(ctx, parsed.args);
       default:
         return { response: `Unknown command: /${parsed.name}` };
     }
@@ -173,10 +184,60 @@ export class SlashCommandHandler {
       return { response: `❌ Model switch failed: ${msg}` };
     }
   }
+
+  private async handleNew(ctx: CommandContext): Promise<CommandResult> {
+    if (!ctx.sessionId) {
+      return { response: "ℹ️ No active session to reset." };
+    }
+
+    try {
+      await ctx.sessionStore.clearMessages(ctx.sessionId);
+      ctx.agentInstance?.clearMessages?.();
+
+      log.info(`Session reset by ${ctx.username} (${ctx.userId})`);
+      return { response: "✅ Session reset. Starting fresh." };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Session reset failed: ${msg}`);
+      return { response: `❌ Reset failed: ${msg}` };
+    }
+  }
+
+  private async handleCompact(ctx: CommandContext, instructions: string): Promise<CommandResult> {
+    if (!ctx.sessionId) {
+      return { response: "ℹ️ No active session to compact." };
+    }
+
+    if (!ctx.agentInstance?.forceCompact) {
+      return { response: "❌ Compaction not supported for this agent." };
+    }
+
+    try {
+      const messagesBefore = (await ctx.sessionStore.getMessages(ctx.sessionId)).length;
+      const compacted = await ctx.agentInstance.forceCompact();
+
+      if (!compacted) {
+        return { response: "ℹ️ Nothing to compact (context too small)." };
+      }
+
+      const messagesAfter = (await ctx.sessionStore.getMessages(ctx.sessionId)).length;
+
+      if (instructions) {
+        log.info(`Compact instructions (not used yet): ${instructions}`);
+      }
+
+      return {
+        response: `✅ Compacted: ${messagesBefore} → ${messagesAfter} messages`,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { response: `❌ Compaction failed: ${msg}` };
+    }
+  }
 }
 
 /** Set of known command names for isCommand() filtering */
-const KNOWN_COMMANDS = new Set(["status", "reload", "model"]);
+const KNOWN_COMMANDS = new Set(["status", "reload", "model", "new", "reset", "compact"]);
 
 /** Format milliseconds as a human-readable uptime string */
 function formatUptime(ms: number): string {

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -426,4 +426,59 @@ describe("DefaultSessionStore", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // clearMessages
+  // -------------------------------------------------------------------------
+
+  describe("clearMessages", () => {
+    it("clears in-memory messages", async () => {
+      const session = await store.create("agent-1");
+      await store.addMessage(session.id, { role: "user", content: textContent("msg1") });
+      await store.addMessage(session.id, { role: "assistant", content: textContent("msg2") });
+
+      await store.clearMessages(session.id);
+
+      const messages = await store.getMessages(session.id);
+      expect(messages).toHaveLength(0);
+    });
+
+    it("truncates transcript file on disk", async () => {
+      const session = await store.create("agent-1");
+      await store.addMessage(session.id, { role: "user", content: textContent("persist1") });
+      await store.addMessage(session.id, { role: "assistant", content: textContent("persist2") });
+
+      const transcriptFile = path.join(tempDir, `${session.id}.jsonl`);
+
+      // Verify messages are persisted
+      const beforeContent = await fs.readFile(transcriptFile, "utf-8");
+      expect(beforeContent.trim().split("\n")).toHaveLength(2);
+
+      await store.clearMessages(session.id);
+
+      // Verify transcript is truncated
+      const afterContent = await fs.readFile(transcriptFile, "utf-8");
+      expect(afterContent).toBe("");
+    });
+
+    it("throws on non-existent session", async () => {
+      await expect(
+        store.clearMessages("non-existent"),
+      ).rejects.toThrow('Session "non-existent" not found');
+    });
+
+    it("updates lastActiveAt", async () => {
+      const session = await store.create("agent-1");
+
+      // Wait a tiny bit to ensure time difference
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const beforeTimestamp = (await store.get(session.id))!.lastActiveAt.getTime();
+
+      await store.clearMessages(session.id);
+
+      const afterTimestamp = (await store.get(session.id))!.lastActiveAt.getTime();
+      expect(afterTimestamp).toBeGreaterThan(beforeTimestamp);
+    });
+  });
+
 });

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -177,6 +177,22 @@ export class DefaultSessionStore implements SessionStore {
     }
   }
 
+  async clearMessages(sessionId: string): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session "${sessionId}" not found`);
+    }
+
+    // Clear in-memory messages
+    session.messages = [];
+    session.messagesLoaded = true;
+    session.lastActiveAt = new Date();
+
+    // Truncate transcript file
+    await fs.writeFile(this.transcriptFile(sessionId), "");
+    await this.persistIndex();
+  }
+
   // -------------------------------------------------------------------------
   // TTL & cleanup
   // -------------------------------------------------------------------------

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -74,5 +74,6 @@ export function createMockSessionStore(sessionId = "session-123"): SessionStore 
     getMessages: vi.fn().mockResolvedValue([]),
     delete: vi.fn(),
     list: vi.fn().mockResolvedValue([]),
+    clearMessages: vi.fn(),
   };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -244,6 +244,8 @@ export interface SessionStore {
   delete(sessionId: string): Promise<void>;
   /** List all sessions (lightweight, no message bodies). */
   list(): Promise<Session[]>;
+  /** Clear all messages from a session (keeps session metadata, clears history) */
+  clearMessages(sessionId: string): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -325,12 +325,20 @@ export class DiscordTransport implements Transport {
     // 4.5. Slash command interception — handle admin commands before agent dispatch
     if (this.commandHandler.isCommand(content)) {
       const agentId = this.resolveAgentId(msg);
+      const sessionStore = this.getSessionStore(agentId);
+      const sessionKey = this.getSessionKey(msg, agentId);
+      const session = await sessionStore.findByKey(sessionKey);
+      const agent = this.config.agentManager.get(agentId);
+
       const result = await this.commandHandler.execute(content, {
         agentManager: this.config.agentManager,
-        sessionStore: this.getSessionStore(agentId),
+        sessionStore,
         agentId,
         userId: msg.author.id,
         username: msg.author.username,
+        sessionId: session?.id,
+        sessionKey,
+        agentInstance: agent,
       });
       await (msg.channel as SendableChannel).send(result.response);
       return;


### PR DESCRIPTION
## Summary
Add session management slash commands for user-facing session control.

## Changes
- **SessionStore.clearMessages()** — Clear messages while preserving session
- **/new, /reset** — Reset session, clear message history
- **/compact** — Manual compaction trigger with before/after stats
- **Discord transport** — Pass session context to command handler

## Testing
- Unit tests for clearMessages()
- Unit tests for /new, /reset, /compact commands
- All existing tests pass (2 pre-existing ACP persistence failures unrelated)

Closes #223