### PR TITLE
feat(#224): inject inbound_meta for group chat context

### DIFF
--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -13,13 +13,14 @@ type MockChannel = {
   sendTyping: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
   isThread: ReturnType<typeof vi.fn>;
+  type?: number;
 };
 
 type MockIncomingMessage = {
-  author: { bot: boolean; username: string; id: string };
+  author: { bot: boolean; username: string; id: string; displayName?: string };
   content: string;
   createdTimestamp: number;
-  guild: { id: string };
+  guild: { id: string } | null;
   channelId: string;
   channel: MockChannel;
   mentions: { has: ReturnType<typeof vi.fn> };
@@ -215,7 +216,13 @@ describe("DiscordTransport", () => {
       expect(sessionStore.addMessage).toHaveBeenNthCalledWith(
         1,
         "session-123",
-        expect.objectContaining({ role: "user", content: textContent("hello again") }),
+        expect.objectContaining({ 
+          role: "user", 
+          content: [expect.objectContaining({
+            type: "text",
+            text: expect.stringContaining("hello again"),
+          })],
+        }),
       );
       expect(promptSpy).toHaveBeenCalledWith([
         { role: "assistant", content: textContent("Previous reply") },
@@ -901,6 +908,111 @@ describe("DiscordTransport", () => {
       // With historyTurns=2, only the last 2 user turns should be kept
       const userMessages = promptInput.filter(m => m.role === "user");
       expect(userMessages.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("inbound_meta injection", () => {
+    function makeChannel(): MockChannel {
+      return {
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(false),
+      };
+    }
+
+    it("injects inbound_meta block for group chats", async () => {
+      sessionStore.findByKey = vi.fn().mockResolvedValue(null);
+      sessionStore.create = vi.fn().mockResolvedValue({ id: "session-1" });
+      sessionStore.getMessages = vi.fn().mockResolvedValue([]);
+
+      const msg: MockIncomingMessage = {
+        author: { bot: false, username: "alice", id: "user-alice", displayName: "Alice" },
+        content: "<@bot-123> Hello world",
+        createdTimestamp: Date.now(),
+        guild: { id: "guild-1" },
+        channelId: "channel-1",
+        channel: makeChannel(),
+        mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        thread: undefined,
+      };
+
+      // Need to set up bindings via config
+      const testTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager,
+        sessionStore,
+        defaultAgentId: "default",
+        channels: {
+          discord: {
+            accounts: {
+              testacct: {
+                guilds: {
+                  "guild-1": { requireMention: true },
+                },
+              },
+            },
+          },
+        },
+        accountId: "testacct",
+      });
+
+      await (
+        testTransport as unknown as {
+          handleMessage: (message: MockIncomingMessage) => Promise<void>;
+        }
+      ).handleMessage(msg);
+
+      const addMessageCall = (sessionStore.addMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(addMessageCall).toBeDefined();
+      const userMessage = addMessageCall[1];
+      const contentText = userMessage.content[0].text;
+
+      // Verify inbound_meta block is present
+      expect(contentText).toContain('<inbound_meta type="untrusted">');
+      expect(contentText).toContain("<chat_type>group</chat_type>");
+      expect(contentText).toContain("<sender_id>user-alice</sender_id>");
+      expect(contentText).toContain("<sender_username>alice</sender_username>");
+      // Verify user message is still there
+      expect(contentText).toContain("Hello world");
+    });
+
+    it("injects direct chat_type for DMs", async () => {
+      sessionStore.findByKey = vi.fn().mockResolvedValue(null);
+      sessionStore.create = vi.fn().mockResolvedValue({ id: "session-1" });
+      sessionStore.getMessages = vi.fn().mockResolvedValue([]);
+
+      const testTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager,
+        sessionStore,
+        defaultAgentId: "default",
+        allowDMs: true,
+      });
+
+      const msg: MockIncomingMessage = {
+        author: { bot: false, username: "bob", id: "user-bob" },
+        content: "private message",
+        createdTimestamp: Date.now(),
+        guild: null, // DM has no guild
+        channelId: "dm-channel",
+        channel: { ...makeChannel(), type: 1 }, // DM channel type
+        mentions: { has: vi.fn(() => false) },
+        thread: undefined,
+      };
+
+      await (
+        testTransport as unknown as {
+          handleMessage: (message: MockIncomingMessage) => Promise<void>;
+        }
+      ).handleMessage(msg);
+
+      const addMessageCall = (sessionStore.addMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(addMessageCall).toBeDefined();
+      const userMessage = addMessageCall[1];
+      const contentText = userMessage.content[0].text;
+
+      expect(contentText).toContain("<chat_type>direct</chat_type>");
+      expect(contentText).toContain("private message");
     });
   });
 

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -27,7 +27,7 @@ import { loggers } from "../core/logger.js";
 import { ThreadBindingManager } from "../core/thread-bindings.js";
 import { runAgentLoop } from "../core/agent-runner.js";
 import { isSilentReply } from "./silent-reply.js";
-import { extractDiscordMetadata } from "./message-metadata.js";
+import { extractDiscordMetadata, formatInboundMeta } from "./message-metadata.js";
 import type { UsageTracker } from "../core/usage-tracker.js";
 import { buildSessionKey } from "../core/session-keys.js";
 import {
@@ -428,11 +428,15 @@ export class DiscordTransport implements Transport {
       : [];
     const enrichedContent = buildHistoryContext(historyEntries, content);
 
-    // 8. Add user message to session
+    // 8. Add user message to session with inbound metadata
     const messageMetadata = extractDiscordMetadata(msg);
+    const chatType = msg.guild ? "group" : "direct";
+    const inboundMeta = formatInboundMeta(messageMetadata, chatType);
+    const contentWithMeta = `${inboundMeta}\n\n${enrichedContent}`;
+    
     const userMessage: Message = {
       role: "user",
-      content: textContent(enrichedContent),
+      content: textContent(contentWithMeta),
       timestamp: msg.createdTimestamp,
       metadata: {
         userId: msg.author.id,

--- a/src/transports/message-metadata.test.ts
+++ b/src/transports/message-metadata.test.ts
@@ -1,7 +1,7 @@
 // src/transports/message-metadata.test.ts — Tests for message metadata extraction
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { extractDiscordMetadata, extractCliMetadata } from "./message-metadata.js";
+import { extractDiscordMetadata, extractCliMetadata, formatInboundMeta, type MessageMetadata } from "./message-metadata.js";
 
 // ---------------------------------------------------------------------------
 // Mock discord.js message factory
@@ -198,5 +198,82 @@ describe("extractCliMetadata", () => {
       type: "dm",
     });
     expect(metadata.replyTo).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatInboundMeta tests
+// ---------------------------------------------------------------------------
+
+describe("formatInboundMeta", () => {
+  it("formats basic metadata for group chat", () => {
+    const meta: MessageMetadata = {
+      sender: { id: "123", username: "testuser", isBot: false },
+      timestamps: { sent: 1700000000000, received: 1700000001000 },
+      channel: { id: "456", name: "general", type: "text" },
+    };
+    
+    const result = formatInboundMeta(meta, "group");
+    
+    expect(result).toContain('<inbound_meta type="untrusted">');
+    expect(result).toContain("<chat_type>group</chat_type>");
+    expect(result).toContain("<channel_id>456</channel_id>");
+    expect(result).toContain("<channel_name>general</channel_name>");
+    expect(result).toContain("<sender_id>123</sender_id>");
+    expect(result).toContain("<sender_username>testuser</sender_username>");
+    expect(result).toContain("<timestamp>1700000000000</timestamp>");
+    expect(result).toContain("</inbound_meta>");
+  });
+
+  it("formats metadata for direct chat", () => {
+    const meta: MessageMetadata = {
+      sender: { id: "123", username: "testuser", isBot: false },
+      timestamps: { sent: 1700000000000, received: 1700000001000 },
+      channel: { id: "789", type: "dm" },
+    };
+    
+    const result = formatInboundMeta(meta, "direct");
+    
+    expect(result).toContain("<chat_type>direct</chat_type>");
+    expect(result).not.toContain("<channel_name>");
+  });
+
+  it("includes reply_to when present", () => {
+    const meta: MessageMetadata = {
+      sender: { id: "123", username: "testuser", isBot: false },
+      timestamps: { sent: 1700000000000, received: 1700000001000 },
+      channel: { id: "456", type: "text" },
+      replyTo: "msg-999",
+    };
+    
+    const result = formatInboundMeta(meta, "group");
+    
+    expect(result).toContain("<reply_to>msg-999</reply_to>");
+  });
+
+  it("includes display name when present", () => {
+    const meta: MessageMetadata = {
+      sender: { id: "123", username: "testuser", displayName: "Test User", isBot: false },
+      timestamps: { sent: 1700000000000, received: 1700000001000 },
+      channel: { id: "456", type: "text" },
+    };
+    
+    const result = formatInboundMeta(meta, "group");
+    
+    expect(result).toContain("<sender_display_name>Test User</sender_display_name>");
+  });
+
+  it("escapes XML special characters", () => {
+    const meta: MessageMetadata = {
+      sender: { id: "123", username: "test<user>", displayName: "Test & User", isBot: false },
+      timestamps: { sent: 1700000000000, received: 1700000001000 },
+      channel: { id: "456", name: "chat\"room'1", type: "text" },
+    };
+    
+    const result = formatInboundMeta(meta, "group");
+    
+    expect(result).toContain("<sender_username>test&lt;user&gt;</sender_username>");
+    expect(result).toContain("<sender_display_name>Test &amp; User</sender_display_name>");
+    expect(result).toContain("<channel_name>chat&quot;room&apos;1</channel_name>");
   });
 });

--- a/src/transports/message-metadata.ts
+++ b/src/transports/message-metadata.ts
@@ -112,3 +112,49 @@ export function extractCliMetadata(): MessageMetadata {
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// Inbound metadata formatting (untrusted context block)
+// ---------------------------------------------------------------------------
+
+/** Format metadata as an XML block for injection into message content. */
+export function formatInboundMeta(meta: MessageMetadata, chatType: "direct" | "group"): string {
+  const lines: string[] = [
+    `<inbound_meta type="untrusted">`,
+    `  <chat_type>${chatType}</chat_type>`,
+    `  <channel_id>${meta.channel.id}</channel_id>`,
+  ];
+  
+  if (meta.channel.name) {
+    lines.push(`  <channel_name>${escapeXml(meta.channel.name)}</channel_name>`);
+  }
+  
+  lines.push(
+    `  <sender_id>${meta.sender.id}</sender_id>`,
+    `  <sender_username>${escapeXml(meta.sender.username)}</sender_username>`,
+  );
+  
+  if (meta.sender.displayName) {
+    lines.push(`  <sender_display_name>${escapeXml(meta.sender.displayName)}</sender_display_name>`);
+  }
+  
+  lines.push(`  <timestamp>${meta.timestamps.sent}</timestamp>`);
+  
+  if (meta.replyTo) {
+    lines.push(`  <reply_to>${meta.replyTo}</reply_to>`);
+  }
+  
+  lines.push(`</inbound_meta>`);
+  
+  return lines.join("\n");
+}
+
+/** Escape XML special characters. */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}


### PR DESCRIPTION
## Summary
Inject structured sender metadata as untrusted XML context block before user message content.

## Changes
- Add `formatInboundMeta()` to generate `<inbound_meta type="untrusted">` XML block
- Inject block before user message content in Discord transport
- Include: sender_id, sender_username, chat_type (group/direct), channel_id, timestamp
- Include reply_to when message is a reply
- Escape XML special characters in user-provided strings

## Testing
- 7 new tests for metadata formatting and injection
- 35 Discord transport tests pass

Closes #224