### PR TITLE
feat(skills): bundled skills discovery from package root

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@
 // Side-effect import: pulls env from ~/.claude/settings.json into process.env
 // before anything else loads (SDK auth, model overrides). Existing env wins,
 // so .env.local and shell exports stay authoritative.
+import { resolveBundledSkillsDir } from "./skills/bundled-dir.js";
 import "./core/claude-settings-init.js";
 import { parseArgs } from "node:util";
 import path from "node:path";
@@ -385,7 +386,7 @@ async function handleChatCommand(): Promise<void> {
   }
 
   await ensureWorkspaceStructure(workspacePath);
-  const workspaceContext = await loadWorkspaceContext(workspacePath);
+  const workspaceContext = await loadWorkspaceContext(workspacePath, { bundledPath: resolveBundledSkillsDir() });
 
   // Build system prompt (no extra options needed for CLI chat)
   const agentSystemPrompt = buildSystemPrompt(agentConfig.systemPrompt, workspaceContext);
@@ -843,7 +844,7 @@ async function main() {
     await ensureWorkspaceStructure(workspacePath);
 
     // Load workspace context (SOUL.md, TOOLS.md, MEMORY.md, BOOTSTRAP.md, etc.)
-    const workspaceContext = await loadWorkspaceContext(workspacePath);
+    const workspaceContext = await loadWorkspaceContext(workspacePath, { bundledPath: resolveBundledSkillsDir() });
     const baseSystemPrompt = agentConfig.systemPrompt; // Store before workspace assembly
     agentConfig.systemPrompt = buildSystemPrompt(agentConfig.systemPrompt, workspaceContext);
     logger.debug(`Loaded workspace context for ${agentConfig.id}: systemPrompt=${workspaceContext.systemPromptAdditions.length > 0}, memory=${workspaceContext.memory !== null}`);

--- a/src/core/agent-manager.ts
+++ b/src/core/agent-manager.ts
@@ -1,3 +1,4 @@
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 // src/core/agent-manager.ts — Agent lifecycle management
 // Creates, stores, and manages AgentInstance objects.
 
@@ -170,7 +171,7 @@ export class DefaultAgentManager implements AgentManager {
         skillsPrompt: ctx.skillsPrompt,
       };
     } else {
-      const workspace = await loadWorkspaceContext(entry.workspacePath);
+      const workspace = await loadWorkspaceContext(entry.workspacePath, { bundledPath: resolveBundledSkillsDir() });
       systemPrompt = buildSystemPrompt(entry.baseSystemPrompt, workspace);
       entry.workspace = workspace;
     }

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { SkillLoader } from "../skills/index.js";
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 
 /** Standard workspace files that contribute to system prompt */
 export const WORKSPACE_FILES = [
@@ -68,7 +69,7 @@ export async function loadWorkspaceContext(workspacePath: string): Promise<Works
   }
 
   // Load skills from workspace
