### PR TITLE
fix(cron): use OR logic when both day fields are non-wildcard (#282)

### DIFF
--- a/src/automation/cron-parser.test.ts
+++ b/src/automation/cron-parser.test.ts
@@ -331,5 +331,60 @@ describe("cron-parser", () => {
       expect(next.getSeconds()).toBe(0);
       expect(next.getMilliseconds()).toBe(0);
     });
+
+    // POSIX OR logic tests
+    it("uses OR logic when both day-of-month and day-of-week are specified", () => {
+      // 15th of month OR Monday at 9 AM
+      const schedule = parseCronExpression("0 9 15 * 1");
+
+      // April 14, 2025 is a Monday (not 15th) — should match via day-of-week
+      const monday = new Date(2025, 3, 14, 9, 0, 0);
+      expect(matchesCron(schedule, monday)).toBe(true);
+
+      // April 15, 2025 is a Tuesday (not Monday) — should match via day-of-month
+      const fifteenth = new Date(2025, 3, 15, 9, 0, 0);
+      expect(matchesCron(schedule, fifteenth)).toBe(true);
+
+      // April 16, 2025 is a Wednesday (neither Monday nor 15th) — should NOT match
+      const wednesday = new Date(2025, 3, 16, 9, 0, 0);
+      expect(matchesCron(schedule, wednesday)).toBe(false);
+    });
+
+    it("uses AND logic when only day-of-month is specified (day-of-week is *)", () => {
+      // 15th of month, any day of week
+      const schedule = parseCronExpression("0 9 15 * *");
+
+      const fifteenth = new Date(2025, 3, 15, 9, 0, 0);
+      expect(matchesCron(schedule, fifteenth)).toBe(true);
+
+      const fourteenth = new Date(2025, 3, 14, 9, 0, 0);
+      expect(matchesCron(schedule, fourteenth)).toBe(false);
+    });
+
+    it("uses AND logic when only day-of-week is specified (day-of-month is *)", () => {
+      // Mondays only
+      const schedule = parseCronExpression("0 9 * * 1");
+
+      // April 14, 2025 is a Monday
+      const monday = new Date(2025, 3, 14, 9, 0, 0);
+      expect(matchesCron(schedule, monday)).toBe(true);
+
+      // April 15, 2025 is a Tuesday
+      const tuesday = new Date(2025, 3, 15, 9, 0, 0);
+      expect(matchesCron(schedule, tuesday)).toBe(false);
+    });
+
+    it("getNextRun respects OR logic for non-wildcard day fields", () => {
+      // 15th of month OR Monday at 9 AM
+      const schedule = parseCronExpression("0 9 15 * 1");
+      // Start from April 12, 2025 (Saturday)
+      const from = new Date(2025, 3, 12, 10, 0, 0);
+
+      const next = getNextRun(schedule, from);
+
+      // Next match should be April 14 (Monday), not April 15 (Tuesday)
+      expect(next.getDate()).toBe(14);
+      expect(next.getDay()).toBe(1); // Monday
+    });
   });
 });

--- a/src/automation/cron-parser.ts
+++ b/src/automation/cron-parser.ts
@@ -217,6 +217,38 @@ export function parseCronExpression(expr: string): CronSchedule {
 // Matching
 // ---------------------------------------------------------------------------
 
+/** Check if a field array represents a wildcard (all values in range). */
+function isWildcard(values: number[], spec: FieldSpec): boolean {
+  if (values.length !== spec.max - spec.min + 1) return false;
+  for (let i = spec.min; i <= spec.max; i++) {
+    if (!values.includes(i)) return false;
+  }
+  return true;
+}
+
+/**
+ * Check whether a given Date matches the day fields of a CronSchedule.
+ * Per POSIX cron standard:
+ * - If either day-of-month or day-of-week is *, use AND logic
+ * - If both are non-wildcard, use OR logic (fire on either match)
+ */
+function matchesDayFields(schedule: CronSchedule, date: Date): boolean {
+  const domSpec = FIELD_SPECS[2]; // day of month: 1-31
+  const dowSpec = FIELD_SPECS[4]; // day of week: 0-6
+
+  const domWildcard = isWildcard(schedule.dayOfMonth, domSpec);
+  const dowWildcard = isWildcard(schedule.dayOfWeek, dowSpec);
+
+  const domMatches = schedule.dayOfMonth.includes(date.getDate());
+  const dowMatches = schedule.dayOfWeek.includes(date.getDay());
+
+  // Per POSIX: if either field is *, use AND; if both are restricted, use OR
+  if (domWildcard || dowWildcard) {
+    return domMatches && dowMatches;
+  }
+  return domMatches || dowMatches;
+}
+
 /**
  * Check whether a given Date matches a CronSchedule.
  */
@@ -224,9 +256,8 @@ export function matchesCron(schedule: CronSchedule, date: Date): boolean {
   return (
     schedule.minute.includes(date.getMinutes()) &&
     schedule.hour.includes(date.getHours()) &&
-    schedule.dayOfMonth.includes(date.getDate()) &&
-    schedule.month.includes(date.getMonth() + 1) && // JS months are 0-based
-    schedule.dayOfWeek.includes(date.getDay())
+    matchesDayFields(schedule, date) &&
+    schedule.month.includes(date.getMonth() + 1) // JS months are 0-based
   );
 }
 
@@ -263,11 +294,8 @@ export function getNextRun(schedule: CronSchedule, from?: Date): Date {
       continue;
     }
 
-    // Check day of month AND day of week
-    if (
-      !schedule.dayOfMonth.includes(candidate.getDate()) ||
-      !schedule.dayOfWeek.includes(candidate.getDay())
-    ) {
+    // Check day fields using POSIX OR logic when both are non-wildcard
+    if (!matchesDayFields(schedule, candidate)) {
       // Advance to next day
       candidate.setDate(candidate.getDate() + 1);
       candidate.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
Fix #282 — Cron parser now follows POSIX standard for day field matching.

## POSIX Cron Standard
- If either day-of-month **or** day-of-week is `*` → use **AND** logic
- If **both** are restricted (non-wildcard) → use **OR** logic

## Example
`0 9 15 * 1` now correctly fires on:
- 15th of any month at 9 AM **OR**
- Any Monday at 9 AM

Previously used AND which almost never matched (only when 15th falls on a Monday).

## Changes
- Add `isWildcard()` helper to detect full-range fields
- Add `matchesDayFields()` implementing POSIX OR logic
- Update `matchesCron()` and `getNextRun()` to use new logic
- Add 4 tests for POSIX day field behavior

## Tests
44/44 cron-parser tests pass.