### PR TITLE
feat(discord): /stop and /cancel for main agent (#364)

### DIFF
--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -1377,7 +1377,7 @@ describe("DiscordTransport", () => {
       await new Promise((r) => setTimeout(r, 100));
 
       const stopChannel = makeChannel();
-      const stopMsg = makeMsg({ channel: stopChannel, content: "/stop", id: "msg-stop", mentions: { has: vi.fn(() => false) } });
+      const stopMsg = makeMsg({ channel: stopChannel, content: "<@bot-123> /stop", id: "msg-stop" });
       await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(stopMsg);
 
       expect(agent.abort).toHaveBeenCalledTimes(1);
@@ -1408,7 +1408,7 @@ describe("DiscordTransport", () => {
 
       const stopChannel = makeChannel();
       await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
-        makeMsg({ channel: stopChannel, content: "/cancel", id: "msg-stop", mentions: { has: vi.fn(() => false) } }),
+        makeMsg({ channel: stopChannel, content: "<@bot-123> /cancel", id: "msg-stop" }),
       );
 
       expect(agent.abort).toHaveBeenCalledTimes(1);
@@ -1471,6 +1471,66 @@ describe("DiscordTransport", () => {
 
       expect(agent.abort).not.toHaveBeenCalled();
       expect(agent.prompt).toHaveBeenCalledTimes(1);
+
+      release();
+      await inFlight;
+    });
+    it("/stop in a group channel without @mention is ignored (multi-bot safety)", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = makeStatefulSessionStore();
+      const { agent, release } = makeHangingAgent();
+      localAgentManager.get = vi.fn().mockReturnValue(agent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+      await localTransport.start();
+
+      const inFlight = (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ content: "<@bot-123> long task", id: "msg-1" }),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Bare /stop in guild, NOT mentioning this bot — must be ignored
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ content: "/stop", id: "msg-stop", mentions: { has: vi.fn(() => false) } }),
+      );
+
+      expect(agent.abort).not.toHaveBeenCalled();
+
+      release();
+      await inFlight;
+    });
+
+    it("/stop in a DM (no guild) works without @mention", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = makeStatefulSessionStore();
+      const { agent, release } = makeHangingAgent();
+      localAgentManager.get = vi.fn().mockReturnValue(agent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+      await localTransport.start();
+
+      const inFlight = (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ content: "long task", id: "msg-1", guild: undefined, mentions: { has: vi.fn(() => false) } }),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      const stopChannel = makeChannel();
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ channel: stopChannel, content: "/stop", id: "msg-stop", guild: undefined, mentions: { has: vi.fn(() => false) } }),
+      );
+
+      expect(agent.abort).toHaveBeenCalledTimes(1);
+      expect(stopChannel.send).toHaveBeenCalledWith("🛑 Stopped.");
 
       release();
       await inFlight;

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -1301,4 +1301,179 @@ describe("DiscordTransport", () => {
       expect(completingAgent.prompt).toHaveBeenCalledTimes(2);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Main-agent /stop and /cancel (issue #364)
+  // ---------------------------------------------------------------------------
+
+  describe("main-agent /stop", () => {
+    function makeChannel(): MockChannel {
+      return {
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(false),
+      };
+    }
+
+    function makeMsg(overrides: Partial<MockIncomingMessage> = {}): MockIncomingMessage {
+      return {
+        author: { bot: false, username: "tester", id: "user-1" },
+        content: "<@bot-123> hello",
+        createdTimestamp: Date.now(),
+        guild: { id: "guild-1" },
+        channelId: "channel-1",
+        channel: makeChannel(),
+        mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        thread: undefined,
+        id: `msg-${Date.now()}`,
+        ...overrides,
+      };
+    }
+
+    function makeHangingAgent() {
+      let resolve!: () => void;
+      const wait = new Promise<void>((r) => { resolve = r; });
+      const agent = {
+        prompt: vi.fn(async function* () {
+          yield { type: "text_delta" as const, text: "thinking..." };
+          await wait;
+          yield { type: "agent_end" as const, messages: [] };
+        }),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+      };
+      return { agent, release: () => resolve() };
+    }
+
+    function makeStatefulSessionStore(sessionId = "session-stop") {
+      const store = createMockSessionStore(sessionId);
+      let stored: { id: string; agentId: string; lastActiveAt: Date; key?: string } | undefined;
+      store.create = vi.fn(async (agentId: string, opts?: { key?: string }) => {
+        stored = { id: sessionId, agentId, lastActiveAt: new Date(), key: opts?.key };
+        return stored;
+      }) as unknown as typeof store.create;
+      store.findByKey = vi.fn(async (key: string) => (stored?.key === key ? stored : undefined)) as unknown as typeof store.findByKey;
+      return store;
+    }
+
+    it("/stop aborts an in-flight main-agent turn and acks with 🛑", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = makeStatefulSessionStore();
+      const { agent, release } = makeHangingAgent();
+      localAgentManager.get = vi.fn().mockReturnValue(agent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+      await localTransport.start();
+
+      const channel = makeChannel();
+      const msg1 = makeMsg({ channel, content: "<@bot-123> long task", id: "msg-1" });
+      const inFlight = (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg1);
+      await new Promise((r) => setTimeout(r, 100));
+
+      const stopChannel = makeChannel();
+      const stopMsg = makeMsg({ channel: stopChannel, content: "/stop", id: "msg-stop", mentions: { has: vi.fn(() => false) } });
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(stopMsg);
+
+      expect(agent.abort).toHaveBeenCalledTimes(1);
+      expect(stopChannel.send).toHaveBeenCalledWith("🛑 Stopped.");
+
+      release();
+      await inFlight;
+    });
+
+    it("/cancel also aborts the in-flight turn", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = makeStatefulSessionStore();
+      const { agent, release } = makeHangingAgent();
+      localAgentManager.get = vi.fn().mockReturnValue(agent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+      await localTransport.start();
+
+      const inFlight = (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ content: "<@bot-123> long task", id: "msg-1" }),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      const stopChannel = makeChannel();
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ channel: stopChannel, content: "/cancel", id: "msg-stop", mentions: { has: vi.fn(() => false) } }),
+      );
+
+      expect(agent.abort).toHaveBeenCalledTimes(1);
+      release();
+      await inFlight;
+    });
+
+    it("/stop with no active turn does not abort and does not dispatch to model", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+      const agent = {
+        prompt: vi.fn(),
+        abort: vi.fn(),
+        steer: vi.fn(),
+        followUp: vi.fn(),
+      };
+      localAgentManager.get = vi.fn().mockReturnValue(agent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+      await localTransport.start();
+
+      const channel = makeChannel();
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ channel, content: "/stop", id: "msg-stop" }),
+      );
+
+      expect(agent.abort).not.toHaveBeenCalled();
+      expect(agent.prompt).not.toHaveBeenCalled();
+      expect(channel.send).not.toHaveBeenCalled();
+    });
+
+    it("normal messages during an in-flight turn do NOT abort (steer-at-turn_end preserved)", async () => {
+      const localAgentManager = createMockAgentManager();
+      const localSessionStore = createMockSessionStore();
+      const { agent, release } = makeHangingAgent();
+      localAgentManager.get = vi.fn().mockReturnValue(agent);
+
+      const localTransport = new DiscordTransport({
+        token: "test-token",
+        agentManager: localAgentManager,
+        sessionStore: localSessionStore,
+        defaultAgentId: "default",
+      });
+      await localTransport.start();
+
+      const inFlight = (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ content: "<@bot-123> long task", id: "msg-1" }),
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Plain user message — should be buffered, not abort
+      await (localTransport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(
+        makeMsg({ content: "<@bot-123> are you done?", id: "msg-2" }),
+      );
+
+      expect(agent.abort).not.toHaveBeenCalled();
+      expect(agent.prompt).toHaveBeenCalledTimes(1);
+
+      release();
+      await inFlight;
+    });
+  });
 });

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -339,6 +339,28 @@ export class DiscordTransport implements Transport {
       }
     }
 
