### PR TITLE
fix(subagent): success depends only on exit code, not error events (#341)

### DIFF
--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -272,7 +272,7 @@ async function collectResultFromEvents(events: AcpxEvent[]): Promise<AcpxResult>
   }
 
   return {
-    success: lastExitCode === 0 && !errors,
+    success: lastExitCode === 0,
     output: messages || undefined,
     error: errors || undefined,
     events,


### PR DESCRIPTION
## Summary
Fixes #341 - subagent incorrectly reports failure when exit code is 0 but error events exist.

## Changes
Changed `collectResultFromEvents()` in `src/tools/subagent.ts` line 275 from:
```typescript
success: lastExitCode === 0 && !errors,
```
to:
```typescript
success: lastExitCode === 0,
```

## Rationale
Error events (like acpx's "Error handling notification" warnings) are informational/diagnostic and shouldn't affect success determination when the exit code is 0. The error messages are still captured in `result.error` for debugging purposes.

## Test plan
- [x] All existing tests pass (`pnpm test`)
- [x] One-line change with clear semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)