### PR TITLE
feat(config): add codingMode option to force subagent for code changes (#299)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -844,6 +844,7 @@ async function main() {
       agentConfig.toolSettings,
       subagentEnabled,
       agentAllowedWorkspaces,
+      agentConfig.codingMode,
     );
 
     // Apply tool policy (allow/deny) before registration

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -96,6 +96,13 @@ export interface AgentConfigFile {
   heartbeatInterval?: number;
   /** Custom heartbeat prompt (overrides the default). */
   heartbeatPrompt?: string;
+  /**
+   * Coding mode controls how the agent handles code modifications:
+   * - 'subagent': Force all code through spawn_subagent (removes write_file, edit)
+   * - 'direct': Agent can modify files directly
+   * - 'auto': Agent chooses (default)
+   */
+  codingMode?: "subagent" | "direct" | "auto";
 }
 
 /** Self-iteration configuration in config file */
@@ -752,6 +759,7 @@ export function toAgentConfig(
     sandbox,
     heartbeatInterval: agent.heartbeatInterval,
     heartbeatPrompt: agent.heartbeatPrompt,
+    codingMode: agent.codingMode,
   };
 }
 

--- a/src/core/tools.test.ts
+++ b/src/core/tools.test.ts
@@ -636,6 +636,48 @@ describe("Built-in tools", () => {
 
       expect(tools.map((entry) => entry.tool.name)).toContain("shell");
     });
+
+    it("excludes file writing tools when codingMode is 'subagent'", () => {
+      const tools = createWorkspaceToolsWithGuards(
+        "/tmp/workspace",
+        { cli: true },
+        true, // subagentEnabled
+        [], // allowedWorkspaces
+        "subagent",
+      );
+      const names = tools.map((entry) => entry.tool.name);
+
+      // Should exclude write_file and edit
+      expect(names).not.toContain("write_file");
+      expect(names).not.toContain("edit");
+
+      // Should still have spawn_subagent, shell, read_file
+      expect(names).toContain("spawn_subagent");
+      expect(names).toContain("shell");
+      expect(names).toContain("read_file");
+    });
+
+    it("includes file writing tools when codingMode is 'direct' or 'auto'", () => {
+      const directTools = createWorkspaceToolsWithGuards(
+        "/tmp/workspace",
+        { cli: true },
+        false,
+        [],
+        "direct",
+      );
+      const autoTools = createWorkspaceToolsWithGuards(
+        "/tmp/workspace",
+        { cli: true },
+        false,
+        [],
+        "auto",
+      );
+
+      expect(directTools.map((e) => e.tool.name)).toContain("write_file");
+      expect(directTools.map((e) => e.tool.name)).toContain("edit");
+      expect(autoTools.map((e) => e.tool.name)).toContain("write_file");
+      expect(autoTools.map((e) => e.tool.name)).toContain("edit");
+    });
   });
 
   describe("resolveToolGuards", () => {

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -846,11 +846,15 @@ export function applyToolPolicy(
 export function createWorkspaceTools(workspacePath: string): { tool: Tool; handler: ToolHandler }[] {
   return createWorkspaceToolsWithGuards(workspacePath);
 }
+/** Tools that modify files - excluded when codingMode is 'subagent' */
+export const FILE_WRITING_TOOLS = ["write_file", "edit"];
+
 export function createWorkspaceToolsWithGuards(
   workspacePath: string,
   settings?: AgentToolSettings,
   subagentEnabled = false,
   allowedWorkspaces: string[] = [],
+  codingMode: "subagent" | "direct" | "auto" = "auto",
 ): { tool: Tool; handler: ToolHandler }[] {
   const guards = resolveToolGuards(settings);
   // Always use workspacePath as base for relative path resolution.
@@ -860,7 +864,7 @@ export function createWorkspaceToolsWithGuards(
   // (e.g., another agent's workspace), causing identity contamination (#92).
   const fileBasePath = workspacePath;
   const constrainToWorkspace = guards.fs.workspaceOnly;
-  const tools = [
+  let tools = [
     createReadFileTool({ basePath: fileBasePath, constrainToWorkspace, allowedWorkspaces }),
     createWriteFileTool({ basePath: fileBasePath, constrainToWorkspace, allowedWorkspaces }),
     createEditFileTool({ basePath: fileBasePath, constrainToWorkspace, allowedWorkspaces }),
@@ -878,5 +882,11 @@ export function createWorkspaceToolsWithGuards(
     tools.push(createWebFetchTool());
     tools.push(createWebSearchTool());
   }
+
+  // Filter out file writing tools when codingMode is 'subagent'
+  if (codingMode === "subagent") {
+    tools = tools.filter((t) => !FILE_WRITING_TOOLS.includes(t.tool.name));
+  }
+
   return tools;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -150,6 +150,13 @@ export interface AgentConfig {
   heartbeatInterval?: number;
   /** Custom heartbeat prompt (overrides the default) */
   heartbeatPrompt?: string;
+  /**
+   * Coding mode controls how the agent handles code modifications:
+   * - 'subagent': Force all code changes through spawn_subagent (removes write_file, edit)
+   * - 'direct': Agent can modify files directly (default behavior)
+   * - 'auto': Agent chooses based on task complexity (default)
+   */
+  codingMode?: "subagent" | "direct" | "auto";
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export { PiMonoCore } from "./core/pi-mono.js";
 export { DefaultAgentManager } from "./core/agent-manager.js";
 export type { AgentCreateOptions } from "./core/agent-manager.js";
 export { DefaultSessionStore } from "./core/session-store.js";
-export { ToolRegistry, createEchoTool, createTimeTool, createSubagentTool, createWorkspaceToolsWithGuards } from "./core/tools.js";
+export { ToolRegistry, createEchoTool, createTimeTool, createSubagentTool, createWorkspaceToolsWithGuards, FILE_WRITING_TOOLS } from "./core/tools.js";
 export type { ToolHandler, ToolEntry, SubagentToolOptions } from "./core/tools.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add `codingMode: 'subagent' | 'direct' | 'auto'` to AgentConfig.

When `codingMode: 'subagent'`:
- Excludes `write_file`, `edit` from available tools
- Agent can still run git, tests, read files via exec/shell
- Forces all code modifications through `spawn_subagent`

Closes #299