### PR TITLE
ci: add vitest coverage report on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,29 +9,36 @@ on:
 jobs:
   CI:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v4
-          
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          
+
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-          
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        
+
       - name: Lint
         run: pnpm run lint
-        
+
       - name: Type check
         run: pnpm run typecheck
-        
+
       - name: Test
-        run: pnpm test
-        
+        run: pnpm run test:coverage
+
+      - name: Coverage report
+        if: github.event_name == 'pull_request'
+        uses: davelosert/vitest-coverage-report-action@v2
+
       - name: Build
         run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:integration": "tsx tests/integration/discord.test.ts",
     "ci": "npm run lint && npm run typecheck && npm run test",
     "prepare": "husky"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     exclude: ['tests/integration/**'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'json-summary', 'html'],
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add `davelosert/vitest-coverage-report-action@v2` step to CI — comments a coverage table on each PR (same setup as copilot-portal).
- Add `test:coverage` script and `json-summary` reporter (required by the action).
- Grant `pull-requests: write` permission to the CI job so the action can post comments.

## Test plan
- [ ] Open this PR and confirm the "Coverage report" step runs and a coverage comment appears.
- [ ] Verify `pnpm run test:coverage` passes locally / in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)