### PR TITLE
fix(commands): sync compacted messages to SessionStore (#278)

### DIFF
--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -223,6 +223,12 @@ export class SlashCommandHandler {
         return { response: "ℹ️ Nothing to compact (context too small)." };
       }
 
+      // Sync compacted messages back to SessionStore
+      if (ctx.agentInstance.getMessages) {
+        const compactedMessages = ctx.agentInstance.getMessages();
+        await ctx.sessionStore.setMessages(ctx.sessionId, compactedMessages);
+      }
+
       const messagesAfter = (await ctx.sessionStore.getMessages(ctx.sessionId)).length;
 
       if (instructions) {

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -629,6 +629,10 @@ class PiMonoInstance implements AgentInstance {
     this.agent.clearMessages();
   }
 
+  getMessages(): Message[] {
+    return this.agent.state.messages.map(fromAgentMessage);
+  }
+
   /**
    * Force context compaction for overflow recovery.
    * Returns true if compaction occurred, false if not possible or not configured.

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -481,4 +481,103 @@ describe("DefaultSessionStore", () => {
     });
   });
 
+  describe("setMessages", () => {
+    it("replaces in-memory messages", async () => {
+      const session = await store.create("agent-1");
+      await store.addMessage(session.id, { role: "user", content: textContent("old1") });
+      await store.addMessage(session.id, { role: "assistant", content: textContent("old2") });
+
+      const newMessages = [
+        { role: "user" as const, content: textContent("new1") },
+        { role: "assistant" as const, content: textContent("new2") },
+        { role: "user" as const, content: textContent("new3") },
+      ];
+
+      await store.setMessages(session.id, newMessages);
+
+      const messages = await store.getMessages(session.id);
+      expect(messages).toHaveLength(3);
+      expect(messages[0].content).toEqual(textContent("new1"));
+      expect(messages[1].content).toEqual(textContent("new2"));
+      expect(messages[2].content).toEqual(textContent("new3"));
+    });
+
+    it("overwrites transcript file on disk", async () => {
+      const session = await store.create("agent-1");
+      await store.addMessage(session.id, { role: "user", content: textContent("old1") });
+      await store.addMessage(session.id, { role: "assistant", content: textContent("old2") });
+
+      const transcriptFile = path.join(tempDir, `${session.id}.jsonl`);
+
+      // Verify old messages are persisted
+      const beforeContent = await fs.readFile(transcriptFile, "utf-8");
+      expect(beforeContent.trim().split("\n")).toHaveLength(2);
+
+      const newMessages = [
+        { role: "user" as const, content: textContent("new1") },
+      ];
+
+      await store.setMessages(session.id, newMessages);
+
+      // Verify transcript is overwritten with new messages
+      const afterContent = await fs.readFile(transcriptFile, "utf-8");
+      const lines = afterContent.trim().split("\n");
+      expect(lines).toHaveLength(1);
+
+      const record = JSON.parse(lines[0]);
+      expect(record.message.content).toEqual(textContent("new1"));
+    });
+
+    it("persists after store restart", async () => {
+      const session = await store.create("agent-1");
+      await store.addMessage(session.id, { role: "user", content: textContent("old") });
+
+      const newMessages = [
+        { role: "user" as const, content: textContent("compacted1") },
+        { role: "assistant" as const, content: textContent("compacted2") },
+      ];
+
+      await store.setMessages(session.id, newMessages);
+
+      // Create new store instance
+      const newStore = new DefaultSessionStore({ dataDir: tempDir });
+      await newStore.init();
+
+      const messages = await newStore.getMessages(session.id);
+      expect(messages).toHaveLength(2);
+      expect(messages[0].content).toEqual(textContent("compacted1"));
+      expect(messages[1].content).toEqual(textContent("compacted2"));
+    });
+
+    it("throws on non-existent session", async () => {
+      await expect(
+        store.setMessages("non-existent", [{ role: "user", content: textContent("test") }]),
+      ).rejects.toThrow('Session "non-existent" not found');
+    });
+
+    it("updates lastActiveAt", async () => {
+      const session = await store.create("agent-1");
+
+      // Wait a tiny bit to ensure time difference
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const beforeTimestamp = (await store.get(session.id))!.lastActiveAt.getTime();
+
+      await store.setMessages(session.id, [{ role: "user", content: textContent("test") }]);
+
+      const afterTimestamp = (await store.get(session.id))!.lastActiveAt.getTime();
+      expect(afterTimestamp).toBeGreaterThan(beforeTimestamp);
+    });
+
+    it("handles empty message array", async () => {
+      const session = await store.create("agent-1");
+      await store.addMessage(session.id, { role: "user", content: textContent("old") });
+
+      await store.setMessages(session.id, []);
+
+      const messages = await store.getMessages(session.id);
+      expect(messages).toHaveLength(0);
+    });
+  });
+
 });

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -193,6 +193,30 @@ export class DefaultSessionStore implements SessionStore {
     await this.persistIndex();
   }
 
+  async setMessages(sessionId: string, messages: Message[]): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session "${sessionId}" not found`);
+    }
+
+    // Update in-memory messages
+    session.messages = [...messages];
+    session.messagesLoaded = true;
+    session.lastActiveAt = new Date();
+
+    // Overwrite transcript file with new messages
+    const file = this.transcriptFile(sessionId);
+    const records = messages.map((message): PersistedTranscriptRecord => ({
+      type: "message",
+      timestamp: message.timestamp ?? Date.now(),
+      message,
+    }));
+    const content = records.map((r) => JSON.stringify(r)).join("\n") + (records.length > 0 ? "\n" : "");
+    await fs.writeFile(file, content);
+
+    this.debouncedPersistIndex();
+  }
+
   // -------------------------------------------------------------------------
   // TTL & cleanup
   // -------------------------------------------------------------------------

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -75,5 +75,6 @@ export function createMockSessionStore(sessionId = "session-123"): SessionStore 
     delete: vi.fn(),
     list: vi.fn().mockResolvedValue([]),
     clearMessages: vi.fn(),
+    setMessages: vi.fn(),
   };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -173,6 +173,8 @@ export interface AgentInstance {
   forceCompact?(): Promise<boolean>;
   /** Clear internal message state before prompting with fresh context */
   clearMessages?(): void;
+  /** Get current messages from the agent instance (for persisting to SessionStore) */
+  getMessages?(): Message[];
 }
 
 // ---------------------------------------------------------------------------
@@ -253,6 +255,8 @@ export interface SessionStore {
   list(): Promise<Session[]>;
   /** Clear all messages from a session (keeps session metadata, clears history) */
   clearMessages(sessionId: string): Promise<void>;
+  /** Replace all messages in a session (used by compaction) */
+  setMessages(sessionId: string, messages: Message[]): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `/compact` command not syncing compacted messages back to SessionStore.

## Problem

`handleCompact()` calls `agentInstance.forceCompact()` which only updates in-memory Agent messages. SessionStore was never updated, so the before/after count always showed the same number (e.g. "✅ Compacted: 150 → 150 messages").

## Changes

1. **Add `setMessages()` to SessionStore interface** (`types.ts`)
   - New method to replace all messages in a session

2. **Implement `setMessages()` in DefaultSessionStore** (`session-store.ts`)
   - Updates in-memory messages
   - Overwrites transcript JSONL file
   - Schedules index persistence

3. **Add `getMessages()` to AgentInstance interface** (`types.ts`)
   - Allows reading current messages from agent instance

4. **Implement `getMessages()` in PiMonoInstance** (`pi-mono.ts`)
   - Maps internal agent messages to external Message format

5. **Sync after compaction** (`slash-commands.ts`)
   - After successful `forceCompact()`, call `setMessages()` to persist

6. **Update test-helpers** with mock `setMessages`

## Tests

6 new tests for `setMessages`:
- Replaces in-memory messages
- Overwrites transcript file on disk
- Persists after store restart
- Throws on non-existent session
- Updates lastActiveAt
- Handles empty message array

1978 tests pass (2 flaky watcher tests unrelated).

Closes #278