### PR TITLE
fix(discord): move subagent thread interception before shouldRespond (#335)

### DIFF
--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -320,7 +320,21 @@ export class DiscordTransport implements Transport {
       return;
     }
 
-    // 3. Should-respond check — record to channel history if not responding
+    // 3. Extract content early for subagent thread interception
+    let content = this.extractContent(msg);
+    if (!content.trim()) return;
+
+    // 3.5. Subagent thread interception — handle /stop in subagent threads BEFORE shouldRespond check
+    // This allows /stop to work without @mention in subagent threads
+    if (isThread) {
+      const task = taskRegistry.getByThreadId(msg.channelId);
+      if (task) {
+        await this.handleSubagentThreadMessage(msg, task, content);
+        return;
+      }
+    }
+
+    // 4. Should-respond check — record to channel history if not responding
     const respond = this.shouldRespond(msg);
 
     // Thread-specific control: if threads.respond=false, don't respond in threads
@@ -362,20 +376,7 @@ export class DiscordTransport implements Transport {
 
     log.debug(`Received message from ${msg.author.username}: ${msg.content.substring(0, 50)}...`);
 
-    // 4. Extract content
-    let content = this.extractContent(msg);
-    if (!content.trim()) return;
-
-    // 4.3. Subagent thread interception — handle /stop in subagent threads
-    if (isThread) {
-      const task = taskRegistry.getByThreadId(msg.channelId);
-      if (task) {
-        await this.handleSubagentThreadMessage(msg, task, content);
-        return;
-      }
-    }
-
-    // 4.5. Slash command interception — handle admin commands before agent dispatch
+    // 5. Slash command interception — handle admin commands before agent dispatch
     if (this.commandHandler.isCommand(content)) {
       const agentId = this.resolveAgentId(msg);
       const sessionStore = this.getSessionStore(agentId);


### PR DESCRIPTION
Moves subagent thread interception (including `/stop` and `/cancel` handling) before the `shouldRespond()` check in `discord.ts`. Previously, `/stop` sent in subagent threads without @mentioning the bot was silently dropped because `shouldRespond()` returned false first.

**Changes:**
- Move `extractContent()` earlier (before shouldRespond)
- Move subagent thread interception to section 3.5 (before shouldRespond at section 4)
- Remove old section 4.3 (moved up)
- Renumber sections for clarity

**Fixes #335**