### PR TITLE
feat(discord): thread control config #272

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -345,6 +345,14 @@ export interface CompactionConfig {
 // Thread bindings — auto-bind Discord threads to agent sessions
 // ---------------------------------------------------------------------------
 
+/** Per-agent thread control configuration */
+export interface ThreadControlConfig {
+  /** Whether to respond to messages in threads. Default: true */
+  respond?: boolean;
+  /** Whether to include thread messages in channel history context. Default: true */
+  observe?: boolean;
+}
+
 /** Configuration for automatic thread-to-session binding */
 export interface ThreadBindingConfig {
   /** Whether thread binding is enabled */

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -12,6 +12,7 @@ const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 type MockChannel = {
   sendTyping: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
+  isThread: ReturnType<typeof vi.fn>;
 };
 
 type MockIncomingMessage = {
@@ -140,6 +141,7 @@ describe("DiscordTransport", () => {
       const channel: MockChannel = {
         sendTyping: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue({}),
+        isThread: vi.fn().mockReturnValue(false),
       };
 
       await (
@@ -189,6 +191,7 @@ describe("DiscordTransport", () => {
       const channel: MockChannel = {
         sendTyping: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(false),
       };
 
       const msg: MockIncomingMessage = {
@@ -226,6 +229,7 @@ describe("DiscordTransport", () => {
       return {
         sendTyping: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(false),
       };
     }
 
@@ -573,6 +577,7 @@ describe("DiscordTransport", () => {
       return {
         sendTyping: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(false),
       };
     }
 
@@ -748,6 +753,7 @@ describe("DiscordTransport", () => {
       return {
         sendTyping: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(false),
       };
     }
 
@@ -895,6 +901,114 @@ describe("DiscordTransport", () => {
       // With historyTurns=2, only the last 2 user turns should be kept
       const userMessages = promptInput.filter(m => m.role === "user");
       expect(userMessages.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("thread control", () => {
+    function makeChannel(isThread = false): MockChannel {
+      return {
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(isThread),
+      };
+    }
+
+    function makeMsg(overrides: Partial<MockIncomingMessage & { channel: MockChannel }> = {}): MockIncomingMessage {
+      return {
+        author: { bot: false, username: "tester", id: "user-1" },
+        content: "<@bot-123> hello",
+        createdTimestamp: Date.now(),
+        guild: { id: "guild-1" },
+        channelId: "channel-1",
+        channel: makeChannel(false),
+        mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        id: `msg-${Date.now()}`,
+        ...overrides,
+      };
+    }
+
+    it("responds to thread messages by default (threads.respond undefined)", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+
+      await localTransport.start();
+      const channel = makeChannel(true); // is a thread
+      const msg = makeMsg({ channel });
+
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      // Should respond (send was called)
+      expect(channel.send).toHaveBeenCalled();
+    });
+
+    it("does NOT respond in threads when threads.respond=false", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+        threads: { respond: false },
+      });
+
+      await localTransport.start();
+      const channel = makeChannel(true); // is a thread
+      const msg = makeMsg({ channel });
+
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      // Should NOT respond
+      expect(channel.send).not.toHaveBeenCalled();
+    });
+
+    it("still responds in regular channels when threads.respond=false", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+        threads: { respond: false },
+      });
+
+      await localTransport.start();
+      const channel = makeChannel(false); // NOT a thread
+      const msg = makeMsg({ channel });
+
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      // Should respond in regular channel
+      expect(channel.send).toHaveBeenCalled();
+    });
+
+    it("ignores thread messages completely when both respond=false and observe=false", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+        threads: { respond: false, observe: false },
+      });
+
+      await localTransport.start();
+      const channel = makeChannel(true); // is a thread
+      const msg = makeMsg({ channel });
+
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      // Should NOT respond and NOT add to session store
+      expect(channel.send).not.toHaveBeenCalled();
+      expect(localSessionStore.addMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -175,6 +175,13 @@ export interface DiscordTransportConfig {
   usageTracker?: UsageTracker;
   /** Discord user IDs allowed to execute slash commands */
   adminUsers?: string[];
+  /** Thread control configuration — whether to respond/observe in threads */
+  threads?: {
+    /** Whether to respond to messages in threads. Default: true */
+    respond?: boolean;
+    /** Whether to include thread messages in channel history context. Default: true */
+    observe?: boolean;
+  };
 }
 
 /**
@@ -299,10 +306,44 @@ export class DiscordTransport implements Transport {
       return;
     }
 
+    // 2.5. Thread control — skip thread messages based on threads.respond/observe config
+    const isThread = msg.channel.isThread();
+    const threadsRespond = this.config.threads?.respond ?? true;
+    const threadsObserve = this.config.threads?.observe ?? true;
+
+    if (isThread && !threadsRespond && !threadsObserve) {
+      // Both disabled — completely ignore thread messages
+      log.debug(`Thread message ignored (threads.respond=false, threads.observe=false)`);
+      return;
+    }
+
     // 3. Should-respond check — record to channel history if not responding
     const respond = this.shouldRespond(msg);
+
+    // Thread-specific control: if threads.respond=false, don't respond in threads
+    // but still may observe (record to history) if threads.observe=true
+    if (isThread && !threadsRespond) {
+      // threads.respond=false — don't respond, but may observe
+      if (threadsObserve && msg.guild && this.config.context?.channelHistory !== false) {
+        const content = this.extractContent(msg);
+        if (content.trim()) {
+          this.channelHistory.append(msg.channelId, {
+            sender: msg.author.username,
+            body: content,
+            timestamp: msg.createdTimestamp,
+            messageId: msg.id,
+          });
+        }
+      }
+      log.debug(`Thread message not responded (threads.respond=false, observe=${threadsObserve})`);
+      return;
+    }
+
     if (!respond) {
-      if (msg.guild && this.config.context?.channelHistory !== false) {
+      // Not a thread case, or threads.respond=true but shouldRespond=false
+      // Only observe if threads.observe allows (for threads) or standard observe for non-threads
+      const shouldObserve = isThread ? threadsObserve : true;
+      if (shouldObserve && msg.guild && this.config.context?.channelHistory !== false) {
         const content = this.extractContent(msg);
         if (content.trim()) {
           this.channelHistory.append(msg.channelId, {


### PR DESCRIPTION
## Summary

Adds per-agent thread control configuration:

- `threads.respond` (default: true) — Whether to respond in threads
- `threads.observe` (default: true) — Whether to record thread messages to history

## Config

```yaml
agents:
  fairy:
    discord:
      threads:
        respond: false   # Don't reply in threads
        observe: false   # Don't see thread messages
```

## Use Cases

- `respond: false, observe: true` — See thread context but don't reply
- `respond: false, observe: false` — Completely ignore threads
- Both `true` (default) — Current behavior

## Changes

- `src/core/types.ts`: Added `ThreadControlConfig` type
- `src/transports/discord.ts`: Added `threads` config + control logic in `handleMessage()`
- `src/transports/discord.test.ts`: Fixed mocks + added 4 thread control tests

## Tests

33 tests pass (29 existing + 4 new)

Fixes #272