-  const skillLoader = new SkillLoader({ workspacePath });
+  const skillLoader = new SkillLoader({ workspacePath, bundledPath: resolveBundledSkillsDir() });
   const skillsPrompt = await skillLoader.generatePrompt();
 
   return {

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -4,7 +4,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { SkillLoader } from "../skills/index.js";
-import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 
 /** Standard workspace files that contribute to system prompt */
 export const WORKSPACE_FILES = [
@@ -36,7 +35,7 @@ export interface WorkspaceContext {
  * Load workspace context from a directory.
  * Reads standard workspace files and combines them for use in system prompt.
  */
-export async function loadWorkspaceContext(workspacePath: string): Promise<WorkspaceContext> {
+export async function loadWorkspaceContext(workspacePath: string, options?: { bundledPath?: string }): Promise<WorkspaceContext> {
   const additions: string[] = [];
 
   // Load standard workspace files
@@ -69,7 +68,7 @@ export async function loadWorkspaceContext(workspacePath: string): Promise<Works
   }
 
   // Load skills from workspace
-  const skillLoader = new SkillLoader({ workspacePath, bundledPath: resolveBundledSkillsDir() });
+  const skillLoader = new SkillLoader({ workspacePath, bundledPath: options?.bundledPath });
   const skillsPrompt = await skillLoader.generatePrompt();
 
   return {

--- a/src/skills/bundled-dir.ts
+++ b/src/skills/bundled-dir.ts
@@ -1,0 +1,62 @@
+// src/skills/bundled-dir.ts — Resolve bundled skills directory
+// Finds the `skills/` directory shipped with the isotopes package.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Check if a directory looks like it contains skills (has subdirs with SKILL.md).
+ */
+function looksLikeSkillsDir(dir: string): boolean {
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      if (entry.isDirectory()) {
+        if (fs.existsSync(path.join(dir, entry.name, "SKILL.md"))) {
+          return true;
+        }
+      }
+    }
+  } catch {
+    // Directory doesn't exist or isn't readable
+  }
+  return false;
+}
+
+/**
+ * Resolve the bundled skills directory by walking up from this module's location
+ * to find the package root, then returning `{root}/skills/`.
+ *
+ * Returns undefined if no bundled skills directory is found.
+ *
+ * Override with ISOTOPES_BUNDLED_SKILLS_DIR env var.
+ */
+export function resolveBundledSkillsDir(): string | undefined {
+  // Allow env override
+  const override = process.env.ISOTOPES_BUNDLED_SKILLS_DIR?.trim();
+  if (override) {
+    return override;
+  }
+
+  // Walk up from this file to find package root (directory containing package.json)
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    let current = path.dirname(thisFile);
+
+    for (let depth = 0; depth < 6; depth++) {
+      const candidate = path.join(current, "skills");
+      if (fs.existsSync(candidate) && looksLikeSkillsDir(candidate)) {
+        return candidate;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  } catch {
+    // Silently fail
+  }
+
+  return undefined;
+}

--- a/src/skills/discovery.ts
+++ b/src/skills/discovery.ts
@@ -29,6 +29,8 @@ export interface DiscoveryOptions {
   workspacePath?: string;
   /** Additional paths to scan for skills */
   additionalPaths?: string[];
+  /** Bundled skills path (lowest priority, from package root) */
+  bundledPath?: string;
 }
 
 export interface DiscoveredSkill {
@@ -68,11 +70,16 @@ export async function discoverSkills(
     globalPath = getGlobalSkillsPath(),
     workspacePath,
     additionalPaths = [],
+    bundledPath,
   } = options;
 
   const pathsToScan: string[] = [];
 
-  // Add paths in discovery order
+  // Add paths in discovery order (bundled first = lowest priority, last wins on dedup)
+  if (bundledPath) {
+    pathsToScan.push(bundledPath);
+  }
+
   pathsToScan.push(globalPath);
 
   if (workspacePath) {

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -5,3 +5,4 @@ export * from "./discovery.js";
 export * from "./parser.js";
 export * from "./prompt.js";
 export * from "./skill-loader.js";
+export * from "./bundled-dir.js";

--- a/src/workspace/context-loader.ts
+++ b/src/workspace/context-loader.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import fs from "node:fs/promises";
 import { createLogger } from "../core/logger.js";
 import { SkillLoader } from "../skills/index.js";
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 
 const log = createLogger("workspace:context-loader");
 
@@ -101,7 +102,7 @@ export class WorkspaceContextLoader {
     }
 
     // Load skills
-    const skillLoader = new SkillLoader({ workspacePath: this.workspacePath });
+    const skillLoader = new SkillLoader({ workspacePath: this.workspacePath, bundledPath: resolveBundledSkillsDir() });
     const skillsPrompt = await skillLoader.generatePrompt();
 
     this.context = {


### PR DESCRIPTION
Adds bundled skills discovery so built-in skills in `skills/` at the package root are automatically found.

**Changes:**
- `src/skills/bundled-dir.ts` — walks up from `import.meta.url` to find `{packageRoot}/skills/`
- `src/skills/discovery.ts` — new `bundledPath` option, scanned at lowest priority (bundled → global → workspace → additional)
- `src/core/workspace.ts` + `src/workspace/context-loader.ts` — pass bundled path to SkillLoader
- Env override: `ISOTOPES_BUNDLED_SKILLS_DIR`

All 88 skill tests pass ✅