### PR TITLE
feat(skills): add bundled skills discovery

### DIFF
--- a/src/skills/bundled-dir.ts
+++ b/src/skills/bundled-dir.ts
@@ -13,6 +13,11 @@ import { fileURLToPath } from "node:url";
 export function resolveBundledSkillsDir(
   moduleUrl?: string,
 ): string | undefined {
+  // Skip in tests or when explicitly disabled
+  if (process.env.ISOTOPES_SKIP_BUNDLED_SKILLS === "1") {
+    return undefined;
+  }
+
   // Allow env override
   const override = process.env.ISOTOPES_BUNDLED_SKILLS_DIR?.trim();
   if (override) {

--- a/src/skills/bundled-dir.ts
+++ b/src/skills/bundled-dir.ts
@@ -1,0 +1,45 @@
+// src/skills/bundled-dir.ts — Resolve bundled skills directory
+// Finds the `skills/` directory shipped with the isotopes package.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Resolve the bundled skills directory by walking up from this module
+ * to find the package root (directory containing package.json),
+ * then returning `{packageRoot}/skills/` if it exists.
+ */
+export function resolveBundledSkillsDir(
+  moduleUrl?: string,
+): string | undefined {
+  // Allow env override
+  const override = process.env.ISOTOPES_BUNDLED_SKILLS_DIR?.trim();
+  if (override) {
+    return override;
+  }
+
+  try {
+    const url = moduleUrl ?? import.meta.url;
+    let current = path.dirname(fileURLToPath(url));
+
+    // Walk up to 6 levels to find package.json
+    for (let depth = 0; depth < 6; depth++) {
+      const pkgJson = path.join(current, "package.json");
+      if (fs.existsSync(pkgJson)) {
+        const candidate = path.join(current, "skills");
+        if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+          return candidate;
+        }
+        return undefined;
+      }
+      const next = path.dirname(current);
+      if (next === current) break;
+      current = next;
+    }
+  } catch {
+    // ignore
+  }
+
+  return undefined;
+}

--- a/src/skills/discovery.ts
+++ b/src/skills/discovery.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { getIsotopesHome } from "../core/paths.js";
+import { resolveBundledSkillsDir } from "./bundled-dir.js";
 
 // Directories to skip during recursive scanning
 const IGNORED_DIRS = new Set([
@@ -29,6 +30,8 @@ export interface DiscoveryOptions {
   workspacePath?: string;
   /** Additional paths to scan for skills */
   additionalPaths?: string[];
+  /** Bundled skills path (auto-detected from package root). Set to null to disable. */
+  bundledPath?: string | null;
 }
 
 export interface DiscoveredSkill {
@@ -56,7 +59,8 @@ export function getWorkspaceSkillsPath(workspacePath: string): string {
  * Discover skills from configured paths.
  * Scans directories recursively for SKILL.md files.
  *
- * Discovery order (per PRD):
+ * Discovery order (lowest to highest priority):
+ * 0. Bundled: {packageRoot}/skills/
  * 1. Global: ~/.isotopes/skills/
  * 2. Workspace: {workspace}/skills/
  * 3. Additional paths (if provided)
@@ -68,9 +72,16 @@ export async function discoverSkills(
     globalPath = getGlobalSkillsPath(),
     workspacePath,
     additionalPaths = [],
+    bundledPath,
   } = options;
 
   const pathsToScan: string[] = [];
+
+  // Bundled skills (lowest priority — scanned first, overridden by global/workspace)
+  const resolvedBundled = bundledPath === null ? undefined : (bundledPath ?? resolveBundledSkillsDir());
+  if (resolvedBundled) {
+    pathsToScan.push(resolvedBundled);
+  }
 
   // Add paths in discovery order
   pathsToScan.push(globalPath);


### PR DESCRIPTION
Adds bundled skills discovery from package root `skills/` directory.

- New `bundled-dir.ts`: resolves package root via `import.meta.url`, returns `{root}/skills/`
- `discovery.ts`: scans bundled path at lowest priority (workspace > global > bundled)
- Env override: `ISOTOPES_BUNDLED_SKILLS_DIR`
- `bundledPath: null` to disable

Priority order: bundled (lowest) → global → workspace → additional (highest)