### PR TITLE
fix(tools): remove duplicate shell tool in favor of exec (#285)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -896,10 +896,12 @@ async function main() {
     }
 
     // Register exec/process tools (shared registry across agents)
-    const execTools = createExecTools({ cwd: workspacePath, registry: processRegistry });
-    const filteredExecTools = applyToolPolicy(execTools, agentConfig.toolSettings);
-    for (const { tool, handler } of filteredExecTools) {
-      toolRegistry.register(tool, handler);
+    if (resolvedToolGuards.cli) {
+      const execTools = createExecTools({ cwd: workspacePath, registry: processRegistry });
+      const filteredExecTools = applyToolPolicy(execTools, agentConfig.toolSettings);
+      for (const { tool, handler } of filteredExecTools) {
+        toolRegistry.register(tool, handler);
+      }
     }
 
     // Build tool guard prompt and store it for hot-reload persistence (M11.4)

--- a/src/core/tools.test.ts
+++ b/src/core/tools.test.ts
@@ -9,7 +9,6 @@ import {
   buildToolGuardPrompt,
   createEchoTool,
   createTimeTool,
-  createShellTool,
   createReadFileTool,
   createWriteFileTool,
   createEditFileTool,
@@ -199,35 +198,6 @@ describe("Built-in tools", () => {
       const result = await handler({ timezone: "Invalid/Zone" });
 
       expect(result).toContain("Invalid timezone");
-    });
-  });
-
-  describe("createShellTool", () => {
-    it("executes command and returns output", async () => {
-      const { handler } = createShellTool();
-      const result = await handler({ command: "echo hello" });
-
-      expect(result.trim()).toBe("hello");
-    });
-
-    it("respects cwd option", async () => {
-      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "shell-test-"));
-      try {
-        const { handler } = createShellTool({ cwd: tempDir });
-        const result = await handler({ command: "pwd" });
-
-        // macOS: /var is symlinked to /private/var
-        expect(result.trim()).toContain(path.basename(tempDir));
-      } finally {
-        await fs.rm(tempDir, { recursive: true, force: true });
-      }
-    });
-
-    it("returns error for failed command", async () => {
-      const { handler } = createShellTool();
-      const result = await handler({ command: "exit 1" });
-
-      expect(result).toContain("[error]");
     });
   });
 
@@ -629,12 +599,14 @@ describe("Built-in tools", () => {
       expect(names).toContain("list_dir");
       expect(names).toContain("get_current_time");
       expect(names).not.toContain("shell");
+      expect(names).not.toContain("exec"); // exec is registered separately in cli.ts
     });
 
-    it("enables shell when cli guard is turned on", () => {
+    it("does not include shell or exec (exec is registered in cli.ts)", () => {
       const tools = createWorkspaceToolsWithGuards("/tmp/workspace", { cli: true });
-
-      expect(tools.map((entry) => entry.tool.name)).toContain("shell");
+      const names = tools.map((entry) => entry.tool.name);
+      expect(names).not.toContain("shell");
+      expect(names).toContain("read_file");
     });
 
     it("excludes file writing tools when codingMode is 'subagent'", () => {
@@ -651,9 +623,8 @@ describe("Built-in tools", () => {
       expect(names).not.toContain("write_file");
       expect(names).not.toContain("edit");
 
-      // Should still have spawn_subagent, shell, read_file
+      // Should still have spawn_subagent, read_file (exec is in cli.ts)
       expect(names).toContain("spawn_subagent");
-      expect(names).toContain("shell");
       expect(names).toContain("read_file");
     });
 
@@ -705,9 +676,8 @@ describe("Built-in tools", () => {
       );
 
       expect(prompt).toContain("Only the following tools are available");
-      expect(prompt).toContain("shell");
       expect(prompt).toContain("restricted to the workspace: /tmp/workspace");
-      expect(prompt).toContain("Shell command execution is enabled");
+      expect(prompt).toContain("exec command execution is enabled");
     });
   });
 });

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -1,7 +1,5 @@
 // src/core/tools.ts — Tool registry and execution
 // Manages tool definitions and their handlers.
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentToolSettings, Tool } from "./types.js";
@@ -12,7 +10,6 @@ import { DiscordSink } from "../subagent/discord-sink.js";
 import { getSubagentContext } from "./subagent-context.js";
 import { failureTracker } from "../subagent/failure-tracker.js";
 import { createLogger } from "./logger.js";
