### PR TITLE
fix(cli): isolate ProcessRegistry per agent (#289)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -791,15 +791,19 @@ async function main() {
   const agentMessageBus = new AgentMessageBus(acpSessionManager);
   const startedAt = new Date();
   const modelOverrides = new Map<string, string>();
-  const processRegistry = new ProcessRegistry();
 
   // Create agents with workspace tools
   const agentWorkspaces = new Map<string, string>();
   const transportContexts = new Map<string, LazyTransportContext>();
+  const processRegistries = new Map<string, ProcessRegistry>();
   const isSingleAgent = config.agents.length === 1;
 
   for (const agentFile of config.agents) {
     const agentConfig = toAgentConfig(agentFile, config.agentDefaults, config.provider, config.tools, config.compaction, config.sandbox);
+
+    // Create per-agent ProcessRegistry for CLI tool isolation (#289)
+    const processRegistry = new ProcessRegistry();
+    processRegistries.set(agentConfig.id, processRegistry);
 
     // Workspace layout:
     //   Explicit config:  agent.workspace (absolute or relative to ISOTOPES_HOME)
@@ -1183,8 +1187,10 @@ async function main() {
       }
     }
 
-    // Kill orphaned background processes (#286)
-    processRegistry.clear();
+    // Kill orphaned background processes (#286, #289)
+    for (const registry of processRegistries.values()) {
+      registry.clear();
+    }
 
     process.exit(0);
   });
@@ -1205,8 +1211,10 @@ async function main() {
       }
     }
 
-    // Kill orphaned background processes (#286)
-    processRegistry.clear();
+    // Kill orphaned background processes (#286, #289)
+    for (const registry of processRegistries.values()) {
+      registry.clear();
+    }
 
     process.exit(0);
   });

--- a/src/tools/exec.test.ts
+++ b/src/tools/exec.test.ts
@@ -363,4 +363,76 @@ describe("createExecTools", () => {
     );
     expect(killResult.success).toBe(true);
   });
+
+  it("isolates processes between separate registries", async () => {
+    // Simulate two agents with separate registries
+    const registry1 = new ProcessRegistry();
+    const registry2 = new ProcessRegistry();
+
+    const tools1 = createExecTools({ registry: registry1 });
+    const tools2 = createExecTools({ registry: registry2 });
+
+    const exec1 = tools1.find((t) => t.tool.name === "exec")!.handler;
+    const list1 = tools1.find((t) => t.tool.name === "process_list")!.handler;
+
+    const exec2 = tools2.find((t) => t.tool.name === "exec")!.handler;
+    const list2 = tools2.find((t) => t.tool.name === "process_list")!.handler;
+
+    // Agent 1 starts a process
+    const result1 = JSON.parse(
+      await exec1({ command: "sleep 60", background: true }),
+    );
+
+    // Agent 2 starts a process
+    const result2 = JSON.parse(
+      await exec2({ command: "sleep 60", background: true }),
+    );
+
+    // Each agent should only see their own process
+    const list1Result = JSON.parse(await list1({}));
+    const list2Result = JSON.parse(await list2({}));
+
+    expect(list1Result.processes).toHaveLength(1);
+    expect(list1Result.processes[0].process_id).toBe(result1.process_id);
+
+    expect(list2Result.processes).toHaveLength(1);
+    expect(list2Result.processes[0].process_id).toBe(result2.process_id);
+
+    // Cleanup
+    registry1.clear();
+    registry2.clear();
+  });
+
+  it("prevents one registry from killing another registry's processes", async () => {
+    const registry1 = new ProcessRegistry();
+    const registry2 = new ProcessRegistry();
+
+    const tools1 = createExecTools({ registry: registry1 });
+    const tools2 = createExecTools({ registry: registry2 });
+
+    const exec1 = tools1.find((t) => t.tool.name === "exec")!.handler;
+    const kill2 = tools2.find((t) => t.tool.name === "process_kill")!.handler;
+
+    // Agent 1 starts a process
+    const result1 = JSON.parse(
+      await exec1({ command: "sleep 60", background: true }),
+    );
+
+    // Agent 2 tries to kill Agent 1's process
+    const killResult = JSON.parse(
+      await kill2({ process_id: result1.process_id }),
+    );
+
+    // Should fail because the process doesn't exist in registry2
+    expect(killResult.error).toContain("Process not found");
+
+    // Verify Agent 1's process is still alive
+    const info = registry1.get(result1.process_id);
+    expect(info).toBeDefined();
+    expect(info!.status).toBe("running");
+
+    // Cleanup
+    registry1.clear();
+    registry2.clear();
+  });
 });


### PR DESCRIPTION
Fixes #289

**Problem:** Single ProcessRegistry shared across all agents, allowing any agent to see/kill other agents' processes.

**Fix:**
- Create ProcessRegistry per agent inside the agent loop
- Track all registries in a Map for shutdown cleanup
- Each agent now has isolated process list and kill operations

**Tests:** Added 2 test cases verifying registry isolation (independent process lists, cross-registry kill fails)