### PR TITLE
fix(cli): clean up session stores and processes on shutdown (#286)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1173,6 +1173,18 @@ async function main() {
     hotReload.stop();
     if (discordManager) await discordManager.stop();
     await apiServer.stop();
+
+    // Clean up session stores (#286)
+    chatSessionStore.destroy();
+    if (discordSessionStores) {
+      for (const store of discordSessionStores.values()) {
+        store.destroy();
+      }
+    }
+
+    // Kill orphaned background processes (#286)
+    processRegistry.clear();
+
     process.exit(0);
   });
 
@@ -1183,6 +1195,18 @@ async function main() {
     hotReload.stop();
     if (discordManager) await discordManager.stop();
     await apiServer.stop();
+
+    // Clean up session stores (#286)
+    chatSessionStore.destroy();
+    if (discordSessionStores) {
+      for (const store of discordSessionStores.values()) {
+        store.destroy();
+      }
+    }
+
+    // Kill orphaned background processes (#286)
+    processRegistry.clear();
+
     process.exit(0);
   });
 }


### PR DESCRIPTION
## Summary
Adds proper cleanup for session stores and background processes in the graceful shutdown handlers.

## Changes
- Call `destroy()` on `chatSessionStore` on SIGINT/SIGTERM
- Call `destroy()` on all `discordSessionStores` entries on SIGINT/SIGTERM
- Call `processRegistry.clear()` to kill orphaned background processes

## Why This Matters
1. **Timer leak prevention**: `DefaultSessionStore` has cleanup and debounce timers that may fire after other resources are torn down
2. **Orphan process prevention**: Background processes spawned via `exec(background=true)` would continue running after daemon exits

## Testing
- `pnpm build` ✅
- Lint/typecheck passes

Fixes #286