### PR TITLE
fix(discord): allow /stop in subagent threads without @mention (#335)

### DIFF
--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -320,7 +320,21 @@ export class DiscordTransport implements Transport {
       return;
     }
 
-    // 3. Should-respond check — record to channel history if not responding
+    // 3. Extract content early for subagent thread interception
+    let content = this.extractContent(msg);
+    if (!content.trim()) return;
+
+    // 3.5. Subagent thread interception — handle /stop in subagent threads BEFORE shouldRespond check
+    // This allows /stop to work without @mention in subagent threads
+    if (isThread) {
+      const task = taskRegistry.getByThreadId(msg.channelId);
+      if (task) {
+        await this.handleSubagentThreadMessage(msg, task, content);
+        return;
+      }
+    }
+
+    // 4. Should-respond check — record to channel history if not responding
     const respond = this.shouldRespond(msg);
 
     // Thread-specific control: if threads.respond=false, don't respond in threads
@@ -362,20 +376,7 @@ export class DiscordTransport implements Transport {
 
     log.debug(`Received message from ${msg.author.username}: ${msg.content.substring(0, 50)}...`);
 
-    // 4. Extract content
-    let content = this.extractContent(msg);
-    if (!content.trim()) return;
-
-    // 4.3. Subagent thread interception — handle /stop in subagent threads
-    if (isThread) {
-      const task = taskRegistry.getByThreadId(msg.channelId);
-      if (task) {
-        await this.handleSubagentThreadMessage(msg, task, content);
-        return;
-      }
-    }
-
-    // 4.5. Slash command interception — handle admin commands before agent dispatch
+    // 5. Slash command interception — handle admin commands before agent dispatch
     if (this.commandHandler.isCommand(content)) {
       const agentId = this.resolveAgentId(msg);
       const sessionStore = this.getSessionStore(agentId);


### PR DESCRIPTION
## Summary
- Fixes #335: `/stop` command in subagent threads is now processed even without @mention
- Moved subagent thread interception to occur before `shouldRespond` check
- Extracted content earlier in message processing flow to enable early thread detection

## Root Cause
Previously, the message processing order was:
1. `shouldRespond(msg)` check (line ~324)
2. Early return if not responding (line ~342)  
3. Subagent thread `/stop` handler (line ~370)

If a user didn't @mention the bot, messages were dropped before reaching the `/stop` handler.

## Fix
Reordered the flow to:
1. Extract content early
2. Check for subagent thread and handle `/stop` **before** `shouldRespond`
3. Run normal `shouldRespond` logic for other messages

## Test Plan
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (all 1982 tests)
- [x] Verified message processing order in code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)