### PR TITLE
feat(subagent): add duration and cost to completion summary (#220)

### DIFF
--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -298,6 +298,9 @@ async function runSubagentWithDiscord(
   // Get threadId after thread is created
   const threadId = sink.getThreadId();
 
+  // Track start time for duration calculation
+  const startTime = Date.now();
+
   // Collect events for building result
   const events: AcpxEvent[] = [];
   try {
@@ -314,6 +317,11 @@ async function runSubagentWithDiscord(
         await sink.sendEvent(event);
       },
     });
+
+    // Calculate duration and extract cost from events
+    const durationMs = Date.now() - startTime;
+    const costUsd = events.find(e => e.costUsd !== undefined)?.costUsd;
+
     // Build AcpxResult for finish message
     const acpxResult = {
       success: result.success,
@@ -321,6 +329,8 @@ async function runSubagentWithDiscord(
       error: result.error,
       events,
       exitCode: result.exitCode,
+      durationMs,
+      costUsd,
     };
     // Send summary to main channel
     await sink.finish(acpxResult);
@@ -349,12 +359,14 @@ async function runSubagentWithDiscord(
     const errorEvent: AcpxEvent = { type: "error", error };
     events.push(errorEvent);
     await sink.sendEvent(errorEvent);
-    // Send failure summary
+    // Send failure summary with duration
+    const durationMs = Date.now() - startTime;
     await sink.finish({
       success: false,
       error,
       events,
       exitCode: 1,
+      durationMs,
     });
     // Call onComplete callback even on failure (for cleanup)
     if (onComplete && threadId) {

--- a/src/subagent/acpx-backend.test.ts
+++ b/src/subagent/acpx-backend.test.ts
@@ -133,6 +133,24 @@ describe("parseJsonLine", () => {
     const event = parseJsonLine(line);
     expect(event).toEqual({ type: "error", error: "unknown error" });
   });
+
+  it("parses Claude CLI result event with cost_usd", () => {
+    const line = JSON.stringify({ type: "result", result: "Final output", cost_usd: 0.0125 });
+    const event = parseJsonLine(line);
+    expect(event).toEqual({ type: "done", content: "Final output", exitCode: 0, costUsd: 0.0125 });
+  });
+
+  it("parses Claude CLI result event without cost_usd", () => {
+    const line = JSON.stringify({ type: "result", result: "Final output" });
+    const event = parseJsonLine(line);
+    expect(event).toEqual({ type: "done", content: "Final output", exitCode: 0, costUsd: undefined });
+  });
+
+  it("parses Claude CLI result event with cost_usd but no result text", () => {
+    const line = JSON.stringify({ type: "result", cost_usd: 0.05 });
+    const event = parseJsonLine(line);
+    expect(event).toEqual({ type: "done", content: undefined, exitCode: 0, costUsd: 0.05 });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/subagent/acpx-backend.ts
+++ b/src/subagent/acpx-backend.ts
@@ -187,14 +187,15 @@ function mapRawEvent(obj: Record<string, unknown>): AcpxEvent | undefined {
     case "result": {
       const result = obj.result as string | undefined;
       const subtype = obj.subtype as string | undefined;
+      const costUsd = typeof obj.cost_usd === "number" ? obj.cost_usd : undefined;
       
       if (subtype === "error_max_turns") {
         return { type: "error", error: "Max turns reached" };
       }
       
-      // Result contains final text output
-      if (result) {
-        return { type: "message", content: result };
+      // Result contains final text output and cost
+      if (result || costUsd !== undefined) {
+        return { type: "done", content: result, exitCode: 0, costUsd };
       }
       return undefined;
     }

--- a/src/subagent/discord-sink.test.ts
+++ b/src/subagent/discord-sink.test.ts
@@ -277,6 +277,47 @@ describe("formatSummary", () => {
     expect(summary).not.toContain("<#");
     expect(summary).not.toContain("Details");
   });
+
+  it("includes duration when durationMs is provided", () => {
+    const result: AcpxResult = {
+      success: true,
+      events: [{ type: "done", exitCode: 0 }],
+      exitCode: 0,
+      durationMs: 45000,
+    };
+    const summary = formatSummary(result);
+    expect(summary).toContain("45s");
+  });
+
+  it("includes cost when costUsd is provided", () => {
+    const result: AcpxResult = {
+      success: true,
+      events: [{ type: "done", exitCode: 0 }],
+      exitCode: 0,
+      costUsd: 0.0123,
+    };
+    const summary = formatSummary(result);
+    expect(summary).toContain("$0.0123");
+  });
+
+  it("includes all stats in one line", () => {
+    const result: AcpxResult = {
+      success: true,
+      events: [
+        { type: "message", content: "hi" },
+        { type: "tool_use", toolName: "shell" },
+        { type: "done", exitCode: 0 },
+      ],
+      exitCode: 0,
+      durationMs: 30000,
+      costUsd: 0.05,
+    };
+    const summary = formatSummary(result);
+    expect(summary).toContain("1 message");
+    expect(summary).toContain("1 tool call");
+    expect(summary).toContain("30s");
+    expect(summary).toContain("$0.0500");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/subagent/discord-sink.ts
+++ b/src/subagent/discord-sink.ts
@@ -87,11 +87,19 @@ export function formatSummary(result: AcpxResult, threadId?: string): string {
 
   let summary = `${status} (exit code: ${result.exitCode})`;
 
-  if (messageCount > 0 || toolCount > 0) {
-    const parts: string[] = [];
-    if (messageCount > 0) parts.push(`${messageCount} message${messageCount !== 1 ? "s" : ""}`);
-    if (toolCount > 0) parts.push(`${toolCount} tool call${toolCount !== 1 ? "s" : ""}`);
-    summary += `\n${parts.join(", ")}`;
+  // Add stats line (messages, tool calls, duration, cost)
+  const statParts: string[] = [];
+  if (messageCount > 0) statParts.push(`${messageCount} message${messageCount !== 1 ? "s" : ""}`);
+  if (toolCount > 0) statParts.push(`${toolCount} tool call${toolCount !== 1 ? "s" : ""}`);
+  if (result.durationMs !== undefined) {
+    const seconds = Math.round(result.durationMs / 1000);
+    statParts.push(`${seconds}s`);
+  }
+  if (result.costUsd !== undefined) {
+    statParts.push(`$${result.costUsd.toFixed(4)}`);
+  }
+  if (statParts.length > 0) {
+    summary += `\n${statParts.join(", ")}`;
   }
 
   if (result.error) {

--- a/src/subagent/types.ts
+++ b/src/subagent/types.ts
@@ -97,6 +97,8 @@ export interface AcpxEvent {
   error?: string;
   /** Process exit code (for "done" events) */
   exitCode?: number;
+  /** Cost in USD (for "done" events, if available) */
+  costUsd?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -115,6 +117,10 @@ export interface AcpxResult {
   events: AcpxEvent[];
   /** Process exit code */
   exitCode: number;
+  /** Cost in USD (if available from the agent) */
+  costUsd?: number;
+  /** Runtime duration in milliseconds */
+  durationMs?: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements #220 — Subagent completion messages now include runtime duration and cost.

## Changes
- Add `costUsd` field to `AcpxEvent` (for 'done' events)
- Add `durationMs` and `costUsd` fields to `AcpxResult`
- Extract `cost_usd` from Claude CLI 'result' events
- Update `formatSummary()` to display duration and cost
- Track start time in `runSubagentWithDiscord`

## Example Output
Before:
```
✅ Completed (exit code: 0)
1 message, 2 tool calls
📋 Details: <#thread-123>
```

After:
```
✅ Completed (exit code: 0)
1 message, 2 tool calls, 45s, $0.0123
📋 Details: <#thread-123>
```

## Tests
- 3 new discord-sink tests for duration/cost formatting
- 3 new acpx-backend tests for cost_usd extraction
- 1962/1963 tests pass (1 pre-existing failure in hot-reload)