### PR TITLE
fix(debounce): cancel() resolves primary with null (#287)

### DIFF
--- a/src/core/debounce.test.ts
+++ b/src/core/debounce.test.ts
@@ -69,7 +69,7 @@ describe("InboundDebouncer", () => {
     expect(r2!.text).toBe("world");
   });
 
-  it("cancel resolves all waiters", async () => {
+  it("cancel resolves all waiters with null", async () => {
     vi.useFakeTimers();
     const debouncer = new InboundDebouncer({ windowMs: 100 });
 
@@ -77,24 +77,30 @@ describe("InboundDebouncer", () => {
     const p2 = debouncer.submit("key1", "b", "m2", 1050);
     debouncer.cancel("key1");
 
-    // Primary gets an empty result, secondary gets null
+    // Both primary and secondary get null
     const r1 = await p1;
     const r2 = await p2;
-    expect(r1!.text).toBe("");
+    expect(r1).toBeNull();
     expect(r2).toBeNull();
     expect(debouncer.pendingCount).toBe(0);
   });
 
-  it("dispose cancels all pending", async () => {
+  it("dispose cancels all pending and resolves with null", async () => {
     vi.useFakeTimers();
     const debouncer = new InboundDebouncer({ windowMs: 100 });
 
-    debouncer.submit("key1", "a", "m1", 1000);
-    debouncer.submit("key2", "b", "m2", 1000);
+    const p1 = debouncer.submit("key1", "a", "m1", 1000);
+    const p2 = debouncer.submit("key2", "b", "m2", 1000);
     expect(debouncer.pendingCount).toBe(2);
 
     debouncer.dispose();
     expect(debouncer.pendingCount).toBe(0);
+
+    // All primary callers get null
+    const r1 = await p1;
+    const r2 = await p2;
+    expect(r1).toBeNull();
+    expect(r2).toBeNull();
   });
 
   it("tracks timestamps from first and last message", async () => {

--- a/src/core/debounce.ts
+++ b/src/core/debounce.ts
@@ -35,7 +35,7 @@ interface PendingBuffer {
   metadata: Record<string, unknown>;
   timer: ReturnType<typeof setTimeout>;
   /** Resolve for the primary (first) caller */
-  primaryResolve: (result: DebouncedMessage) => void;
+  primaryResolve: (result: DebouncedMessage | null) => void;
   /** Resolves for secondary callers — they get null */
   secondaryResolves: Array<(result: null) => void>;
 }
@@ -93,7 +93,7 @@ export class InboundDebouncer {
     }
 
     // Primary caller — create new buffer
-    return new Promise<DebouncedMessage>((resolve) => {
+    return new Promise<DebouncedMessage | null>((resolve) => {
       const buffer: PendingBuffer = {
         texts: [text],
         messageIds: [messageId],
@@ -114,7 +114,7 @@ export class InboundDebouncer {
     if (!buffer) return;
     clearTimeout(buffer.timer);
     // Resolve all waiters with null to unblock them
-    buffer.primaryResolve({ text: "", messageIds: [], firstTimestamp: 0, lastTimestamp: 0, metadata: {} });
+    buffer.primaryResolve(null);
     for (const resolve of buffer.secondaryResolves) {
       resolve(null);
     }


### PR DESCRIPTION
Fixes #287

## Problem
`InboundDebouncer.cancel()` resolved primary caller with an empty `DebouncedMessage` object instead of `null`, causing callers to process empty messages as if they were valid.

## Fix
- Changed `primaryResolve` type from `(result: DebouncedMessage) => void` to `(result: DebouncedMessage | null) => void`
- Updated `cancel()` to resolve with `null` instead of empty object
- Changed primary caller Promise type from `Promise<DebouncedMessage>` to `Promise<DebouncedMessage | null>`

## Testing
- Updated test `"cancel resolves all waiters with null"` to verify both primary and secondary get `null`
- Updated test `"dispose cancels all pending and resolves with null"` to verify all primary callers get `null` after dispose
- All 1980 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)