### PR TITLE
fix(discord): inject pending messages after long tool calls #333

### DIFF
--- a/src/core/agent-runner.test.ts
+++ b/src/core/agent-runner.test.ts
@@ -134,4 +134,68 @@ describe("runAgentLoop", () => {
 
     expect(deltas).toEqual(["a", "ab"]);
   });
+
+  it("calls onToolComplete after turn_end and injects via steer", async () => {
+    const agent = createMockAgentInstance([
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    const sessionStore = createMockSessionStore();
+    const onToolComplete = vi.fn().mockResolvedValue("[Messages arrived]\nuser1: hello");
+
+    await runAgentLoop({
+      agent,
+      input: "hi",
+      sessionId: "s1",
+      sessionStore,
+      log: createMockLogger(),
+      onToolComplete,
+    });
+
+    expect(onToolComplete).toHaveBeenCalledTimes(1);
+    expect(agent.steer).toHaveBeenCalledWith({
+      role: "user",
+      content: textContent("[Messages arrived]\nuser1: hello"),
+    });
+  });
+
+  it("does not call steer if onToolComplete returns null", async () => {
+    const agent = createMockAgentInstance([
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    const sessionStore = createMockSessionStore();
+    const onToolComplete = vi.fn().mockResolvedValue(null);
+
+    await runAgentLoop({
+      agent,
+      input: "hi",
+      sessionId: "s1",
+      sessionStore,
+      log: createMockLogger(),
+      onToolComplete,
+    });
+
+    expect(onToolComplete).toHaveBeenCalledTimes(1);
+    expect(agent.steer).not.toHaveBeenCalled();
+  });
+
+  it("does not call onToolComplete if not provided", async () => {
+    const agent = createMockAgentInstance([
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    const sessionStore = createMockSessionStore();
+
+    await runAgentLoop({
+      agent,
+      input: "hi",
+      sessionId: "s1",
+      sessionStore,
+      log: createMockLogger(),
+    });
+
+    // Should not crash, just skip the callback
+    expect(agent.steer).not.toHaveBeenCalled();
+  });
 });

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -31,6 +31,8 @@ export interface RunAgentOptions {
   onTextDelta?: OnTextDelta;
   /** Optional usage tracker for per-session/global accumulation */
   usageTracker?: UsageTracker;
+  /** Called after turn_end events to check for pending messages */
+  onToolComplete?: () => Promise<string | null>;
 }
 
 /**
@@ -47,7 +49,7 @@ export interface RunAgentOptions {
  * stay in the transport layer via the onTextDelta callback.
  */
 export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResult> {
-  const { agent, input, sessionId, sessionStore, log, onTextDelta, usageTracker } = opts;
+  const { agent, input, sessionId, sessionStore, log, onTextDelta, usageTracker, onToolComplete } = opts;
 
   let responseText = "";
   let errorMessage: string | null = null;
@@ -61,6 +63,15 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
     } else if (event.type === "turn_end") {
       if (usageTracker && event.usage) {
         usageTracker.record(sessionId, event.usage);
+      }
+
+      // Check for pending messages after tool calls complete
+      if (onToolComplete) {
+        const pendingContext = await onToolComplete();
+        if (pendingContext) {
+          log.debug(`Injecting pending messages via steer()`);
+          agent.steer({ role: "user", content: textContent(pendingContext) });
+        }
       }
     } else if (event.type === "agent_end") {
       // Store final assistant message

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -1123,4 +1123,112 @@ describe("DiscordTransport", () => {
       expect(localSessionStore.addMessage).not.toHaveBeenCalled();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Frozen context (pending message buffering during long tool calls)
+  // ---------------------------------------------------------------------------
+
+  describe("frozen context — pending message buffering", () => {
+    function makeChannel(): MockChannel {
+      return {
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(false),
+      };
+    }
+
+    function makeMsg(overrides: Partial<MockIncomingMessage> = {}): MockIncomingMessage {
+      return {
+        author: { bot: false, username: "tester", id: "user-1" },
+        content: "<@bot-123> hello",
+        createdTimestamp: Date.now(),
+        guild: { id: "guild-1" },
+        channelId: "channel-1",
+        channel: makeChannel(),
+        mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        thread: undefined,
+        id: `msg-${Date.now()}`,
+        ...overrides,
+      };
+    }
+
+    it("buffers messages when session is active (in-flight prompt)", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+
+      // Create a promise that we can control to simulate a long-running agent
+      let resolvePrompt: () => void;
+      const promptWait = new Promise<void>((resolve) => { resolvePrompt = resolve; });
+
+      // Agent that waits for our signal before completing
+      const hangingAgent = {
+        prompt: vi.fn(async function* () {
+          yield { type: "text_delta" as const, text: "Working..." };
+          await promptWait; // Wait here until we signal
+          yield { type: "agent_end" as const, messages: [] };
+        }),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+      };
+      localAgentManager.get = vi.fn().mockReturnValue(hangingAgent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+
+      await localTransport.start();
+
+      // First message — starts the agent prompt (makes session active)
+      const msg1 = makeMsg({ content: "<@bot-123> start work", id: "msg-1" });
+      const handleMessagePromise = (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg1);
+
+      // Wait for prompt to be initiated (give it time to mark session as active)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Second message — should be buffered since session is active
+      const msg2 = makeMsg({ content: "<@bot-123> are you done yet?", id: "msg-2" });
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg2);
+
+      // Agent should only be called once (second message was buffered)
+      expect(hangingAgent.prompt).toHaveBeenCalledTimes(1);
+
+      // Now signal the agent to complete
+      resolvePrompt!();
+      await handleMessagePromise;
+    });
+
+    it("clears active session and pending buffer after agent completes", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+
+      // Agent that completes normally
+      const completingAgent = createMockAgentInstance([
+        { type: "text_delta", text: "Done!" },
+        { type: "agent_end", messages: [] },
+      ]);
+      localAgentManager.get = vi.fn().mockReturnValue(completingAgent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+
+      await localTransport.start();
+
+      const msg = makeMsg({ content: "<@bot-123> hello", id: "msg-1" });
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      // After completion, sending another message should trigger a new prompt (not buffered)
+      const msg2 = makeMsg({ content: "<@bot-123> hello again", id: "msg-2" });
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg2);
+
+      expect(completingAgent.prompt).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -207,6 +207,11 @@ export class DiscordTransport implements Transport {
   private debouncer: InboundDebouncer;
   private commandHandler: SlashCommandHandler;
 
+  // Track which sessions are currently in a prompt turn
+  private activeSessions = new Set<string>();
+  // Buffer messages that arrive while a session is prompting
+  private pendingMessages = new Map<string, Array<{ content: string; sender: string; timestamp: number }>>();
+
   constructor(config: DiscordTransportConfig) {
     this.config = config;
     this.threadBindingManager = config.threadBindingManager ?? new ThreadBindingManager();
@@ -422,6 +427,29 @@ export class DiscordTransport implements Transport {
     const sessionStore = this.getSessionStore(agentId);
     const sessionKey = this.getSessionKey(msg, agentId);
     const session = await this.findOrCreateSession(sessionStore, sessionKey, agentId, msg);
+
+    // 6.5. If session is currently active (in a prompt turn), buffer this message instead
+    if (this.activeSessions.has(session.id)) {
+      log.debug(`Session ${session.id} is active, buffering message from ${msg.author.username}`);
+      const pending = this.pendingMessages.get(session.id) ?? [];
+      pending.push({
+        content,
+        sender: msg.author.username,
+        timestamp: msg.createdTimestamp,
+      });
+      this.pendingMessages.set(session.id, pending);
+
+      // Still record to channel history for context
+      if (this.config.context?.channelHistory !== false && msg.guild) {
+        this.channelHistory.append(msg.channelId, {
+          sender: msg.author.username,
+          body: content,
+          timestamp: msg.createdTimestamp,
+          messageId: msg.id,
+        });
+      }
+      return;
+    }
 
     // 7. Consume channel history and build enriched content
     const historyEntries = (this.config.context?.channelHistory !== false && msg.guild)
@@ -670,6 +698,9 @@ export class DiscordTransport implements Transport {
     // Start typing indicator
     const typing = this.startTyping(channel);
 
+    // Mark session as active
+    this.activeSessions.add(sessionId);
+
     try {
       // Track what we've already sent via the segmented buffer
       let lastSentLength = 0;
@@ -701,6 +732,14 @@ export class DiscordTransport implements Transport {
             }
           },
           usageTracker: this.config.usageTracker,
+          onToolComplete: async () => {
+            const pending = this.pendingMessages.get(sessionId);
+            if (!pending?.length) return null;
+
+            const messages = pending.splice(0); // drain buffer
+            const formatted = messages.map(m => `${m.sender}: ${m.content}`).join("\n");
+            return `[Messages arrived while you were working]\n${formatted}`;
+          },
         });
       };
 
@@ -753,6 +792,10 @@ export class DiscordTransport implements Transport {
       }
     } finally {
       typing.stop();
+      // Mark session as no longer active
+      this.activeSessions.delete(sessionId);
+      // Clean up any remaining pending messages (shouldn't happen, but safety)
+      this.pendingMessages.delete(sessionId);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #333 — frozen context during long tool calls.

## Problem

When an agent is executing a long tool call (e.g., `spawn_subagent` ~300s), new Discord messages arrive but the LLM has already started its turn. Messages queue up in channel history but are never visible to the LLM until the next turn starts.

## Solution

**Step 1: Per-session turn state + pending message buffer**

Added to `discord.ts`:
- `activeSessions` Set — tracks which sessions are currently in a prompt turn
- `pendingMessages` Map — buffers messages that arrive while session is prompting
- When a session is active, new messages are buffered instead of triggering a new prompt
- Messages still recorded to channel history for context

**Step 2: Inject pending messages via steer()**

Added `onToolComplete` callback to `runAgentLoop()`:
- Called after each `turn_end` event (when tool calls complete)
- Checks the pending message buffer
- If messages are pending, drains the buffer and injects via `agent.steer()`
- Format: `[Messages arrived while you were working]\nuser1: message1\nuser2: message2`

**Cleanup:**
- `activeSessions` cleared in finally block
- `pendingMessages` cleaned up after session completes

## Tests Added

- `runAgentLoop` with mock `onToolComplete` returning messages (verifies steer injection)
- `runAgentLoop` with `onToolComplete` returning null (no steer call)
- `runAgentLoop` without `onToolComplete` (backward compatible)
- Discord buffering test (messages buffered when session active)
- Discord cleanup test (session no longer active after completion)

## Files Changed

- `src/transports/discord.ts` — turn tracking and pending buffer
- `src/core/agent-runner.ts` — `onToolComplete` callback
- `src/transports/discord.test.ts` — buffering tests
- `src/core/agent-runner.test.ts` — callback tests

All 1996 tests pass ✅