### PR TITLE
fix(workspace): load yesterday's daily memory (#288)

### DIFF
--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -102,6 +102,75 @@ describe("Workspace", () => {
       expect(ctx.memory).toContain("Daily notes");
     });
 
+    it("loads only today's memory when yesterday doesn't exist", async () => {
+      await fs.mkdir(path.join(tempDir, "memory"));
+      const today = new Date().toISOString().split("T")[0];
+      await fs.writeFile(
+        path.join(tempDir, "memory", `${today}.md`),
+        "Today's notes",
+      );
+
+      const ctx = await loadWorkspaceContext(tempDir);
+
+      expect(ctx.memory).toContain("Today's notes");
+      expect(ctx.memory).toContain("## Today's Notes");
+      expect(ctx.memory).not.toContain("## Yesterday's Notes");
+    });
+
+    it("loads only yesterday's memory when today doesn't exist", async () => {
+      await fs.mkdir(path.join(tempDir, "memory"));
+      const yesterday = new Date(Date.now() - 86400000).toISOString().split("T")[0];
+      await fs.writeFile(
+        path.join(tempDir, "memory", `${yesterday}.md`),
+        "Yesterday's notes",
+      );
+
+      const ctx = await loadWorkspaceContext(tempDir);
+
+      expect(ctx.memory).toContain("Yesterday's notes");
+      expect(ctx.memory).toContain("## Yesterday's Notes");
+      expect(ctx.memory).not.toContain("## Today's Notes");
+    });
+
+    it("loads both yesterday and today's memory in chronological order", async () => {
+      await fs.writeFile(path.join(tempDir, "MEMORY.md"), "Base memory");
+      await fs.mkdir(path.join(tempDir, "memory"));
+
+      const yesterday = new Date(Date.now() - 86400000).toISOString().split("T")[0];
+      const today = new Date().toISOString().split("T")[0];
+
+      await fs.writeFile(
+        path.join(tempDir, "memory", `${yesterday}.md`),
+        "Yesterday's content",
+      );
+      await fs.writeFile(
+        path.join(tempDir, "memory", `${today}.md`),
+        "Today's content",
+      );
+
+      const ctx = await loadWorkspaceContext(tempDir);
+
+      expect(ctx.memory).toContain("Base memory");
+      expect(ctx.memory).toContain("Yesterday's content");
+      expect(ctx.memory).toContain("Today's content");
+
+      // Verify chronological order: yesterday should come before today
+      const yesterdayIndex = ctx.memory!.indexOf("Yesterday's Notes");
+      const todayIndex = ctx.memory!.indexOf("Today's Notes");
+      expect(yesterdayIndex).toBeLessThan(todayIndex);
+    });
+
+    it("loads neither yesterday nor today when both don't exist", async () => {
+      await fs.writeFile(path.join(tempDir, "MEMORY.md"), "Base memory only");
+      await fs.mkdir(path.join(tempDir, "memory"));
+
+      const ctx = await loadWorkspaceContext(tempDir);
+
+      expect(ctx.memory).toBe("Base memory only");
+      expect(ctx.memory).not.toContain("## Yesterday's Notes");
+      expect(ctx.memory).not.toContain("## Today's Notes");
+    });
+
     it("returns empty values for missing files", async () => {
       const ctx = await loadWorkspaceContext(tempDir);
 

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -51,12 +51,20 @@ export async function loadWorkspaceContext(workspacePath: string): Promise<Works
   const memoryPath = path.join(workspacePath, "MEMORY.md");
   memory = await readFileIfExists(memoryPath);
 
+  // Load yesterday's daily memory if exists
+  const yesterday = new Date(Date.now() - 86400000).toISOString().split("T")[0]; // YYYY-MM-DD
+  const yesterdayMemoryPath = path.join(workspacePath, "memory", `${yesterday}.md`);
+  const yesterdayMemory = await readFileIfExists(yesterdayMemoryPath);
+  if (yesterdayMemory) {
+    memory = memory ? `${memory}\n\n## Yesterday's Notes\n\n${yesterdayMemory}` : `## Yesterday's Notes\n\n${yesterdayMemory}`;
+  }
+
   // Load today's daily memory if exists
   const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
   const dailyMemoryPath = path.join(workspacePath, "memory", `${today}.md`);
   const dailyMemory = await readFileIfExists(dailyMemoryPath);
   if (dailyMemory) {
-    memory = memory ? `${memory}\n\n## Today's Notes\n\n${dailyMemory}` : dailyMemory;
+    memory = memory ? `${memory}\n\n## Today's Notes\n\n${dailyMemory}` : `## Today's Notes\n\n${dailyMemory}`;
   }
 
   // Load skills from workspace


### PR DESCRIPTION
## Summary
- Loads both yesterday's and today's daily memory files from `memory/` directory
- Uses chronological order: yesterday before today
- Adds section headers "Yesterday's Notes" and "Today's Notes"
- Comprehensive test coverage for all scenarios

## Changes
- Modified `src/core/workspace.ts` to load yesterday's memory using `Date.now() - 86400000`
- Always include section headers when daily memory files exist
- Added 4 new test cases covering:
  - Only today exists
  - Only yesterday exists
  - Both exist (verifies chronological order)
  - Neither exists

## Test plan
- [x] All existing tests pass
- [x] New test cases cover edge cases
- [x] Build succeeds
- [x] Pre-commit hooks pass

Fixes #288

🤖 Generated with [Claude Code](https://claude.ai/claude-code)