### PR TITLE
fix(tools): wire maxTurns from config to subagent spawn (#321)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -845,6 +845,7 @@ async function main() {
       subagentEnabled,
       agentAllowedWorkspaces,
       agentConfig.codingMode,
+      config.acp?.subagent?.maxTurns,
     );
 
     // Apply tool policy (allow/deny) before registration

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -151,6 +151,8 @@ export interface SubagentToolOptions {
   allowedAgents?: string[];
   /** Default timeout in seconds (default: 300) */
   timeout?: number;
+  /** Maximum number of turns for the sub-agent (default: 50) */
+  maxTurns?: number;
 }
 /**
  * Create a sub-agent spawning tool.
@@ -161,7 +163,7 @@ export interface SubagentToolOptions {
  * posted to the main channel when complete.
  */
 export function createSubagentTool(options: SubagentToolOptions): { tool: Tool; handler: ToolHandler } {
-  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout = 300 } = options;
+  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout = 300, maxTurns } = options;
   const supportedAgents = getSupportedAgents();
   const agents = allowedAgents ?? [...supportedAgents];
   // Combine workspace path with additional allowed workspaces
@@ -221,10 +223,10 @@ export function createSubagentTool(options: SubagentToolOptions): { tool: Tool; 
         let result: string;
         if (discordContext) {
           // Run with Discord streaming
-          result = await runSubagentWithDiscord(task, agent as AcpxAgent, cwd, timeout, allAllowedWorkspaces, discordContext);
+          result = await runSubagentWithDiscord(task, agent as AcpxAgent, cwd, timeout, allAllowedWorkspaces, discordContext, maxTurns);
         } else {
           // Run without Discord streaming (original behavior)
-          result = await runSubagentPlain(task, agent as AcpxAgent, cwd, timeout, allAllowedWorkspaces);
+          result = await runSubagentPlain(task, agent as AcpxAgent, cwd, timeout, allAllowedWorkspaces, maxTurns);
         }
 
         // Record failure if result indicates failure
@@ -253,12 +255,14 @@ async function runSubagentPlain(
   cwd: string,
   timeout: number,
   allowedWorkspaces: string[],
+  maxTurns?: number,
 ): Promise<string> {
   const result = await spawnSubagent(task, {
     agent,
     cwd,
     timeout,
     allowedWorkspaces,
+    maxTurns,
   });
   if (result.success) {
     return result.output ?? "[sub-agent completed with no output]";
@@ -277,6 +281,7 @@ async function runSubagentWithDiscord(
   timeout: number,
   allowedWorkspaces: string[],
   context: NonNullable<ReturnType<typeof getSubagentContext>>,
+  maxTurns?: number,
 ): Promise<string> {
   const { sendMessage, createThread, channelId, showToolCalls = true, onComplete } = context;
   // Create Discord sink with thread enabled
@@ -306,6 +311,7 @@ async function runSubagentWithDiscord(
       agent,
       cwd,
       timeout,
+      maxTurns,
       allowedWorkspaces,
       channelId,
       threadId, // Pass threadId for /stop support in threads
@@ -798,6 +804,7 @@ export function createWorkspaceToolsWithGuards(
   subagentEnabled = false,
   allowedWorkspaces: string[] = [],
   codingMode: "subagent" | "direct" | "auto" = "auto",
+  subagentMaxTurns?: number,
 ): { tool: Tool; handler: ToolHandler }[] {
   const guards = resolveToolGuards(settings);
   // Always use workspacePath as base for relative path resolution.
@@ -815,7 +822,7 @@ export function createWorkspaceToolsWithGuards(
     createTimeTool(),
   ];
   if (subagentEnabled) {
-    tools.push(createSubagentTool({ workspacePath, allowedWorkspaces }));
+    tools.push(createSubagentTool({ workspacePath, allowedWorkspaces, maxTurns: subagentMaxTurns }));
   }
   // Web fetch tool
   if (settings?.web) {


### PR DESCRIPTION
## Summary

P0 bug fix: `acp.subagent.maxTurns` config was declared but never passed through to the subagent tool. All subagents fell back to the hardcoded default of 50 turns.

## Root Cause

Same wire-through pattern as #103 (`allowedWorkspaces`):
1. `isotopes.yaml` → `acp.subagent.maxTurns: 100` ✅
2. `cli.ts` → `createWorkspaceToolsWithGuards()` — **never passed maxTurns**
3. `tools.ts` → `SubagentToolOptions` had no `maxTurns` field
4. `subagent.ts` → `options.maxTurns ?? 50` → always 50

## Fix

Wire the full chain:
```
cli.ts (config.acp.subagent.maxTurns)
  → createWorkspaceToolsWithGuards(subagentMaxTurns)
    → createSubagentTool({ maxTurns })
      → runSubagentPlain/runSubagentWithDiscord(maxTurns)
        → spawnSubagent({ maxTurns })
          → acpx-backend --max-turns N
```

## Changes
- `src/core/tools.ts`: Add `maxTurns` to `SubagentToolOptions`, pass through `createSubagentTool`, `runSubagentPlain`, `runSubagentWithDiscord`, and `createWorkspaceToolsWithGuards`
- `src/cli.ts`: Pass `config.acp?.subagent?.maxTurns` to `createWorkspaceToolsWithGuards`

## Testing
- `pnpm build` ✅
- `pnpm test` ✅ (1974 pass, 8 skip)
- Full chain verified with `git grep maxTurns`

Closes #321