-const execAsync = promisify(exec);
 const log = createLogger("tools:subagent");
 /** Function that executes a tool call and returns a string result. */
 export type ToolHandler = (args: unknown) => Promise<string>;
@@ -380,60 +377,6 @@ async function runSubagentWithDiscord(
   }
 }
 // ---------------------------------------------------------------------------
-// Shell tool
-// ---------------------------------------------------------------------------
-export interface ShellToolOptions {
-  /** Working directory for command execution */
-  cwd?: string;
-  /** Maximum execution time in ms (default: 30000) */
-  timeout?: number;
-  /** Maximum output size in bytes (default: 100KB) */
-  maxOutput?: number;
-}
-/**
- * Create a shell execution tool.
- */
-export function createShellTool(options: ShellToolOptions = {}): { tool: Tool; handler: ToolHandler } {
-  const { cwd, timeout = 30000, maxOutput = 100 * 1024 } = options;
-  return {
-    tool: {
-      name: "shell",
-      description: "Execute a shell command and return the output. Use for running programs, scripts, or system commands.",
-      parameters: {
-        type: "object",
-        properties: {
-          command: {
-            type: "string",
-            description: "The shell command to execute",
-          },
-        },
-        required: ["command"],
-      },
-    },
-    handler: async (args) => {
-      const { command } = args as { command: string };
-      try {
-        const { stdout, stderr } = await execAsync(command, {
-          cwd,
-          timeout,
-          maxBuffer: maxOutput,
-        });
-        let output = stdout;
-        if (stderr) {
-          output += (output ? "\n" : "") + `[stderr] ${stderr}`;
-        }
-        return output || "(no output)";
-      } catch (error) {
-        const err = error as { message?: string; code?: number; signal?: string; stderr?: string };
-        if (err.signal === "SIGTERM") {
-          return `[error] Command timed out after ${timeout}ms`;
-        }
-        return `[error] ${err.message || String(error)}${err.stderr ? `\n[stderr] ${err.stderr}` : ""}`;
-      }
-    },
-  };
-}
-// ---------------------------------------------------------------------------
 // File tools
 // ---------------------------------------------------------------------------
 export interface FileToolOptions {
@@ -799,10 +742,10 @@ export function buildToolGuardPrompt(
     lines.push("- File operations may access host paths outside the workspace.");
   }
   if (guards.cli) {
-    lines.push(`- Shell command execution is enabled and runs with cwd=${workspacePath}.`);
-    lines.push("- Use shell only when file tools are insufficient for the task.");
+    lines.push(`- Shell/exec command execution is enabled and runs with cwd=${workspacePath}.`);
+    lines.push("- Use exec only when file tools are insufficient for the task.");
   } else {
-    lines.push("- Shell command execution is disabled in this runtime.");
+    lines.push("- Shell/exec command execution is disabled in this runtime.");
   }
   return lines.join("\n");
 }
@@ -871,9 +814,6 @@ export function createWorkspaceToolsWithGuards(
     createListDirTool({ basePath: fileBasePath, constrainToWorkspace, allowedWorkspaces }),
     createTimeTool(),
   ];
-  if (guards.cli) {
-    tools.unshift(createShellTool({ cwd: workspacePath }));
-  }
   if (subagentEnabled) {
     tools.push(createSubagentTool({ workspacePath, allowedWorkspaces }));
   }

