### PR TITLE
refactor: remove unused ThreadControlConfig and extractCliMetadata

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -394,14 +394,6 @@ export interface CompactionConfig {
 // Thread bindings — auto-bind Discord threads to agent sessions
 // ---------------------------------------------------------------------------
 
-/** Per-agent thread control configuration */
-export interface ThreadControlConfig {
-  /** Whether to respond to messages in threads. Default: true */
-  respond?: boolean;
-  /** Whether to include thread messages in channel history context. Default: true */
-  observe?: boolean;
-}
-
 /** Configuration for automatic thread-to-session binding */
 export interface ThreadBindingConfig {
   /** Whether thread binding is enabled */

--- a/src/transports/message-metadata.test.ts
+++ b/src/transports/message-metadata.test.ts
@@ -1,7 +1,7 @@
 // src/transports/message-metadata.test.ts — Tests for message metadata extraction
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { extractDiscordMetadata, extractCliMetadata, formatInboundMeta, type MessageMetadata } from "./message-metadata.js";
+import { extractDiscordMetadata, formatInboundMeta, type MessageMetadata } from "./message-metadata.js";
 
 // ---------------------------------------------------------------------------
 // Mock discord.js message factory
@@ -173,31 +173,6 @@ describe("extractDiscordMetadata", () => {
     const metadata = extractDiscordMetadata(msg as any);
 
     expect(metadata.sender.displayName).toBeUndefined();
-  });
-});
-
-describe("extractCliMetadata", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1700000010000);
-  });
-
-  it("returns CLI-specific metadata", () => {
-    const metadata = extractCliMetadata();
-
-    expect(metadata.sender).toEqual({
-      id: "cli-user",
-      username: "cli",
-      isBot: false,
-    });
-    expect(metadata.timestamps.sent).toBe(1700000010000);
-    expect(metadata.timestamps.received).toBe(1700000010000);
-    expect(metadata.channel).toEqual({
-      id: "cli",
-      name: "cli",
-      type: "dm",
-    });
-    expect(metadata.replyTo).toBeUndefined();
   });
 });
 

--- a/src/transports/message-metadata.ts
+++ b/src/transports/message-metadata.ts
@@ -88,32 +88,6 @@ export function extractDiscordMetadata(msg: DiscordMessage): MessageMetadata {
 }
 
 // ---------------------------------------------------------------------------
-// CLI extraction
-// ---------------------------------------------------------------------------
-
-/**
- * Create metadata for a CLI (local) message.
- */
-export function extractCliMetadata(): MessageMetadata {
-  return {
-    sender: {
-      id: "cli-user",
-      username: "cli",
-      isBot: false,
-    },
-    timestamps: {
-      sent: Date.now(),
-      received: Date.now(),
-    },
-    channel: {
-      id: "cli",
-      name: "cli",
-      type: "dm",
-    },
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Inbound metadata formatting (untrusted context block)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Remove `ThreadControlConfig` interface (`core/types.ts`) — declared but never referenced anywhere, not even re-exported from `src/index.ts`.
- Remove `extractCliMetadata` (`transports/message-metadata.ts`) and its test — the only consumer of the function was its own `.test.ts` file. We were testing a function nobody called.

Net: **-60 lines / +1 line**.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `npx vitest run src/transports/message-metadata.test.ts` — 17 passed (was 18, dropped the orphan test)
- [x] `grep -r "ThreadControlConfig\|extractCliMetadata" src` — no leftover references

🤖 Generated with [Claude Code](https://claude.com/claude-code)