### PR TITLE
refactor(subagent): consolidate timeout default, bump to 15min

### DIFF
--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -163,7 +163,7 @@ export interface SubagentToolOptions {
  * posted to the main channel when complete.
  */
 export function createSubagentTool(options: SubagentToolOptions): { tool: Tool; handler: ToolHandler } {
-  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout = 300, maxTurns } = options;
+  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns } = options;
   const supportedAgents = getSupportedAgents();
   const agents = allowedAgents ?? [...supportedAgents];
   // Combine workspace path with additional allowed workspaces
@@ -255,7 +255,7 @@ async function runSubagentPlain(
   task: string,
   agent: SubagentAgent,
   cwd: string,
-  timeout: number,
+  timeout: number | undefined,
   allowedWorkspaces: string[],
   maxTurns?: number,
 ): Promise<string> {
@@ -280,7 +280,7 @@ async function runSubagentWithDiscord(
   task: string,
   agent: SubagentAgent,
   cwd: string,
-  timeout: number,
+  timeout: number | undefined,
   allowedWorkspaces: string[],
   context: NonNullable<ReturnType<typeof getSubagentContext>>,
   maxTurns?: number,

--- a/src/iteration/code-executor.ts
+++ b/src/iteration/code-executor.ts
@@ -238,7 +238,7 @@ export function restoreFromBackup(backupPath: string): boolean {
  * Executes iteration steps using Claude subagent with verification.
  */
 export class CodeExecutor {
-  private config: Required<CodeExecutorConfig>;
+  private config: Omit<Required<CodeExecutorConfig>, "timeout"> & { timeout?: number };
 
   constructor(config: CodeExecutorConfig) {
     this.config = {
@@ -247,7 +247,7 @@ export class CodeExecutor {
       verify: config.verify ?? true,
       model: config.model ?? "",
       maxTurns: config.maxTurns ?? 20,
-      timeout: config.timeout ?? 300,
+      timeout: config.timeout,
     };
   }
 

--- a/src/subagent/backend.ts
+++ b/src/subagent/backend.ts
@@ -269,11 +269,10 @@ export class SubagentBackend {
 
     yield { type: "start" };
 
-    // Optional timeout: abort after N seconds if specified
-    const timeoutHandle = options.timeout
-      ? setTimeout(() => abortController.abort(), options.timeout * 1000)
-      : undefined;
-    timeoutHandle?.unref();
+    // Timeout: abort after N seconds. Default 900s (15 min) — single source of truth.
+    const timeoutSec = options.timeout ?? 900;
+    const timeoutHandle = setTimeout(() => abortController.abort(), timeoutSec * 1000);
+    timeoutHandle.unref();
 
     let sawDone = false;
     // tool_use blocks carry name+id; tool_result blocks only carry the id.
@@ -300,7 +299,7 @@ export class SubagentBackend {
         sawDone = true;
       }
     } finally {
-      if (timeoutHandle) clearTimeout(timeoutHandle);
+      clearTimeout(timeoutHandle);
       runs.delete(taskId);
     }
 

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -163,7 +163,7 @@ export async function spawnSubagent(
       prompt,
       cwd: options.cwd,
       model: options.model,
-      timeout: options.timeout ?? 300,
+      timeout: options.timeout,
       maxTurns: options.maxTurns ?? 50,
     });
 


### PR DESCRIPTION
## Summary
- Sink the subagent timeout default into `SubagentBackend.spawn` — the only place a timer is actually armed — instead of duplicating `?? 300` across `createSubagentTool`, `spawnSubagent`, and `CodeExecutor`. Upstream layers now pass `undefined` and let backend decide.
- Bump the default from **300s → 900s (15 min)**. 300s was inherited from the `acpx` process-level kill era (#355 swapped that for `AbortController`, which makes hard-timeouts less load-bearing). 5 min was too tight for normal multi-file subagent tasks — the trigger for this cleanup was a 14-msg / 59-tool-call run aborted at exactly 300s.

## Why this matters
- One place to tune timeout. Previously, changing it required updating three files in lockstep; forgetting any one would silently regress.
- Cleaner semantics: backend is the only owner of the abort timer, so it owns the default.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1837 passed / 8 skipped / 0 failed
- [ ] Smoke: spawn a subagent from Discord, confirm it can run >5 min without being aborted

🤖 Generated with [Claude Code](https://claude.com/claude-code)