### PR TITLE
fix(core): filter empty assistant messages to prevent 400 errors

### DIFF
--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -866,6 +866,107 @@ describe("stripOrphanedToolResults", () => {
 
     expect(result).toHaveLength(2);
   });
+
+  it("strips aborted assistant messages with empty content", () => {
+    const messages = [
+      { role: "user", content: "do something", timestamp: 1000 },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "aborted",
+        timestamp: 2000,
+      },
+      { role: "user", content: "try again", timestamp: 3000 },
+    ] as unknown[];
+
+    const result = stripOrphanedToolResults(messages as import("@mariozechner/pi-agent-core").AgentMessage[]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.role)).toEqual(["user", "user"]);
+  });
+
+  it("strips error assistant messages with empty content", () => {
+    const messages = [
+      { role: "user", content: "search for X", timestamp: 1000 },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        timestamp: 2000,
+      },
+      { role: "user", content: "try again", timestamp: 3000 },
+    ] as unknown[];
+
+    const result = stripOrphanedToolResults(messages as import("@mariozechner/pi-agent-core").AgentMessage[]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.role)).toEqual(["user", "user"]);
+  });
+
+  it("keeps normal assistant messages with content", () => {
+    const messages = [
+      { role: "user", content: "hello", timestamp: 1000 },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "hi there" }],
+        stopReason: "end_turn",
+        timestamp: 2000,
+      },
+    ] as unknown[];
+
+    const result = stripOrphanedToolResults(messages as import("@mariozechner/pi-agent-core").AgentMessage[]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("keeps aborted assistant messages that have content", () => {
+    const messages = [
+      { role: "user", content: "tell me a story", timestamp: 1000 },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Once upon a time..." }],
+        stopReason: "aborted",
+        timestamp: 2000,
+      },
+    ] as unknown[];
+
+    const result = stripOrphanedToolResults(messages as import("@mariozechner/pi-agent-core").AgentMessage[]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("handles both empty assistant and orphaned toolResult together", () => {
+    const messages = [
+      { role: "user", content: "first request", timestamp: 1000 },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "toolu_123", name: "shell" }],
+        stopReason: "error",
+        timestamp: 2000,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_123",
+        content: "output",
+        timestamp: 3000,
+      },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "aborted",
+        timestamp: 4000,
+      },
+      { role: "user", content: "retry", timestamp: 5000 },
+    ] as unknown[];
+
+    const result = stripOrphanedToolResults(messages as import("@mariozechner/pi-agent-core").AgentMessage[]);
+
+    // Should strip both the orphaned toolResult AND the empty aborted assistant
+    expect(result).toHaveLength(3);
+    expect(result.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+  });
 });
 
 describe("transformContext hook (#146)", () => {

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -235,18 +235,22 @@ function getAgentEndMetadata(messages: Message[]): {
 }
 
 // ---------------------------------------------------------------------------
-// Orphaned toolResult stripping (#146)
+// Message sanitization (#146)
 // ---------------------------------------------------------------------------
 
 /**
- * Strip `toolResult` messages whose corresponding assistant `toolCall` is
- * missing from the context.  This happens when the SDK's `transformMessages`
- * drops errored/aborted assistant messages but keeps their tool results,
- * which the Anthropic API then rejects as orphaned `tool_result` blocks.
+ * Sanitize messages to prevent 400 errors from the Claude API:
+ * 1. Strip aborted/errored assistant messages with empty content
+ * 2. Strip `toolResult` messages whose corresponding assistant `toolCall` is
+ *    missing from the context
+ *
+ * This happens when the SDK's `transformMessages` drops errored/aborted
+ * assistant messages but keeps their tool results, which the Anthropic API
+ * then rejects as orphaned `tool_result` blocks.
  *
  * Operates on `AgentMessage[]` (pi-agent-core format).
  */
-export function stripOrphanedToolResults(messages: AgentMessage[]): AgentMessage[] {
+export function sanitizeMessages(messages: AgentMessage[]): AgentMessage[] {
   // Collect all toolCall IDs present in non-errored/non-aborted assistants
   const validToolCallIds = new Set<string>();
   for (const msg of messages) {
@@ -262,16 +266,34 @@ export function stripOrphanedToolResults(messages: AgentMessage[]): AgentMessage
   }
 
   return messages.filter((msg) => {
-    if (msg.role !== "toolResult") return true;
-    const m = msg as { role: string; toolCallId?: string };
-    // Keep if toolCallId matches a valid (non-errored) assistant toolCall
-    if (m.toolCallId && !validToolCallIds.has(m.toolCallId)) {
-      log.debug(`Stripping orphaned toolResult (toolCallId: ${m.toolCallId})`);
-      return false;
+    // Filter out aborted/errored assistant messages with empty content
+    if (msg.role === "assistant") {
+      const m = msg as { role: string; stopReason?: string; content?: unknown };
+      if ((m.stopReason === "error" || m.stopReason === "aborted") &&
+          (Array.isArray(m.content) && m.content.length === 0)) {
+        log.debug(`Stripping empty assistant message (stopReason: ${m.stopReason})`);
+        return false;
+      }
     }
+
+    // Filter out orphaned toolResults
+    if (msg.role === "toolResult") {
+      const m = msg as { role: string; toolCallId?: string };
+      // Keep if toolCallId matches a valid (non-errored) assistant toolCall
+      if (m.toolCallId && !validToolCallIds.has(m.toolCallId)) {
+        log.debug(`Stripping orphaned toolResult (toolCallId: ${m.toolCallId})`);
+        return false;
+      }
+    }
+
     return true;
   });
 }
+
+/**
+ * @deprecated Use sanitizeMessages instead
+ */
+export const stripOrphanedToolResults = sanitizeMessages;
 
 // ---------------------------------------------------------------------------
 // Tool conversion
@@ -373,9 +395,10 @@ export class PiMonoCore implements AgentCore {
     }
 
     const transformContext = async (messages: AgentMessage[], signal?: AbortSignal): Promise<AgentMessage[]> => {
-      // Strip orphaned toolResult messages whose assistant (with the
-      // matching toolCall) was dropped by the SDK due to error/abort (#146).
-      const sanitized = stripOrphanedToolResults(messages);
+      // Sanitize messages: strip empty aborted/errored assistant messages and
+      // orphaned toolResult messages whose assistant (with the matching toolCall)
+      // was dropped by the SDK due to error/abort (#146).
+      const sanitized = sanitizeMessages(messages);
       // Then apply compaction if configured
       if (compactionTransform) {
         return compactionTransform(sanitized, signal);


### PR DESCRIPTION
## Summary
- Fixes 400 errors from Claude API caused by empty assistant messages with `stopReason: "error"` or `"aborted"`
- Renamed `stripOrphanedToolResults` to `sanitizeMessages` to reflect expanded scope
- Kept backward-compatible export alias

## Root Cause
In `src/core/pi-mono.ts`, the `stripOrphanedToolResults` function:
1. Collected valid toolCallIds, correctly skipping aborted assistants ✓
2. Filtered orphaned toolResults ✓
3. BUT did NOT filter out the aborted assistant messages themselves ✗

Result: `{"role":"assistant","content":[]}` was sent to Claude API → 400 error

## Changes
**Modified `src/core/pi-mono.ts`:**
- Renamed `stripOrphanedToolResults` → `sanitizeMessages`
- Added filtering for assistant messages where:
  - `stopReason === "error"` OR `stopReason === "aborted"` 
  - AND `content` is empty array `[]`
- Preserved backward compatibility via deprecated export alias
- Updated call site and comments

**Added tests in `src/core/pi-mono.test.ts`:**
- ✅ Aborted assistant messages with empty content are filtered
- ✅ Error assistant messages with empty content are filtered
- ✅ Normal assistant messages are kept
- ✅ Aborted assistant messages WITH content are kept
- ✅ Orphaned toolResults are still filtered (existing behavior)
- ✅ Both issues can be handled in same message stream

## Test plan
- [x] All existing tests pass: `pnpm test src/core/pi-mono.test.ts`
- [x] New tests cover all edge cases
- [x] Type check passes: `pnpm typecheck`
- [x] Lint passes: `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)