+    // 3.6. Main-agent /stop or /cancel — abort current runAgentLoop if any.
+    // Runs before shouldRespond so it works in nomention mode without @mention.
+    // Always swallowed so /stop is never dispatched as a normal user message.
+    const normalizedStop = content.trim().toLowerCase();
+    if (normalizedStop === "/stop" || normalizedStop === "/cancel") {
+      const agentId = this.resolveAgentId(msg);
+      const sessionStore = this.getSessionStore(agentId);
+      const sessionKey = this.getSessionKey(msg, agentId);
+      const session = await sessionStore.findByKey(sessionKey);
+      if (session && this.activeSessions.has(session.id)) {
+        const agent = this.config.agentManager.get(agentId);
+        if (agent) {
+          log.info(`Main-agent /stop`, { sessionId: session.id, agentId });
+          agent.abort();
+          this.pendingMessages.delete(session.id);
+          await (msg.channel as SendableChannel).send("🛑 Stopped.");
+          return;
+        }
+      }
+      return;
+    }
+
     // 4. Should-respond check — record to channel history if not responding
     const respond = this.shouldRespond(msg);
 

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -340,10 +340,18 @@ export class DiscordTransport implements Transport {
     }
 
     // 3.6. Main-agent /stop or /cancel — abort current runAgentLoop if any.
