### PR TITLE
feat: #273 support /stop and /cancel in subagent threads

### DIFF
--- a/docs/design/273-thread-steer-stop.md
+++ b/docs/design/273-thread-steer-stop.md
@@ -1,0 +1,120 @@
+# Design: #273 — Subagent Thread Steer/Stop
+
+## Problem
+
+When a subagent is running and streaming output to a Discord thread:
+1. User messages in that thread are not visible to Isotopes
+2. No way to stop/cancel a running subagent from the thread
+3. No way to steer (redirect) the subagent with additional input
+
+The thread is effectively write-only.
+
+## Root Cause Analysis
+
+1. **Thread messages reach `handleMessage()`** — Discord's API does send them
+2. **But they get filtered out** — by `shouldRespond()` logic or `threads.respond` config
+3. **Even if they passed**, there's no routing to associate thread messages with a running subagent
+4. **TaskRegistry tracks tasks** but doesn't track the thread they're streaming to
+
+## Solution: Thread-to-Task Routing
+
+### 1. Extend TaskRegistry to track threadId
+
+```typescript
+// task-registry.ts
+export interface TaskInfo {
+  taskId: string;
+  sessionId: string;
+  channelId: string;
+  threadId?: string;       // NEW: thread where subagent streams output
+  startedAt: Date;
+}
+```
+
+When `DiscordSink.start()` creates a thread, register the threadId with the task.
+
+### 2. `/stop` slash command in subagent thread
+
+Add handler in `slash-commands.ts`:
+
+```typescript
+// When /stop is invoked in a thread:
+// 1. Look up task by threadId in TaskRegistry
+// 2. Call backend.cancel(taskId)
+// 3. Reply "Subagent cancelled"
+```
+
+### 3. Thread message detection in handleMessage()
+
+In `discord.ts handleMessage()`, before filtering:
+
+```typescript
+// Check if this message is in a subagent thread
+const taskForThread = taskRegistry.getByThreadId(msg.channelId);
+if (taskForThread) {
+  // This is a subagent thread — route to special handler
+  return this.handleSubagentThreadMessage(msg, taskForThread);
+}
+```
+
+### 4. handleSubagentThreadMessage() — minimal P0
+
+For P0, just support `/stop`:
+- If message starts with `/stop` or `/cancel`, cancel the task
+- Otherwise, acknowledge but don't forward (steering is P1)
+
+## File Changes
+
+| File | Changes |
+|------|---------|
+| `src/subagent/task-registry.ts` | Add `threadId` field, `getByThreadId()` method |
+| `src/subagent/discord-sink.ts` | Register threadId when created |
+| `src/tools/subagent.ts` | Pass threadId to TaskRegistry |
+| `src/transports/discord.ts` | Add `handleSubagentThreadMessage()`, check before filters |
+| `src/commands/slash-commands.ts` | Add `/stop` handler (reuse `/cancel`) |
+| Tests for all above |
+
+## Sequence Diagram
+
+```
+User: /spawn claude "fix bug"
+  │
+  ├─> subagent.ts: spawnSubagent() → taskId = "subagent-1"
+  │     └─> taskRegistry.register(taskId, sessionId, channelId)
+  │
+  ├─> discord-sink.ts: DiscordSink.start()
+  │     └─> Creates thread "fix bug"
+  │     └─> taskRegistry.setThreadId(taskId, thread.id)
+  │
+  └─> Subagent runs, streams to thread...
+
+User (in thread): /stop
+  │
+  ├─> discord.ts: handleMessage()
+  │     └─> taskRegistry.getByThreadId(thread.id) → TaskInfo
+  │     └─> handleSubagentThreadMessage(msg, task)
+  │
+  └─> discord.ts: handleSubagentThreadMessage()
+        └─> backend.cancel(task.taskId)
+        └─> reply("Subagent cancelled")
+```
+
+## Testing
+
+1. Unit tests for TaskRegistry.getByThreadId()
+2. Unit tests for handleSubagentThreadMessage() with `/stop`
+3. Integration: mock thread message → verify task cancellation
+
+## Future (P1 — Steering)
+
+Forward non-command messages to the running subagent's stdin:
+```typescript
+// In handleSubagentThreadMessage():
+if (!isCommand) {
+  // Forward message content to subagent (if acpx supports stdin after start)
+  // Currently not possible — acpx stdin is closed after prompt
+  // Would need acpx/claude to support interactive input
+}
+```
+
+Note: acpx closes stdin after initial prompt, so true steering requires acpx changes. P0 is stop-only.

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -270,6 +270,10 @@ async function runSubagentWithDiscord(
   log.info("Starting sub-agent with Discord streaming", { agent, cwd, channelId });
   // Start the sink (creates thread)
   await sink.start(taskLabel);
+
+  // Get threadId after thread is created
+  const threadId = sink.getThreadId();
+
   // Collect events for building result
   const events: AcpxEvent[] = [];
   try {
@@ -279,6 +283,8 @@ async function runSubagentWithDiscord(
       cwd,
       timeout,
       allowedWorkspaces,
+      channelId,
+      threadId, // Pass threadId for /stop support in threads
       onEvent: async (event) => {
         events.push(event);
         await sink.sendEvent(event);
@@ -295,7 +301,6 @@ async function runSubagentWithDiscord(
     // Send summary to main channel
     await sink.finish(acpxResult);
     // Call onComplete callback for auto-unbind
-    const threadId = sink.getThreadId();
     if (onComplete && threadId) {
       try {
         await onComplete(threadId);
@@ -328,7 +333,6 @@ async function runSubagentWithDiscord(
       exitCode: 1,
     });
     // Call onComplete callback even on failure (for cleanup)
-    const threadId = sink.getThreadId();
     if (onComplete && threadId) {
       try {
         await onComplete(threadId);

--- a/src/subagent/task-registry.test.ts
+++ b/src/subagent/task-registry.test.ts
@@ -81,4 +81,38 @@ describe("TaskRegistry", () => {
       expect(registry.list()).toEqual([]);
     });
   });
+
+  describe("setThreadId()", () => {
+    it("sets threadId on existing task", () => {
+      registry.register("task-1", "sess-1", "chan-1");
+      registry.setThreadId("task-1", "thread-123");
+      const task = registry.get("task-1");
+      expect(task!.threadId).toBe("thread-123");
+    });
+
+    it("is a no-op for unknown taskId", () => {
+      expect(() => registry.setThreadId("nonexistent", "thread-1")).not.toThrow();
+    });
+  });
+
+  describe("getByThreadId()", () => {
+    it("returns task with matching threadId", () => {
+      registry.register("task-1", "sess-1", "chan-1");
+      registry.setThreadId("task-1", "thread-123");
+      
+      const task = registry.getByThreadId("thread-123");
+      expect(task).toBeDefined();
+      expect(task!.taskId).toBe("task-1");
+    });
+
+    it("returns undefined when no task has that threadId", () => {
+      registry.register("task-1", "sess-1", "chan-1");
+      expect(registry.getByThreadId("thread-999")).toBeUndefined();
+    });
+
+    it("returns undefined when tasks have no threadId set", () => {
+      registry.register("task-1", "sess-1", "chan-1");
+      expect(registry.getByThreadId("thread-1")).toBeUndefined();
+    });
+  });
 });

--- a/src/subagent/task-registry.ts
+++ b/src/subagent/task-registry.ts
@@ -6,6 +6,8 @@ export interface TaskInfo {
   taskId: string;
   sessionId: string;
   channelId: string;
+  /** Thread ID where subagent streams output (if any) */
+  threadId?: string;
   startedAt: Date;
 }
 
@@ -42,6 +44,19 @@ export class TaskRegistry {
   /** Get all tasks for a given session. */
   getBySession(sessionId: string): TaskInfo[] {
     return [...this.tasks.values()].filter((t) => t.sessionId === sessionId);
+  }
+
+  /** Get task by thread ID, or undefined if not found. */
+  getByThreadId(threadId: string): TaskInfo | undefined {
+    return [...this.tasks.values()].find((t) => t.threadId === threadId);
+  }
+
+  /** Set the thread ID for a running task. */
+  setThreadId(taskId: string, threadId: string): void {
+    const task = this.tasks.get(taskId);
+    if (task) {
+      task.threadId = threadId;
+    }
   }
 
   /** List all running tasks. */

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -48,6 +48,8 @@ export interface SpawnSubagentOptions {
   sessionId?: string;
   /** Channel ID for task registry tracking */
   channelId?: string;
+  /** Thread ID where subagent streams output (for /stop support) */
+  threadId?: string;
 }
 
 /** Result from spawning a sub-agent */
@@ -146,6 +148,11 @@ export async function spawnSubagent(
 
   // Register task for tracking/abort
   taskRegistry.register(taskId, options.sessionId ?? "", options.channelId ?? "");
+
+  // Set threadId if provided (for /stop support in threads)
+  if (options.threadId) {
+    taskRegistry.setThreadId(taskId, options.threadId);
+  }
 
   try {
     const events = backend.spawn(taskId, {

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -39,6 +39,8 @@ import { ChannelHistoryBuffer, buildHistoryContext } from "../core/channel-histo
 import { DedupeCache } from "../core/dedupe.js";
 import { InboundDebouncer } from "../core/debounce.js";
 import { SlashCommandHandler } from "../commands/slash-commands.js";
+import { taskRegistry } from "../subagent/task-registry.js";
+import { cancelSubagent } from "../tools/subagent.js";
 
 const log = loggers.discord;
 
@@ -363,6 +365,15 @@ export class DiscordTransport implements Transport {
     let content = this.extractContent(msg);
     if (!content.trim()) return;
 
+    // 4.3. Subagent thread interception — handle /stop in subagent threads
+    if (isThread) {
+      const task = taskRegistry.getByThreadId(msg.channelId);
+      if (task) {
+        await this.handleSubagentThreadMessage(msg, task, content);
+        return;
+      }
+    }
+
     // 4.5. Slash command interception — handle admin commands before agent dispatch
     if (this.commandHandler.isCommand(content)) {
       const agentId = this.resolveAgentId(msg);
@@ -470,6 +481,37 @@ export class DiscordTransport implements Transport {
       accountId: this.config.accountId,
       isMentioned,
       isDM: false,
+    });
+  }
+
+  /**
+   * Handle a message in a subagent thread.
+   * Supports /stop and /cancel commands to kill the running subagent.
+   */
+  private async handleSubagentThreadMessage(
+    msg: DiscordMessage,
+    task: { taskId: string; sessionId: string; channelId: string; threadId?: string },
+    content: string,
+  ): Promise<void> {
+    const normalizedContent = content.trim().toLowerCase();
+
+    // Check for stop/cancel commands
+    if (normalizedContent === "/stop" || normalizedContent === "/cancel") {
+      log.info(`Cancelling subagent from thread`, { taskId: task.taskId, threadId: msg.channelId });
+      const cancelled = cancelSubagent(task.taskId);
+      if (cancelled) {
+        await (msg.channel as SendableChannel).send("🛑 Subagent cancelled.");
+      } else {
+        await (msg.channel as SendableChannel).send("⚠️ Subagent already finished or not found.");
+      }
+      return;
+    }
+
+    // For now, other messages in subagent threads are acknowledged but not forwarded
+    // (acpx stdin is closed after initial prompt — true steering requires acpx changes)
+    log.debug(`Subagent thread message ignored (steering not supported)`, {
+      taskId: task.taskId,
+      content: content.slice(0, 50),
     });
   }
 


### PR DESCRIPTION
## Summary

When a subagent is running and streaming output to a Discord thread, users can now send `/stop` or `/cancel` in that thread to kill the running subagent.

## Changes

- **TaskRegistry**: Add `threadId` field, `setThreadId()`, and `getByThreadId()` methods
- **discord.ts**: Intercept messages in subagent threads before normal routing, handle `/stop` and `/cancel` commands
- **tools.ts**: Pass threadId to `spawnSubagent()` after `sink.start()` creates the thread
- **subagent.ts**: Register threadId in TaskRegistry via `setThreadId()`

## How it works

1. When `runSubagentWithDiscord()` starts, it calls `sink.start()` which creates a thread
2. The threadId is passed to `spawnSubagent()` which registers it with the task
3. When a message arrives in a thread, `handleMessage()` checks `taskRegistry.getByThreadId()`
4. If a running task is found, `/stop` or `/cancel` triggers `cancelSubagent(taskId)`

## Testing

- Added 5 new tests for TaskRegistry (`setThreadId`, `getByThreadId`)
- All 190 subagent/discord tests pass

## Note on steering

True steering (forwarding user messages to the running subagent) is not yet supported because acpx closes stdin after the initial prompt. This would require changes to acpx. For now, non-command messages in subagent threads are logged but ignored.

Closes #273