### PR TITLE
fix(cli): use correct workspace in chat command (#318)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -375,7 +375,9 @@ async function handleChatCommand(): Promise<void> {
     const resolved = resolveExplicitWorkspacePath(agentFile.workspace);
     workspacePath = await ensureExplicitWorkspaceDir(resolved);
   } else {
-    workspacePath = await ensureWorkspaceDir(agentFile.id);
+    const isSingleAgent = config.agents.length === 1;
+    const workspaceKey = isSingleAgent ? "default" : agentFile.id;
+    workspacePath = await ensureWorkspaceDir(workspaceKey);
   }
 
   await ensureWorkspaceStructure(workspacePath);


### PR DESCRIPTION
Fixes #318

## Problem
`isotopes chat` always used `agentFile.id` as workspace key, but daemon uses `"default"` for single-agent configs.

## Fix
Apply same single-agent logic: `const workspaceKey = isSingleAgent ? "default" : agentFile.id`

One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)