### PR TITLE
feat(#275): Subagent failure tracking to prevent repeated failures

### DIFF
--- a/docs/design/275-subagent-failure-tracking.md
+++ b/docs/design/275-subagent-failure-tracking.md
@@ -1,0 +1,142 @@
+# Design: #275 Subagent Failure Tracking
+
+## Issue
+https://github.com/GhostComplex/isotopes/issues/275
+
+## Problem
+Agent repeatedly spawns failing subagents for the same task, ignoring:
+1. Previous failures (exit code 3 = max turns)
+2. Explicit `/stop` commands from user
+
+## Solution
+
+### 1. FailureTracker — per-session task failure memory
+
+Track task failures by hashing the task description. After N failures, refuse to spawn.
+
+```typescript
+// src/subagent/failure-tracker.ts
+
+interface FailureRecord {
+  count: number;
+  lastError: string;
+  cancelled: boolean; // True if /stop was used
+}
+
+class FailureTracker {
+  // sessionId -> taskHash -> FailureRecord
+  private failures = new Map<string, Map<string, FailureRecord>>();
+  
+  recordFailure(sessionId: string, task: string, error: string): void;
+  recordCancel(sessionId: string, task: string): void;
+  shouldBlock(sessionId: string, task: string, maxFailures: number): { blocked: boolean; reason?: string };
+  clearSession(sessionId: string): void;
+}
+```
+
+### 2. Task Hash Function
+
+Simple hash based on task description (normalized):
+- Lowercase
+- Remove extra whitespace
+- Hash first 200 chars (captures essence of task)
+
+```typescript
+function hashTask(task: string): string {
+  const normalized = task.toLowerCase().trim().replace(/\s+/g, ' ').slice(0, 200);
+  // Simple djb2 hash
+  let hash = 5381;
+  for (let i = 0; i < normalized.length; i++) {
+    hash = ((hash << 5) + hash) + normalized.charCodeAt(i);
+  }
+  return hash.toString(36);
+}
+```
+
+### 3. Integration Points
+
+**A. spawn_subagent handler (src/core/tools.ts)**
+
+```typescript
+handler: async (args) => {
+  const { task, agent, working_directory } = args;
+  
+  // Get sessionId from subagent context
+  const ctx = getSubagentContext();
+  const sessionId = ctx?.sessionId;
+  
+  if (sessionId) {
+    const check = failureTracker.shouldBlock(sessionId, task, 2);
+    if (check.blocked) {
+      return `[blocked] ${check.reason}`;
+    }
+  }
+  
+  // ... existing spawn logic ...
+  
+  if (!result.success && sessionId) {
+    failureTracker.recordFailure(sessionId, task, result.error || 'unknown');
+  }
+  
+  return result;
+}
+```
+
+**B. /stop command handler (src/transports/discord.ts)**
+
+When `/stop` kills a subagent, also record cancellation:
+
+```typescript
+if (task) {
+  const killed = await killTask(task.taskId);
+  if (killed && ctx.sessionId) {
+    // We don't have the original task description here...
+    // Need to store it in TaskInfo
+  }
+}
+```
+
+**Problem:** TaskInfo doesn't store the original task description. Need to add it.
+
+### 4. Update TaskInfo
+
+```typescript
+export interface TaskInfo {
+  taskId: string;
+  sessionId: string;
+  channelId: string;
+  threadId?: string;
+  startedAt: Date;
+  task: string;  // NEW: original task description
+}
+```
+
+### 5. File Changes
+
+| File | Change |
+|------|--------|
+| `src/subagent/failure-tracker.ts` | NEW: FailureTracker class |
+| `src/subagent/failure-tracker.test.ts` | NEW: tests |
+| `src/subagent/task-registry.ts` | Add `task` field to TaskInfo |
+| `src/core/tools.ts` | Check failure tracker before spawn |
+| `src/core/subagent-context.ts` | Add sessionId to context |
+| `src/transports/discord.ts` | Record cancel when /stop used |
+
+### 6. Config
+
+Default `maxFailures = 2`. Can be made configurable later.
+
+## Test Plan
+
+1. `recordFailure()` increments count
+2. `shouldBlock()` returns true after 2 failures
+3. `recordCancel()` marks task as cancelled
+4. Cancelled tasks are immediately blocked
+5. `clearSession()` resets all failure state
+
+## Acceptance Criteria
+
+- [ ] After 2 consecutive failures, same task is blocked with clear message
+- [ ] `/stop` blocks task from being re-attempted
+- [ ] Agent receives clear feedback when blocked
+- [ ] No false positives (different tasks don't affect each other)

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -3,6 +3,7 @@
 
 import type { AgentManager, SessionStore, AgentInstance } from "../core/types.js";
 import { createLogger } from "../core/logger.js";
+import { failureTracker } from "../subagent/failure-tracker.js";
 
 const log = createLogger("commands");
 
@@ -193,6 +194,8 @@ export class SlashCommandHandler {
     try {
       await ctx.sessionStore.clearMessages(ctx.sessionId);
       ctx.agentInstance?.clearMessages?.();
+      // Clear failure tracker for this session (allow re-attempting previously failed tasks)
+      failureTracker.clearSession(ctx.sessionId);
 
       log.info(`Session reset by ${ctx.username} (${ctx.userId})`);
       return { response: "✅ Session reset. Starting fresh." };

--- a/src/core/subagent-context.ts
+++ b/src/core/subagent-context.ts
@@ -19,6 +19,8 @@ export interface SubagentDiscordContext {
   createThread: CreateThreadFn;
   /** Channel ID where the subagent was triggered */
   channelId: string;
+  /** Session ID for failure tracking */
+  sessionId?: string;
   /** Whether to show tool calls in the thread */
   showToolCalls?: boolean;
   /** Callback invoked when subagent completes (for auto-unbind) */

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -10,6 +10,7 @@ import { createWebFetchTool, createWebSearchTool } from "../tools/web.js";
 import type { AcpxAgent, AcpxEvent, DiscordSinkConfig } from "../subagent/types.js";
 import { DiscordSink } from "../subagent/discord-sink.js";
 import { getSubagentContext } from "./subagent-context.js";
+import { failureTracker } from "../subagent/failure-tracker.js";
 import { createLogger } from "./logger.js";
 const execAsync = promisify(exec);
 const log = createLogger("tools:subagent");
@@ -208,16 +209,39 @@ export function createSubagentTool(options: SubagentToolOptions): { tool: Tool; 
         : workspacePath;
       // Check for Discord context
       const discordContext = getSubagentContext();
+
+      // Check failure tracker (only when sessionId available)
+      const sessionId = discordContext?.sessionId;
+      if (sessionId) {
+        const check = failureTracker.shouldBlock(sessionId, task);
+        if (check.blocked) {
+          log.warn("Blocking subagent spawn due to previous failures", { sessionId, reason: check.reason });
+          return `[blocked] ${check.reason}`;
+        }
+      }
+
       try {
+        let result: string;
         if (discordContext) {
           // Run with Discord streaming
-          return await runSubagentWithDiscord(task, agent as AcpxAgent, cwd, timeout, allAllowedWorkspaces, discordContext);
+          result = await runSubagentWithDiscord(task, agent as AcpxAgent, cwd, timeout, allAllowedWorkspaces, discordContext);
         } else {
           // Run without Discord streaming (original behavior)
-          return await runSubagentPlain(task, agent as AcpxAgent, cwd, timeout, allAllowedWorkspaces);
+          result = await runSubagentPlain(task, agent as AcpxAgent, cwd, timeout, allAllowedWorkspaces);
         }
+
+        // Record failure if result indicates failure
+        if (sessionId && (result.includes("[sub-agent failed]") || result.includes("[error]"))) {
+          failureTracker.recordFailure(sessionId, task, result);
+        }
+
+        return result;
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err);
+        // Record failure
+        if (sessionId) {
+          failureTracker.recordFailure(sessionId, task, error);
+        }
         return `[error] Failed to spawn sub-agent: ${error}`;
       }
     },

--- a/src/subagent/failure-tracker.test.ts
+++ b/src/subagent/failure-tracker.test.ts
@@ -1,0 +1,135 @@
+// src/subagent/failure-tracker.test.ts
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { FailureTracker } from "./failure-tracker.js";
+
+describe("FailureTracker", () => {
+  let tracker: FailureTracker;
+
+  beforeEach(() => {
+    tracker = new FailureTracker();
+  });
+
+  describe("recordFailure", () => {
+    it("increments failure count", () => {
+      tracker.recordFailure("session-1", "implement feature X", "max turns");
+      expect(tracker.getFailureCount("session-1", "implement feature X")).toBe(1);
+
+      tracker.recordFailure("session-1", "implement feature X", "max turns");
+      expect(tracker.getFailureCount("session-1", "implement feature X")).toBe(2);
+    });
+
+    it("tracks failures independently per session", () => {
+      tracker.recordFailure("session-1", "task A", "error");
+      tracker.recordFailure("session-2", "task A", "error");
+
+      expect(tracker.getFailureCount("session-1", "task A")).toBe(1);
+      expect(tracker.getFailureCount("session-2", "task A")).toBe(1);
+    });
+
+    it("tracks failures independently per task", () => {
+      tracker.recordFailure("session-1", "task A", "error");
+      tracker.recordFailure("session-1", "task B", "error");
+
+      expect(tracker.getFailureCount("session-1", "task A")).toBe(1);
+      expect(tracker.getFailureCount("session-1", "task B")).toBe(1);
+    });
+  });
+
+  describe("recordCancel", () => {
+    it("marks task as cancelled", () => {
+      tracker.recordCancel("session-1", "implement feature X");
+      expect(tracker.isCancelled("session-1", "implement feature X")).toBe(true);
+    });
+
+    it("does not increment failure count", () => {
+      tracker.recordCancel("session-1", "task A");
+      expect(tracker.getFailureCount("session-1", "task A")).toBe(0);
+    });
+  });
+
+  describe("shouldBlock", () => {
+    it("returns blocked:false for new task", () => {
+      const result = tracker.shouldBlock("session-1", "new task");
+      expect(result.blocked).toBe(false);
+    });
+
+    it("returns blocked:false after 1 failure (default maxFailures=2)", () => {
+      tracker.recordFailure("session-1", "task A", "error");
+      const result = tracker.shouldBlock("session-1", "task A");
+      expect(result.blocked).toBe(false);
+    });
+
+    it("returns blocked:true after 2 failures (default maxFailures=2)", () => {
+      tracker.recordFailure("session-1", "task A", "first error");
+      tracker.recordFailure("session-1", "task A", "second error");
+      const result = tracker.shouldBlock("session-1", "task A");
+      expect(result.blocked).toBe(true);
+      expect(result.reason).toContain("failed 2 times");
+      expect(result.reason).toContain("second error");
+    });
+
+    it("respects custom maxFailures", () => {
+      tracker.recordFailure("session-1", "task A", "error");
+      expect(tracker.shouldBlock("session-1", "task A", 1).blocked).toBe(true);
+      expect(tracker.shouldBlock("session-1", "task A", 3).blocked).toBe(false);
+    });
+
+    it("returns blocked:true for cancelled task", () => {
+      tracker.recordCancel("session-1", "task A");
+      const result = tracker.shouldBlock("session-1", "task A");
+      expect(result.blocked).toBe(true);
+      expect(result.reason).toContain("cancelled");
+    });
+
+    it("blocks cancelled task even with 0 failures", () => {
+      tracker.recordCancel("session-1", "task A");
+      const result = tracker.shouldBlock("session-1", "task A", 10);
+      expect(result.blocked).toBe(true);
+    });
+  });
+
+  describe("clearSession", () => {
+    it("clears all failures for a session", () => {
+      tracker.recordFailure("session-1", "task A", "error");
+      tracker.recordFailure("session-1", "task B", "error");
+      tracker.recordCancel("session-1", "task C");
+
+      tracker.clearSession("session-1");
+
+      expect(tracker.getFailureCount("session-1", "task A")).toBe(0);
+      expect(tracker.getFailureCount("session-1", "task B")).toBe(0);
+      expect(tracker.isCancelled("session-1", "task C")).toBe(false);
+    });
+
+    it("does not affect other sessions", () => {
+      tracker.recordFailure("session-1", "task A", "error");
+      tracker.recordFailure("session-2", "task A", "error");
+
+      tracker.clearSession("session-1");
+
+      expect(tracker.getFailureCount("session-1", "task A")).toBe(0);
+      expect(tracker.getFailureCount("session-2", "task A")).toBe(1);
+    });
+  });
+
+  describe("task normalization", () => {
+    it("treats similar tasks as the same (case insensitive)", () => {
+      tracker.recordFailure("session-1", "Implement Feature X", "error");
+      expect(tracker.getFailureCount("session-1", "implement feature x")).toBe(1);
+    });
+
+    it("treats similar tasks as the same (extra whitespace)", () => {
+      tracker.recordFailure("session-1", "implement   feature\n\nx", "error");
+      expect(tracker.getFailureCount("session-1", "implement feature x")).toBe(1);
+    });
+
+    it("only uses first 200 chars for hashing", () => {
+      const longTask1 = "implement " + "a".repeat(300);
+      const longTask2 = "implement " + "a".repeat(300) + " extra stuff";
+      tracker.recordFailure("session-1", longTask1, "error");
+      // Should match because first 200 chars are the same
+      expect(tracker.getFailureCount("session-1", longTask2)).toBe(1);
+    });
+  });
+});

--- a/src/subagent/failure-tracker.ts
+++ b/src/subagent/failure-tracker.ts
@@ -1,0 +1,152 @@
+// src/subagent/failure-tracker.ts — Tracks subagent task failures per session
+// Prevents repeated spawning of failing tasks.
+
+import { createLogger } from "../core/logger.js";
+
+const log = createLogger("failure-tracker");
+
+/** Record of failures for a specific task. */
+interface FailureRecord {
+  count: number;
+  lastError: string;
+  cancelled: boolean;
+}
+
+/** Result of checking if a task should be blocked. */
+export interface BlockCheck {
+  blocked: boolean;
+  reason?: string;
+}
+
+/**
+ * Hash a task description into a short key.
+ * Uses first 200 chars, normalized (lowercase, single spaces).
+ */
+function hashTask(task: string): string {
+  const normalized = task.toLowerCase().trim().replace(/\s+/g, " ").slice(0, 200);
+  // djb2 hash
+  let hash = 5381;
+  for (let i = 0; i < normalized.length; i++) {
+    hash = ((hash << 5) + hash) + normalized.charCodeAt(i);
+  }
+  // Return positive number in base36
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * FailureTracker — per-session memory of task failures.
+ *
+ * Tracks how many times a task has failed in a session. After N failures,
+ * blocks further attempts. Also tracks explicitly cancelled tasks (/stop).
+ */
+export class FailureTracker {
+  // sessionId -> taskHash -> FailureRecord
+  private failures = new Map<string, Map<string, FailureRecord>>();
+
+  /**
+   * Record a task failure.
+   */
+  recordFailure(sessionId: string, task: string, error: string): void {
+    const taskHash = hashTask(task);
+    let sessionMap = this.failures.get(sessionId);
+    if (!sessionMap) {
+      sessionMap = new Map();
+      this.failures.set(sessionId, sessionMap);
+    }
+
+    const record = sessionMap.get(taskHash);
+    if (record) {
+      record.count++;
+      record.lastError = error;
+    } else {
+      sessionMap.set(taskHash, { count: 1, lastError: error, cancelled: false });
+    }
+
+    log.info("Recorded task failure", { sessionId, taskHash, count: sessionMap.get(taskHash)?.count });
+  }
+
+  /**
+   * Record a task cancellation (e.g., /stop command).
+   * Cancelled tasks are immediately blocked from re-attempt.
+   */
+  recordCancel(sessionId: string, task: string): void {
+    const taskHash = hashTask(task);
+    let sessionMap = this.failures.get(sessionId);
+    if (!sessionMap) {
+      sessionMap = new Map();
+      this.failures.set(sessionId, sessionMap);
+    }
+
+    const record = sessionMap.get(taskHash);
+    if (record) {
+      record.cancelled = true;
+    } else {
+      sessionMap.set(taskHash, { count: 0, lastError: "cancelled", cancelled: true });
+    }
+
+    log.info("Recorded task cancellation", { sessionId, taskHash });
+  }
+
+  /**
+   * Check if a task should be blocked.
+   * @param maxFailures - Number of failures before blocking (default: 2)
+   */
+  shouldBlock(sessionId: string, task: string, maxFailures = 2): BlockCheck {
+    const taskHash = hashTask(task);
+    const sessionMap = this.failures.get(sessionId);
+    if (!sessionMap) {
+      return { blocked: false };
+    }
+
+    const record = sessionMap.get(taskHash);
+    if (!record) {
+      return { blocked: false };
+    }
+
+    if (record.cancelled) {
+      return {
+        blocked: true,
+        reason: "This task was cancelled. Not re-attempting in this session.",
+      };
+    }
+
+    if (record.count >= maxFailures) {
+      return {
+        blocked: true,
+        reason: `This task has failed ${record.count} times. Last error: ${record.lastError}. Not re-attempting.`,
+      };
+    }
+
+    return { blocked: false };
+  }
+
+  /**
+   * Clear all failure records for a session.
+   * Called when session is reset (/new, /reset).
+   */
+  clearSession(sessionId: string): void {
+    this.failures.delete(sessionId);
+    log.info("Cleared session failures", { sessionId });
+  }
+
+  /**
+   * Get the failure count for a specific task (for testing).
+   */
+  getFailureCount(sessionId: string, task: string): number {
+    const taskHash = hashTask(task);
+    const sessionMap = this.failures.get(sessionId);
+    return sessionMap?.get(taskHash)?.count ?? 0;
+  }
+
+  /**
+   * Check if a task is cancelled (for testing).
+   */
+  isCancelled(sessionId: string, task: string): boolean {
+    const taskHash = hashTask(task);
+    const sessionMap = this.failures.get(sessionId);
+    return sessionMap?.get(taskHash)?.cancelled ?? false;
+  }
+}
+
+/** Singleton failure tracker shared across the application. */
+export const failureTracker = new FailureTracker();

--- a/src/subagent/index.ts
+++ b/src/subagent/index.ts
@@ -47,6 +47,9 @@ export type { SendMessageFn, CreateThreadFn } from "./discord-sink.js";
 export { TaskRegistry, taskRegistry } from "./task-registry.js";
 export type { TaskInfo } from "./task-registry.js";
 
+export { FailureTracker, failureTracker } from "./failure-tracker.js";
+export type { BlockCheck } from "./failure-tracker.js";
+
 // ---------------------------------------------------------------------------
 // SubagentManager
 // ---------------------------------------------------------------------------

--- a/src/subagent/task-registry.test.ts
+++ b/src/subagent/task-registry.test.ts
@@ -12,26 +12,28 @@ describe("TaskRegistry", () => {
 
   describe("register()", () => {
     it("adds a task", () => {
-      registry.register("task-1", "sess-1", "chan-1");
+      registry.register("task-1", "sess-1", "chan-1", "do something");
       const task = registry.get("task-1");
       expect(task).toBeDefined();
       expect(task!.taskId).toBe("task-1");
       expect(task!.sessionId).toBe("sess-1");
       expect(task!.channelId).toBe("chan-1");
+      expect(task!.task).toBe("do something");
       expect(task!.startedAt).toBeInstanceOf(Date);
     });
 
     it("overwrites existing task with same id", () => {
-      registry.register("task-1", "sess-1", "chan-1");
-      registry.register("task-1", "sess-2", "chan-2");
+      registry.register("task-1", "sess-1", "chan-1", "task A");
+      registry.register("task-1", "sess-2", "chan-2", "task B");
       const task = registry.get("task-1");
       expect(task!.sessionId).toBe("sess-2");
+      expect(task!.task).toBe("task B");
     });
   });
 
   describe("unregister()", () => {
     it("removes a task", () => {
-      registry.register("task-1", "sess-1", "chan-1");
+      registry.register("task-1", "sess-1", "chan-1", "do something");
       registry.unregister("task-1");
       expect(registry.get("task-1")).toBeUndefined();
     });
@@ -43,8 +45,8 @@ describe("TaskRegistry", () => {
 
   describe("get()", () => {
     it("returns the correct task", () => {
-      registry.register("task-1", "sess-1", "chan-1");
-      registry.register("task-2", "sess-2", "chan-2");
+      registry.register("task-1", "sess-1", "chan-1", "task A");
+      registry.register("task-2", "sess-2", "chan-2", "task B");
       expect(registry.get("task-1")!.sessionId).toBe("sess-1");
       expect(registry.get("task-2")!.sessionId).toBe("sess-2");
     });
@@ -56,9 +58,9 @@ describe("TaskRegistry", () => {
 
   describe("getBySession()", () => {
     it("filters tasks by sessionId", () => {
-      registry.register("task-1", "sess-1", "chan-1");
-      registry.register("task-2", "sess-1", "chan-2");
-      registry.register("task-3", "sess-2", "chan-1");
+      registry.register("task-1", "sess-1", "chan-1", "task A");
+      registry.register("task-2", "sess-1", "chan-2", "task B");
+      registry.register("task-3", "sess-2", "chan-1", "task C");
 
       const sess1Tasks = registry.getBySession("sess-1");
       expect(sess1Tasks).toHaveLength(2);
@@ -72,8 +74,8 @@ describe("TaskRegistry", () => {
 
   describe("list()", () => {
     it("returns all tasks", () => {
-      registry.register("task-1", "sess-1", "chan-1");
-      registry.register("task-2", "sess-2", "chan-2");
+      registry.register("task-1", "sess-1", "chan-1", "task A");
+      registry.register("task-2", "sess-2", "chan-2", "task B");
       expect(registry.list()).toHaveLength(2);
     });
 
@@ -84,7 +86,7 @@ describe("TaskRegistry", () => {
 
   describe("setThreadId()", () => {
     it("sets threadId on existing task", () => {
-      registry.register("task-1", "sess-1", "chan-1");
+      registry.register("task-1", "sess-1", "chan-1", "do something");
       registry.setThreadId("task-1", "thread-123");
       const task = registry.get("task-1");
       expect(task!.threadId).toBe("thread-123");
@@ -97,7 +99,7 @@ describe("TaskRegistry", () => {
 
   describe("getByThreadId()", () => {
     it("returns task with matching threadId", () => {
-      registry.register("task-1", "sess-1", "chan-1");
+      registry.register("task-1", "sess-1", "chan-1", "do something");
       registry.setThreadId("task-1", "thread-123");
       
       const task = registry.getByThreadId("thread-123");
@@ -106,12 +108,12 @@ describe("TaskRegistry", () => {
     });
 
     it("returns undefined when no task has that threadId", () => {
-      registry.register("task-1", "sess-1", "chan-1");
+      registry.register("task-1", "sess-1", "chan-1", "do something");
       expect(registry.getByThreadId("thread-999")).toBeUndefined();
     });
 
     it("returns undefined when tasks have no threadId set", () => {
-      registry.register("task-1", "sess-1", "chan-1");
+      registry.register("task-1", "sess-1", "chan-1", "do something");
       expect(registry.getByThreadId("thread-1")).toBeUndefined();
     });
   });

--- a/src/subagent/task-registry.ts
+++ b/src/subagent/task-registry.ts
@@ -8,6 +8,8 @@ export interface TaskInfo {
   channelId: string;
   /** Thread ID where subagent streams output (if any) */
   threadId?: string;
+  /** Original task description */
+  task: string;
   startedAt: Date;
 }
 
@@ -22,11 +24,12 @@ export class TaskRegistry {
   private tasks: Map<string, TaskInfo> = new Map();
 
   /** Register a new running task. */
-  register(taskId: string, sessionId: string, channelId: string): void {
+  register(taskId: string, sessionId: string, channelId: string, task: string): void {
     this.tasks.set(taskId, {
       taskId,
       sessionId,
       channelId,
+      task,
       startedAt: new Date(),
     });
   }

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -147,7 +147,7 @@ export async function spawnSubagent(
   const backend = getBackend(options.allowedWorkspaces);
 
   // Register task for tracking/abort
-  taskRegistry.register(taskId, options.sessionId ?? "", options.channelId ?? "");
+  taskRegistry.register(taskId, options.sessionId ?? "", options.channelId ?? "", prompt);
 
   // Set threadId if provided (for /stop support in threads)
   if (options.threadId) {

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -40,6 +40,7 @@ import { DedupeCache } from "../core/dedupe.js";
 import { InboundDebouncer } from "../core/debounce.js";
 import { SlashCommandHandler } from "../commands/slash-commands.js";
 import { taskRegistry } from "../subagent/task-registry.js";
+import { failureTracker } from "../subagent/failure-tracker.js";
 import { cancelSubagent } from "../tools/subagent.js";
 
 const log = loggers.discord;
@@ -490,7 +491,7 @@ export class DiscordTransport implements Transport {
    */
   private async handleSubagentThreadMessage(
     msg: DiscordMessage,
-    task: { taskId: string; sessionId: string; channelId: string; threadId?: string },
+    task: { taskId: string; sessionId: string; channelId: string; threadId?: string; task: string },
     content: string,
   ): Promise<void> {
     const normalizedContent = content.trim().toLowerCase();
@@ -500,6 +501,10 @@ export class DiscordTransport implements Transport {
       log.info(`Cancelling subagent from thread`, { taskId: task.taskId, threadId: msg.channelId });
       const cancelled = cancelSubagent(task.taskId);
       if (cancelled) {
+        // Record cancellation to block future re-attempts of this task
+        if (task.sessionId) {
+          failureTracker.recordCancel(task.sessionId, task.task);
+        }
         await (msg.channel as SendableChannel).send("🛑 Subagent cancelled.");
       } else {
         await (msg.channel as SendableChannel).send("⚠️ Subagent already finished or not found.");
@@ -586,7 +591,7 @@ export class DiscordTransport implements Transport {
    * Create a subagent Discord context for the given channel.
    * This context enables subagent tool to stream output to Discord threads.
    */
-  private createSubagentContext(channel: SendableChannel): SubagentDiscordContext {
+  private createSubagentContext(channel: SendableChannel, sessionId?: string): SubagentDiscordContext {
     const threadBindingConfig = this.config.threadBindings;
     const autoUnbindEnabled = threadBindingConfig?.autoUnbindOnComplete !== false;
     const sendFarewell = threadBindingConfig?.sendFarewell ?? false;
@@ -615,6 +620,7 @@ export class DiscordTransport implements Transport {
         return { id: thread.id };
       },
       channelId: channel.id,
+      sessionId,
       showToolCalls: this.config.subagentShowToolCalls ?? true,
       onComplete: autoUnbindEnabled
         ? async (threadId: string) => {
@@ -699,7 +705,7 @@ export class DiscordTransport implements Transport {
 
       if (this.config.enableSubagentStreaming !== false) {
         // Run with subagent Discord context enabled
-        const subagentContext = this.createSubagentContext(channel);
+        const subagentContext = this.createSubagentContext(channel, sessionId);
         const result = await runWithSubagentContextAsync(subagentContext, runLoop);
 
         errorMessage = result.errorMessage;


### PR DESCRIPTION
## Summary
Implements failure tracking for subagent tasks to prevent the agent from repeatedly spawning failing subagents.

## Changes
- **FailureTracker** — new class that tracks task failures per session using task hash
- **Block after failures** — after 2 consecutive failures of the same task, block further attempts
- **Block after cancel** — when `/stop` or `/cancel` is used, block re-attempts of that task
- **Session reset clears state** — `/new` and `/reset` commands clear failure state
- **TaskInfo.task** — added original task description for tracking cancelled tasks

## Technical Details
- Task descriptions are hashed (djb2) after normalization (lowercase, single spaces, first 200 chars)
- Failure tracking is session-scoped, not global
- sessionId is passed through SubagentDiscordContext

## Files Changed
- `src/subagent/failure-tracker.ts` — NEW: FailureTracker class
- `src/subagent/failure-tracker.test.ts` — NEW: 16 tests
- `src/subagent/task-registry.ts` — add `task` field to TaskInfo
- `src/core/tools.ts` — check failure tracker before spawn
- `src/core/subagent-context.ts` — add sessionId to context
- `src/transports/discord.ts` — record cancel on /stop, pass sessionId
- `src/commands/slash-commands.ts` — clear failures on /new

## Test Results
- 16 new tests for FailureTracker
- 1956 total tests pass (1 pre-existing failure in acp persistence)

Closes #275