-    // Runs before shouldRespond so it works in nomention mode without @mention.
-    // Always swallowed so /stop is never dispatched as a normal user message.
-    const normalizedStop = content.trim().toLowerCase();
-    if (normalizedStop === "/stop" || normalizedStop === "/cancel") {
+    // Runs before shouldRespond so it works without channel-config gating, but in
+    // group channels we still require @mention so a shared /stop in a multi-bot
+    // channel only aborts the addressed bot's session. DMs are 1:1 so no mention
+    // is required there. Allows an optional leading @mention token in the raw
+    // content since extractContent only strips numeric Discord ids.
+    const stopMatch = /^(?:<@!?\S+>\s*)?\/(stop|cancel)\s*$/i.exec(msg.content.trim());
+    if (stopMatch) {
+      const botId = this.client.user?.id;
+      const isMentioned = botId ? msg.mentions.has(botId) : false;
+      if (msg.guild && !isMentioned) {
+        return; // group channel without @mention — not for this bot
+      }
       const agentId = this.resolveAgentId(msg);
       const sessionStore = this.getSessionStore(agentId);
       const sessionKey = this.getSessionKey(msg, agentId);


### PR DESCRIPTION
## Summary
- Intercepts `/stop` and `/cancel` in `handleMessage` (before `shouldRespond`, after subagent-thread interception) and calls the existing `AgentInstance.abort()` against the in-flight `runAgentLoop` for the message's session.
- Acks with 🛑, drops any buffered pending messages for the aborted session, and silently swallows `/stop` when no turn is active so it never reaches the model.
- Mirrors the long-standing subagent-thread `/stop` behavior (`src/transports/discord.ts:520-549`); does not introduce a new `AbortController` since `agent.abort()` is already plumbed through `PiMonoCore` (`src/core/pi-mono.ts:616`).

## Non-goals
- **No auto-abort on every new message.** Nomention/passive mode relies on the existing steer-at-`turn_end` path (`src/core/agent-runner.ts:69-75`); a regression test locks this in.
- **Feishu transport is not modified.** Feishu has no `activeSessions`/buffering infrastructure today; deferring to a follow-up to keep this PR focused on the Discord paths the issue references.
- No `failureTracker` integration for the main agent (it is keyed on subagent task ids).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 1403 / 1403 pass (4 new tests under `main-agent /stop`)
- [ ] Manual smoke: in a Discord channel, mention the bot with a long task, then send `/stop` — expect 🛑 within ~2s and no further output

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)