### PR TITLE
feat(skills): add github and coding-agent built-in skills

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: coding-agent
+description: "Delegate coding tasks to sub-agents via spawn_subagent. Use when: (1) building/creating new features, (2) refactoring code, (3) fixing bugs that need multi-file changes, (4) reviewing PRs. Default agent: claude. NOT for: simple one-liner fixes (just exec), reading code (use read_file), or tasks that only need shell commands."
+---
+
+# Coding Agent
+
+Delegate coding tasks to sub-agents via `spawn_subagent`. Always use **claude** as the default agent unless it fails — then fall back to codex or gemini.
+
+## Agent Priority
+
+1. **claude** — Default. Always try first.
+2. **codex** — Fallback if claude fails or hangs.
+3. **gemini** — Secondary fallback.
+
+## When to Use
+
+✅ **USE this skill when:**
+
+- Building or creating new features
+- Refactoring large codebases
+- Fixing bugs that span multiple files
+- Implementing specs or designs
+- Reviewing PRs (spawn agent to analyze diff)
+- Writing tests
+
+## When NOT to Use
+
+❌ **DON'T use this skill when:**
+
+- Simple one-liner fixes → just use `exec` with sed/patch
+- Reading/exploring code → use `read_file` or `exec cat`
+- Running tests or builds → use `exec` directly
+- Git operations → use `exec` with git commands
+
+## The Pattern
+
+### One-Shot Task
+
+```
+spawn_subagent(
+  agent: "claude",
+  task: "In /Users/steins.ghost/_repos/isotopes, do X. Details: ...",
+  working_directory: "/Users/steins.ghost/_repos/isotopes"
+)
+```
+
+### Key Rules
+
+1. **Always specify working_directory** — agent wakes up focused on the right project
+2. **Be specific in the task** — include file paths, function names, expected behavior
+3. **Include constraints** — "don't modify tests", "keep backward compatible", etc.
+4. **One concern per spawn** — don't ask one agent to do 5 unrelated things
+
+### Task Template
+
+```
+Task: [what to do]
+Working directory: [path]
+Files to modify: [list specific files if known]
+Context: [why we're doing this]
+Constraints:
+- [constraint 1]
+- [constraint 2]
+Validation: Run `npm run build` and `npm test` after changes.
+```
+
+## PR Review Pattern
+
+```
+spawn_subagent(
+  agent: "claude",
+  task: "Review PR #XX in /Users/steins.ghost/_repos/isotopes.
+    Run: git diff main...feat/branch-name
+    Check for: bugs, missing error handling, test coverage, style issues.
+    Summarize findings.",
+  working_directory: "/Users/steins.ghost/_repos/isotopes"
+)
+```
+
+## Parallel Work with Git Worktrees
+
+For fixing multiple issues in parallel:
+
+```bash
+# 1. Create worktrees
+git worktree add -b fix/issue-78 /tmp/issue-78 main
+git worktree add -b fix/issue-99 /tmp/issue-99 main
+
+# 2. Spawn agents in each
+spawn_subagent(agent: "claude", task: "Fix issue #78...", working_directory: "/tmp/issue-78")
+spawn_subagent(agent: "claude", task: "Fix issue #99...", working_directory: "/tmp/issue-99")
+
+# 3. Create PRs after fixes
+cd /tmp/issue-78 && git push -u origin fix/issue-78
+gh pr create --title "fix: ..." --body "..."
+
+# 4. Cleanup
+git worktree remove /tmp/issue-78
+```
+
+## Progress Updates
+
+When spawning coding agents:
+- Send 1 short message when you start (what's running + where)
+- Update when something changes: milestone completes, error hit, agent finishes
+- If agent fails, say what failed and why immediately
+
+## ⚠️ Rules
+
+1. **Always spawn claude first** — only switch agent if claude fails
+2. **Never hand-code patches yourself** — you're an orchestrator, delegate to agents
+3. **Be patient** — don't kill agents because they're "slow"
+4. **Never spawn agents in your own workspace** (`~/.isotopes/workspace-dev`) for code changes — always in the source repo
+5. **Run tests after changes** — `npm run build && npm test` in the repo
+6. **One concern per agent spawn** — keep tasks focused

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -84,19 +84,19 @@ For fixing multiple issues in parallel:
 
 ```bash
 # 1. Create worktrees
-git worktree add -b fix/issue-78 /tmp/issue-78 main
-git worktree add -b fix/issue-99 /tmp/issue-99 main
+git worktree add -b fix/issue-78 _repos/worktrees/issue-78 main
+git worktree add -b fix/issue-99 _repos/worktrees/issue-99 main
 
 # 2. Spawn agents in each
-spawn_subagent(agent: "claude", task: "Fix issue #78...", working_directory: "/tmp/issue-78")
-spawn_subagent(agent: "claude", task: "Fix issue #99...", working_directory: "/tmp/issue-99")
+spawn_subagent(agent: "claude", task: "Fix issue #78...", working_directory: "_repos/worktrees/issue-78")
+spawn_subagent(agent: "claude", task: "Fix issue #99...", working_directory: "_repos/worktrees/issue-99")
 
 # 3. Create PRs after fixes
-cd /tmp/issue-78 && git push -u origin fix/issue-78
+cd _repos/worktrees/issue-78 && git push -u origin fix/issue-78
 gh pr create --title "fix: ..." --body "..."
 
 # 4. Cleanup
-git worktree remove /tmp/issue-78
+git worktree remove _repos/worktrees/issue-78
 ```
 
 ## Progress Updates
@@ -111,6 +111,6 @@ When spawning coding agents:
 1. **Always spawn claude first** — only switch agent if claude fails
 2. **Never hand-code patches yourself** — you're an orchestrator, delegate to agents
 3. **Be patient** — don't kill agents because they're "slow"
-4. **Never spawn agents in your own workspace** (`~/.isotopes/workspace-dev`) for code changes — always in the source repo
+4. **Never spawn agents in your own workspace** (your own workspace directory) for code changes — always in the source repo
 5. **Run tests after changes** — `npm run build && npm test` in the repo
 6. **One concern per agent spawn** — keep tasks focused

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: github
+description: "GitHub operations via `gh` CLI: issues, PRs, CI runs, code review, API queries. Use when: (1) checking PR status or CI, (2) creating/commenting on issues, (3) listing/filtering PRs or issues, (4) viewing run logs. NOT for: complex web UI interactions, bulk operations across many repos, or when gh auth is not configured."
+---
+
+# GitHub Skill
+
+Use the `gh` CLI to interact with GitHub repositories, issues, PRs, and CI.
+
+## When to Use
+
+✅ **USE this skill when:**
+
+- Checking PR status, reviews, or merge readiness
+- Viewing CI/workflow run status and logs
+- Creating, closing, or commenting on issues
+- Creating or merging pull requests
+- Querying GitHub API for repository data
+- Listing repos, releases, or collaborators
+
+## When NOT to Use
+
+❌ **DON'T use this skill when:**
+
+- Local git operations (commit, push, pull, branch) → use `git` directly
+- Non-GitHub repos (GitLab, Bitbucket, self-hosted) → different CLIs
+- Cloning repositories → use `git clone`
+- Reviewing actual code changes → use `coding-agent` skill
+- Complex multi-file diffs → use `coding-agent` or read files directly
+
+## Setup
+
+```bash
+# Authenticate (one-time)
+gh auth login
+
+# Verify
+gh auth status
+```
+
+## Common Commands
+
+### Pull Requests
+
+```bash
+# List PRs
+gh pr list --repo owner/repo
+
+# Check CI status
+gh pr checks 55 --repo owner/repo
+
+# View PR details
+gh pr view 55 --repo owner/repo
+
+# Create PR
+gh pr create --title "feat: add feature" --body "Description"
+
+# Merge PR
+gh pr merge 55 --squash --repo owner/repo
+```
+
+### Issues
+
+```bash
+# List issues
+gh issue list --repo owner/repo --state open
+
+# Create issue
+gh issue create --title "Bug: something broken" --body "Details..."
+
+# Close issue
+gh issue close 42 --repo owner/repo
+```
+
+### CI/Workflow Runs
+
+```bash
+# List recent runs
+gh run list --repo owner/repo --limit 10
+
+# View specific run
+gh run view <run-id> --repo owner/repo
+
+# View failed step logs only
+gh run view <run-id> --repo owner/repo --log-failed
+
+# Re-run failed jobs
+gh run rerun <run-id> --failed --repo owner/repo
+```
+
+### API Queries
+
+```bash
+# Get PR with specific fields
+gh api repos/owner/repo/pulls/55 --jq '.title, .state, .user.login'
+
+# List all labels
+gh api repos/owner/repo/labels --jq '.[].name'
+
+# Get repo stats
+gh api repos/owner/repo --jq '{stars: .stargazers_count, forks: .forks_count}'
+```
+
+## JSON Output
+
+Most commands support `--json` for structured output with `--jq` filtering:
+
+```bash
+gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.title)"'
+gh pr list --json number,title,state,mergeable --jq '.[] | select(.mergeable == "MERGEABLE")'
+```
+
+## Templates
+
+### PR Review Summary
+
+```bash
+# Get PR overview for review
+PR=55 REPO=owner/repo
+echo "## PR #$PR Summary"
+gh pr view $PR --repo $REPO --json title,body,author,additions,deletions,changedFiles \
+  --jq '"**\(.title)** by @\(.author.login)\n\n\(.body)\n\n📊 +\(.additions) -\(.deletions) across \(.changedFiles) files"'
+gh pr checks $PR --repo $REPO
+```
+
+### Issue Triage
+
+```bash
+# Quick issue triage view
+gh issue list --repo owner/repo --state open --json number,title,labels,createdAt \
+  --jq '.[] | "[\(.number)] \(.title) - \([.labels[].name] | join(", ")) (\(.createdAt[:10]))"'
+```
+
+## Notes
+
+- Always specify `--repo owner/repo` when not in a git directory
+- Use URLs directly: `gh pr view https://github.com/owner/repo/pull/55`
+- Rate limits apply; use `gh api --cache 1h` for repeated queries


### PR DESCRIPTION
## Summary
Add two built-in skills referenced from OpenClaw:

### github
- Direct port from OpenClaw's github skill
- Removed `metadata.openclaw` block
- gh CLI reference for issues, PRs, CI, API queries

### coding-agent
- Adapted from OpenClaw's coding-agent skill for Isotopes
- **Always spawn claude first** (not Codex) — fall back to codex/gemini only on failure
- Uses `spawn_subagent` instead of OpenClaw's `bash pty:true` pattern
- Removed OpenClaw-specific references (`openclaw system event`, `$OPENCLAW_STATE_DIR`, etc.)
- Kept useful patterns: worktree parallel work, PR review, progress updates

Closes no issue — skill infrastructure.