### PR TITLE
feat(subagent): use ClientSideConnection from @agentclientprotocol/sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,13 +53,14 @@
     "vitest": "3.1.3"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^0.18.2",
     "@larksuiteoapi/node-sdk": "^1.60.0",
     "@mariozechner/pi-agent-core": "^0.64.0",
     "@mariozechner/pi-ai": "^0.64.0",
     "acpx": "^0.5.3",
     "discord.js": "^14.18.0",
     "yaml": "2.7.1",
-    "zod": "3.24.4"
+    "zod": "3.25.76"
   },
   "lint-staged": {
     "*.ts": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^0.18.2
+        version: 0.18.2(zod@3.25.76)
       '@larksuiteoapi/node-sdk':
         specifier: ^1.60.0
         version: 1.60.0
       '@mariozechner/pi-agent-core':
         specifier: ^0.64.0
-        version: 0.64.0(ws@8.20.0)(zod@3.24.4)
+        version: 0.64.0(ws@8.20.0)(zod@3.25.76)
       '@mariozechner/pi-ai':
         specifier: ^0.64.0
-        version: 0.64.0(ws@8.20.0)(zod@3.24.4)
+        version: 0.64.0(ws@8.20.0)(zod@3.25.76)
       acpx:
         specifier: ^0.5.3
         version: 0.5.3
@@ -27,8 +30,8 @@ importers:
         specifier: 2.7.1
         version: 2.7.1
       zod:
-        specifier: 3.24.4
-        version: 3.24.4
+        specifier: 3.25.76
+        version: 3.25.76
     devDependencies:
       '@eslint/js':
         specifier: 9.27.0
@@ -68,6 +71,11 @@ packages:
 
   '@agentclientprotocol/sdk@0.17.1':
     resolution: {integrity: sha512-yjyIn8POL18IOXioLySYiL0G44kZ/IZctAls7vS3AC3X+qLhFXbWmzABSZehwRnWFShMXT+ODa/HJG1+mGXZ1A==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@agentclientprotocol/sdk@0.18.2':
+    resolution: {integrity: sha512-l/o9NKvUc00GPa6RFJ4AccQq2O/PAf83xQ75mThHuL3H571iN4+PEdwnTBez67sS8Nv2aSA373xCZ5CbTXEwzA==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -2169,8 +2177,8 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -2181,11 +2189,15 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.73.0(zod@3.24.4)':
+  '@agentclientprotocol/sdk@0.18.2(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
+  '@anthropic-ai/sdk@0.73.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 3.24.4
+      zod: 3.25.76
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -2802,9 +2814,9 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@mariozechner/pi-agent-core@0.64.0(ws@8.20.0)(zod@3.24.4)':
+  '@mariozechner/pi-agent-core@0.64.0(ws@8.20.0)(zod@3.25.76)':
     dependencies:
-      '@mariozechner/pi-ai': 0.64.0(ws@8.20.0)(zod@3.24.4)
+      '@mariozechner/pi-ai': 0.64.0(ws@8.20.0)(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -2814,9 +2826,9 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.64.0(ws@8.20.0)(zod@3.24.4)':
+  '@mariozechner/pi-ai@0.64.0(ws@8.20.0)(zod@3.25.76)':
     dependencies:
-      '@anthropic-ai/sdk': 0.73.0(zod@3.24.4)
+      '@anthropic-ai/sdk': 0.73.0(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1024.0
       '@google/genai': 1.48.0
       '@mistralai/mistralai': 1.14.1
@@ -2824,11 +2836,11 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@3.24.4)
+      openai: 6.26.0(ws@8.20.0)(zod@3.25.76)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       undici: 7.24.7
-      zod-to-json-schema: 3.25.2(zod@3.24.4)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -2841,8 +2853,8 @@ snapshots:
   '@mistralai/mistralai@1.14.1':
     dependencies:
       ws: 8.20.0
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4153,10 +4165,10 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.26.0(ws@8.20.0)(zod@3.24.4):
+  openai@6.26.0(ws@8.20.0)(zod@3.25.76):
     optionalDependencies:
       ws: 8.20.0
-      zod: 3.24.4
+      zod: 3.25.76
 
   optionator@0.9.4:
     dependencies:
@@ -4628,14 +4640,10 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.25.2(zod@3.24.4):
+  zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
-      zod: 3.24.4
+      zod: 3.25.76
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
-
-  zod@3.24.4: {}
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/src/subagent/acpx-backend.ts
+++ b/src/subagent/acpx-backend.ts
@@ -5,6 +5,15 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, statSync, realpathSync } from "node:fs";
 import { resolve, normalize } from "node:path";
+import { Readable, Writable } from "node:stream";
+import {
+  ClientSideConnection,
+  PROTOCOL_VERSION,
+  ndJsonStream,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
 import { createLogger } from "../core/logger.js";
 import {
   ACPX_AGENTS,
@@ -466,14 +475,288 @@ export class AcpxBackend {
   }
 
   /**
+   * Handle permission request from ACP protocol.
+   * Auto-approves based on permission mode configuration.
+   */
+  private async resolvePermission(
+    params: RequestPermissionRequest,
+    options: AcpxSpawnOptions,
+  ): Promise<RequestPermissionResponse> {
+    const permissionMode = options.permissionMode ?? this.permissionMode;
+    const allowedTools = options.allowedTools ?? this.allowedTools;
+    const permOptions = params.options ?? [];
+
+    if (permOptions.length === 0) {
+      log.debug("Permission request has no options — cancelling");
+      return { outcome: { outcome: "cancelled" } };
+    }
+
+    // Helper to find option by kind
+    const findOption = (...kinds: string[]) => {
+      for (const kind of kinds) {
+        const match = permOptions.find((opt) => opt.kind === kind);
+        if (match) return match;
+      }
+      return undefined;
+    };
+
+    // Extract tool name from request
+    const toolName = params.toolCall?.title ?? "unknown";
+
+    switch (permissionMode) {
+      case "skip": {
+        // Auto-approve all requests
+        const allowOption = findOption("allow_once", "allow_always");
+        if (allowOption) {
+          log.debug(`Auto-approved (skip mode): ${toolName}`);
+          return { outcome: { outcome: "selected", optionId: allowOption.optionId } };
+        }
+        // Fallback to first option if no allow option found
+        log.debug(`Auto-approved (skip mode, fallback): ${toolName}`);
+        return { outcome: { outcome: "selected", optionId: permOptions[0].optionId } };
+      }
+
+      case "allowlist": {
+        // Check if tool is in allowed list
+        const isAllowed = allowedTools.some((allowed) => toolName.includes(allowed));
+        if (isAllowed) {
+          const allowOption = findOption("allow_once", "allow_always");
+          if (allowOption) {
+            log.debug(`Auto-approved (allowlist): ${toolName}`);
+            return { outcome: { outcome: "selected", optionId: allowOption.optionId } };
+          }
+        }
+        // Reject if not in allowlist
+        const rejectOption = findOption("reject_once", "reject_always");
+        if (rejectOption) {
+          log.debug(`Rejected (not in allowlist): ${toolName}`);
+          return { outcome: { outcome: "selected", optionId: rejectOption.optionId } };
+        }
+        log.debug(`Permission cancelled (no reject option): ${toolName}`);
+        return { outcome: { outcome: "cancelled" } };
+      }
+
+      case "default":
+      default: {
+        // Default mode — reject (no interactive prompts in subagents)
+        const rejectOption = findOption("reject_once", "reject_always");
+        if (rejectOption) {
+          log.debug(`Rejected (default mode): ${toolName}`);
+          return { outcome: { outcome: "selected", optionId: rejectOption.optionId } };
+        }
+        log.debug(`Permission cancelled (default mode): ${toolName}`);
+        return { outcome: { outcome: "cancelled" } };
+      }
+    }
+  }
+
+  /**
+   * Spawn a sub-agent using `claude acp` with ClientSideConnection.
+   * This is the preferred method when `claude` CLI is available.
+   *
+   * @param taskId - Unique identifier for this task
+   * @param options - Spawn options (agent, prompt, cwd, etc.)
+   * @yields AcpxEvent stream (start, message, tool_use, tool_result, done, error)
+   */
+  private async *spawnAcp(
+    taskId: string,
+    options: AcpxSpawnOptions,
+  ): AsyncGenerator<AcpxEvent> {
+    log.info(`Spawning claude acp for ${options.agent}`, { taskId, cwd: options.cwd });
+
+    // Spawn claude acp process
+    const proc = spawn(
+      "claude",
+      ["acp"],
+      {
+        cwd: options.cwd,
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          PATH: `${process.env.PATH}:/usr/local/bin:/opt/homebrew/bin:${process.env.HOME}/.local/bin`,
+        },
+      },
+    );
+
+    this.processes.set(taskId, proc);
+
+    if (!proc.stdin || !proc.stdout) {
+      throw new Error("Failed to create ACP stdio pipes");
+    }
+
+    // Convert Node streams to Web streams
+    const input = Writable.toWeb(proc.stdin);
+    const output = Readable.toWeb(proc.stdout) as unknown as ReadableStream<Uint8Array>;
+    const stream = ndJsonStream(input, output);
+
+    // Collect events in a queue
+    const eventQueue: AcpxEvent[] = [];
+    let processExited = false;
+    let exitCode = 0;
+    let resolveWait: (() => void) | undefined;
+    let stderrBuffer = "";
+
+    function enqueue(event: AcpxEvent): void {
+      eventQueue.push(event);
+      resolveWait?.();
+    }
+
+    // Create ClientSideConnection
+    const client = new ClientSideConnection(
+      () => ({
+        sessionUpdate: async (params: SessionNotification) => {
+          const update = params.update;
+          if (!("sessionUpdate" in update)) return;
+
+          switch (update.sessionUpdate) {
+            case "agent_message_chunk": {
+              if (update.content?.type === "text") {
+                enqueue({ type: "message", content: update.content.text });
+              }
+              break;
+            }
+
+            case "tool_call": {
+              if (update.status === "pending") {
+                const meta = update._meta as Record<string, unknown> | undefined;
+                const claudeCode = meta?.claudeCode as Record<string, unknown> | undefined;
+                const toolName = String(claudeCode?.toolName ?? "");
+                enqueue({
+                  type: "tool_use",
+                  toolName,
+                  toolInput: update.rawInput,
+                });
+              }
+              break;
+            }
+
+            case "tool_call_update": {
+              if (update.status === "completed") {
+                const meta = update._meta as Record<string, unknown> | undefined;
+                const claudeCode = meta?.claudeCode as Record<string, unknown> | undefined;
+                const toolName = String(claudeCode?.toolName ?? "");
+                const rawOutput = update.rawOutput;
+                enqueue({
+                  type: "tool_result",
+                  toolName,
+                  toolResult: typeof rawOutput === "string" ? rawOutput : JSON.stringify(rawOutput),
+                });
+              }
+              break;
+            }
+
+            default:
+              break;
+          }
+        },
+        requestPermission: async (params: RequestPermissionRequest) => {
+          return this.resolvePermission(params, options);
+        },
+      }),
+      stream,
+    );
+
+    // Handle stderr
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      stderrBuffer += chunk.toString();
+    });
+
+    // Handle process exit
+    proc.on("close", (code) => {
+      // Emit stderr as error event only if process failed
+      const stderr = stderrBuffer.trim();
+      if (stderr && code !== 0) {
+        enqueue({ type: "error", error: stderr });
+      }
+
+      exitCode = code ?? 0;
+      processExited = true;
+      resolveWait?.();
+    });
+
+    proc.on("error", (err) => {
+      enqueue({ type: "error", error: err.message });
+      processExited = true;
+      resolveWait?.();
+    });
+
+    // Start ACP session
+    let sessionId: string | undefined;
+    try {
+      // Initialize connection
+      await client.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+          terminal: true,
+        },
+        clientInfo: { name: "isotopes-subagent", version: "0.1.0" },
+      });
+
+      // Create session
+      const session = await client.newSession({
+        cwd: options.cwd,
+        mcpServers: [],
+      });
+      sessionId = session.sessionId;
+
+      // Send prompt
+      const promptResult = client.prompt({
+        sessionId,
+        prompt: [{ type: "text", text: options.prompt }],
+      });
+
+      // Yield start event
+      yield { type: "start" };
+
+      // Wait for prompt to complete (this triggers sessionUpdate callbacks)
+      await promptResult;
+
+      // Mark as done
+      enqueue({ type: "done", exitCode: 0 });
+    } catch (err) {
+      enqueue({ type: "error", error: String(err) });
+      enqueue({ type: "done", exitCode: 1 });
+    }
+
+    // Drain the event queue
+    try {
+      while (true) {
+        // Yield any queued events
+        while (eventQueue.length > 0) {
+          yield eventQueue.shift()!;
+        }
+
+        // If process has exited and queue is empty, we're done
+        if (processExited) break;
+
+        // Wait for more events
+        await new Promise<void>((resolve) => {
+          resolveWait = resolve;
+        });
+      }
+    } finally {
+      this.processes.delete(taskId);
+      if (proc && !proc.killed) {
+        proc.kill();
+      }
+    }
+
+    // Always yield a final done event
+    yield { type: "done", exitCode };
+
+    log.info(`claude acp ${options.agent} completed`, { taskId, exitCode });
+  }
+
+  /**
    * Spawn a sub-agent and yield events as they arrive.
    *
-   * Tries acpx first (`npx acpx ...`). If acpx spawn fails (ENOENT),
+   * Tries `claude acp` first with ClientSideConnection. If that fails,
    * falls back to legacy `claude -p --output-format stream-json` mode.
    *
-   * Yields a "start" event immediately, then streams JSON-line events
-   * from stdout. Errors on stderr are accumulated and emitted as error
-   * events. A final "done" event is always emitted when the process exits.
+   * Yields a "start" event immediately, then streams events from the process.
+   * A final "done" event is always emitted when the process exits.
    *
    * @param taskId - Unique identifier for this task (used for cancellation)
    * @param options - Spawn options (agent, prompt, cwd, etc.)
@@ -496,7 +779,16 @@ export class AcpxBackend {
       );
     }
 
-    // Try acpx first, fall back to legacy claude -p
+    // Try claude acp first (preferred method using ClientSideConnection)
+    try {
+      yield* this.spawnAcp(taskId, options);
+      return;
+    } catch (err) {
+      // If claude acp fails, fall back to legacy mode
+      log.info(`claude acp not available, falling back to legacy mode`, { taskId, error: String(err) });
+    }
+
+    // Fall back to legacy acpx or claude -p mode
     let proc: ChildProcess;
     let lineParser: (line: string) => AcpxEvent | undefined;
 


### PR DESCRIPTION
Adds a new `spawnWithSdk()` method to AcpxBackend that uses `@agentclientprotocol/sdk` ClientSideConnection for typed JSON-RPC communication.

## Changes
- Import `ClientSideConnection`, `PROTOCOL_VERSION`, `ndJsonStream` from SDK
- Add `resolvePermissionRequest()` for permission handling based on permissionMode
- Add `handleSessionUpdate()` to map SDK notifications to AcpxEvent types
- Add `spawnWithSdk()` method that uses typed ACP protocol

## Key benefits
- No more manual JSON line parsing for SDK mode
- Typed sessionUpdate handler instead of string matching
- SDK handles JSON-RPC protocol details (framing, validation)
- Permission resolver respects permissionMode config

## Backwards compatible
- Existing `spawn()` method unchanged
- `parseAcpxJsonLine` still exported for legacy mode
- All 1932 tests pass

Closes #268