### PR TITLE
fix(subagent): use separate variable for backend cache key (#277)

### DIFF
--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -68,6 +68,9 @@ export interface SpawnSubagentResult {
 /** Shared backend instance (lazy initialized) */
 let sharedBackend: AcpxBackend | undefined;
 
+/** Cache key for the shared backend (workspace roots joined by `:`) */
+let sharedBackendKey: string | undefined;
+
 /** Cached backend config */
 let backendConfig: SubagentBackendConfig = {};
 
@@ -81,6 +84,7 @@ export function initSubagentBackend(config: SubagentBackendConfig): void {
   backendConfig = config;
   // Clear existing backend so it gets recreated with new config
   sharedBackend = undefined;
+  sharedBackendKey = undefined;
   log.info("Subagent backend initialized", { 
     permissionMode: config.permissionMode ?? "allowlist",
     allowedTools: config.allowedTools,
@@ -90,12 +94,13 @@ export function initSubagentBackend(config: SubagentBackendConfig): void {
 function getBackend(allowedWorkspaces?: string[]): AcpxBackend {
   // Create new backend if workspaces changed or not initialized
   const key = allowedWorkspaces?.sort().join(":") ?? "";
-  if (!sharedBackend || sharedBackend.workspacesKey !== key) {
+  if (!sharedBackend || sharedBackendKey !== key) {
     sharedBackend = new AcpxBackend({
       allowedWorkspaceRoots: allowedWorkspaces,
       permissionMode: backendConfig.permissionMode,
       allowedTools: backendConfig.allowedTools,
     });
+    sharedBackendKey = key;
   }
   return sharedBackend;
 }


### PR DESCRIPTION
## Summary
Fix #277 — Backend cache now works correctly by storing the key separately.

## Problem
`getBackend()` compared `sharedBackend.workspacesKey` which doesn't exist (always `undefined`), causing:
- New backend created on every call with empty workspaces
- Cache invalidation broken

## Fix
- Add `sharedBackendKey` variable to track workspace configuration
- Clear both backend and key on `initSubagentBackend()`

## Tests
224 subagent-related tests pass.