--- a/tests/e2e-smoke.test.ts
+++ b/tests/e2e-smoke.test.ts
@@ -258,26 +258,26 @@ describe("NO_REPLY suppression", () => {
 describe("tool policy deny", () => {
   it("removes denied tools from the registry", () => {
     const tools = createWorkspaceToolsWithGuards(tmpDir, { cli: true });
-    const filtered = applyToolPolicy(tools, { deny: ["shell"] });
+    const filtered = applyToolPolicy(tools, { deny: ["read_file"] });
 
     const names = filtered.map((t) => t.tool.name);
-    expect(names).not.toContain("shell");
-    expect(names).toContain("read_file");
+    expect(names).not.toContain("read_file");
+    expect(names).toContain("write_file");
     expect(names).toContain("edit");
   });
 
   it("denied tool cannot be executed", async () => {
     const tools = createWorkspaceToolsWithGuards(tmpDir, { cli: true });
-    const filtered = applyToolPolicy(tools, { deny: ["shell"] });
+    const filtered = applyToolPolicy(tools, { deny: ["read_file"] });
 
     const registry = new ToolRegistry();
     for (const { tool, handler } of filtered) {
       registry.register(tool, handler);
     }
 
-    expect(registry.has("shell")).toBe(false);
-    await expect(registry.execute("shell", { command: "echo hi" }))
-      .rejects.toThrow('Tool "shell" not found');
+    expect(registry.has("read_file")).toBe(false);
+    await expect(registry.execute("read_file", { path: "test.txt" }))
+      .rejects.toThrow('Tool "read_file" not found');
   });
 
   it("exec tool denied via policy is not executable", async () => {
@@ -306,13 +306,13 @@ describe("tool policy deny", () => {
   it("deny takes precedence over allow", () => {
     const tools = createWorkspaceToolsWithGuards(tmpDir, { cli: true });
     const filtered = applyToolPolicy(tools, {
-      allow: ["read_file", "shell"],
-      deny: ["shell"],
+      allow: ["read_file", "edit"],
+      deny: ["edit"],
     });
 
     const names = filtered.map((t) => t.tool.name);
     expect(names).toContain("read_file");
-    expect(names).not.toContain("shell");
+    expect(names).not.toContain("edit");
   });
 });
 
@@ -324,7 +324,7 @@ describe("full tool wiring", () => {
   it("registers all core tools without conflict", async () => {
     const registry = new ToolRegistry();
 
-    // Workspace tools (read, write, edit, list_dir, time + shell when cli=true)
+    // Workspace tools (read, write, edit, list_dir, time)
     const workspaceTools = createWorkspaceToolsWithGuards(tmpDir, {
       cli: true,
       web: true,
@@ -333,9 +333,7 @@ describe("full tool wiring", () => {
       registry.register(tool, handler);
     }
 
-    // Exec tools (exec, process_list, process_kill) — note: shell is separate
-    // In cli.ts, exec tools are added alongside workspace tools. Since "shell"
-    // and "exec" are different tools, both can coexist.
+    // Exec tools (exec, process_list, process_kill) — registered separately like cli.ts
     const execTools = createExecTools({ cwd: tmpDir });
     for (const { tool, handler } of execTools) {
       registry.register(tool, handler);
@@ -361,7 +359,6 @@ describe("full tool wiring", () => {
     expect(registry.has("write_file")).toBe(true);
     expect(registry.has("edit")).toBe(true);
     expect(registry.has("list_dir")).toBe(true);
-    expect(registry.has("shell")).toBe(true);
     expect(registry.has("exec")).toBe(true);
     expect(registry.has("web_fetch")).toBe(true);
     expect(registry.has("web_search")).toBe(true);


### PR DESCRIPTION
## Summary
Removes the redundant `shell` tool (`createShellTool`) since `exec` from `src/tools/exec.ts` is strictly more capable (supports `background: true` mode).

## Changes
- **Removed** `createShellTool()` and `ShellToolOptions` from `src/core/tools.ts`
- **Removed** unused `exec`/`promisify` imports
- **Gated** `createExecTools()` registration behind `resolvedToolGuards.cli` in `cli.ts`
- **Updated** `buildToolGuardPrompt()` to reference `exec` instead of `shell`
- **Updated** tests to reflect shell tool removal

## Testing
- `pnpm build` ✅
- `pnpm test` ✅ (1970 passed)

Fixes #285