### PR TITLE
fix(transports): persist drained pending messages to SessionStore

### DIFF
--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -1201,6 +1201,76 @@ describe("DiscordTransport", () => {
       await handleMessagePromise;
     });
 
+    it("persists drained pending messages to SessionStore (issue #371)", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+
+      let resolveAgent: () => void;
+      const agentWait = new Promise<void>((resolve) => { resolveAgent = resolve; });
+
+      // Agent: emits text, waits, then turn_end (drain happens here) + agent_end
+      const agent = {
+        prompt: vi.fn(async function* () {
+          yield { type: "text_delta" as const, text: "thinking..." };
+          await agentWait;
+          yield { type: "turn_end" as const, usage: undefined };
+          yield { type: "agent_end" as const, messages: [] };
+        }),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+      };
+      localAgentManager.get = vi.fn().mockReturnValue(agent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+      await localTransport.start();
+
+      // msg1 triggers the agent (also persisted via the normal addMessage path)
+      const t1 = 1700000000000;
+      const msg1 = makeMsg({ content: "<@bot-123> hello", id: "msg-1", createdTimestamp: t1 });
+      const inFlight = (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg1);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // msg2 and msg3 arrive while agent is busy → should be buffered
+      const msg2 = makeMsg({
+        content: "<@bot-123> follow-up two",
+        id: "msg-2",
+        createdTimestamp: t1 + 1000,
+        author: { bot: false, username: "bob", id: "user-2" },
+      });
+      const msg3 = makeMsg({
+        content: "<@bot-123> follow-up three",
+        id: "msg-3",
+        createdTimestamp: t1 + 2000,
+        author: { bot: false, username: "carol", id: "user-3" },
+      });
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg2);
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg3);
+
+      // Release the agent — turn_end fires onToolComplete which should persist msg2, msg3
+      resolveAgent!();
+      await inFlight;
+
+      const calls = (localSessionStore.addMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+      const userCalls = calls.filter((c) => (c[1] as { role: string }).role === "user");
+      // Expect: msg1 (initial), msg2, msg3
+      expect(userCalls.length).toBeGreaterThanOrEqual(3);
+
+      const buffered = userCalls.filter((c) => (c[1] as { metadata?: { buffered?: boolean } }).metadata?.buffered);
+      expect(buffered).toHaveLength(2);
+
+      const senders = buffered.map((c) => (c[1] as { metadata: { sender: string } }).metadata.sender).sort();
+      expect(senders).toEqual(["bob", "carol"]);
+
+      const timestamps = buffered.map((c) => (c[1] as { timestamp: number }).timestamp).sort();
+      expect(timestamps).toEqual([t1 + 1000, t1 + 2000]);
+    });
+
     it("clears active session and pending buffer after agent completes", async () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -428,7 +428,9 @@ export class DiscordTransport implements Transport {
     const sessionKey = this.getSessionKey(msg, agentId);
     const session = await this.findOrCreateSession(sessionStore, sessionKey, agentId, msg);
 
-    // 6.5. If session is currently active (in a prompt turn), buffer this message instead
+    // 6.5. If session is currently active (in a prompt turn), buffer this message instead.
+    // The buffer is drained at turn_end via onToolComplete, where each message is
+    // also persisted to SessionStore so future prompt() invocations replay them.
     if (this.activeSessions.has(session.id)) {
       log.debug(`Session ${session.id} is active, buffering message from ${msg.author.username}`);
       const pending = this.pendingMessages.get(session.id) ?? [];
@@ -438,16 +440,9 @@ export class DiscordTransport implements Transport {
         timestamp: msg.createdTimestamp,
       });
       this.pendingMessages.set(session.id, pending);
-
-      // Still record to channel history for context
-      if (this.config.context?.channelHistory !== false && msg.guild) {
-        this.channelHistory.append(msg.channelId, {
-          sender: msg.author.username,
-          body: content,
-          timestamp: msg.createdTimestamp,
-          messageId: msg.id,
-        });
-      }
+      // Note: do not also append to channelHistory — onToolComplete persists to
+      // SessionStore, and channelHistory injection on the next trigger would
+      // re-surface the same message a second time.
       return;
     }
 
@@ -737,6 +732,21 @@ export class DiscordTransport implements Transport {
             if (!pending?.length) return null;
 
             const messages = pending.splice(0); // drain buffer
+
+            // Persist each buffered message to SessionStore so history reflects
+            // what the model actually saw via steer(). Without this, replayed
+            // history (clearMessages + getMessages on next prompt) loses these
+            // messages, leaving the assistant reply referencing user input that
+            // appears never to have been sent.
+            for (const m of messages) {
+              await sessionStore.addMessage(sessionId, {
+                role: "user",
+                content: textContent(m.content),
+                timestamp: m.timestamp,
+                metadata: { sender: m.sender, buffered: true },
+              });
+            }
+
             const formatted = messages.map(m => `${m.sender}: ${m.content}`).join("\n");
             return `[Messages arrived while you were working]\n${formatted}`;
           },


### PR DESCRIPTION
## Summary
- Persist messages drained from `pendingMessages` (buffered while a turn was in flight) to `SessionStore` as user messages with `metadata.buffered: true`, so subsequent `prompt()` calls feed the model a history that matches what it actually saw via `steer()`.
- Remove the now-redundant `channelHistory.append()` from the buffered branch — history comes from `SessionStore` and would otherwise double-inject.

## Test plan
- [x] New test `persists drained pending messages to SessionStore (issue #371)` in `src/transports/discord.test.ts` verifies `addMessage` is called for each buffered message with the original sender, timestamp, and `metadata.buffered: true`.
- [x] `pnpm test` — 1399 passing.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)