### PR TITLE
fix(logger): evaluate log level dynamically on each call (#276)

### DIFF
--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -122,4 +122,43 @@ describe("Logger", () => {
       );
     });
   });
+
+  describe("dynamic log level", () => {
+    it("respects LOG_LEVEL changes at runtime", () => {
+      // Start with info level
+      vi.stubEnv("LOG_LEVEL", "info");
+      const log = createLogger("dynamic");
+
+      // debug should be filtered at info level
+      log.debug("should not appear");
+      expect(console.debug).not.toHaveBeenCalled();
+
+      // Change to debug level
+      vi.stubEnv("LOG_LEVEL", "debug");
+
+      // Now debug should appear (same logger instance)
+      log.debug("should appear");
+      expect(console.debug).toHaveBeenCalledWith(
+        expect.stringContaining("should appear"),
+      );
+    });
+
+    it("respects LOG_LEVEL changes for filtering", () => {
+      // Start with debug level
+      vi.stubEnv("LOG_LEVEL", "debug");
+      const log = createLogger("dynamic");
+
+      log.info("info at debug level");
+      expect(console.log).toHaveBeenCalled();
+
+      vi.mocked(console.log).mockClear();
+
+      // Raise to error level
+      vi.stubEnv("LOG_LEVEL", "error");
+
+      // info should now be filtered
+      log.info("info at error level");
+      expect(console.log).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -61,10 +61,9 @@ export interface Logger {
  * @param tag - Short identifier prepended to every log line (e.g. `"core"`, `"discord"`)
  */
 export function createLogger(tag: string): Logger {
-  const minLevel = LOG_LEVELS[getLogLevel()];
-
   const log = (level: LogLevel, message: string, args: unknown[]) => {
-    if (LOG_LEVELS[level] < minLevel) return;
+    // Evaluate log level on each call (not at construction) so runtime changes take effect
+    if (LOG_LEVELS[level] < LOG_LEVELS[getLogLevel()]) return;
 
     const formatted = format(level, tag, message);
 


### PR DESCRIPTION
## Summary
Fix #276 — LOG_LEVEL changes now take effect at runtime instead of being frozen at module load time.

## Changes
- Remove captured `minLevel` constant from `createLogger()` closure
- Evaluate `getLogLevel()` on each log call instead of once at construction
- Runtime `process.env.LOG_LEVEL = 'debug'` now works immediately

## Tests
- Add 2 new tests verifying dynamic level changes
- 12/12 logger tests pass

## Performance
Negligible — one env read per log call, and most calls are filtered out early anyway.