### PR TITLE
refactor: remove unused isSetupComplete helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,6 @@ export {
   getWorkspaceTemplates,
   readWorkspaceState,
   writeWorkspaceState,
-  isSetupComplete,
   reconcileWorkspaceState,
   WorkspaceContextLoader,
   CONTEXT_FILES,

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -31,7 +31,6 @@ export type { WorkspaceTemplate } from "./templates.js";
 export {
   readWorkspaceState,
   writeWorkspaceState,
-  isSetupComplete,
   reconcileWorkspaceState,
 } from "./state.js";
 export type { WorkspaceState } from "./state.js";

--- a/src/workspace/state.test.ts
+++ b/src/workspace/state.test.ts
@@ -7,7 +7,6 @@ import os from "node:os";
 import {
   readWorkspaceState,
   writeWorkspaceState,
-  isSetupComplete,
   reconcileWorkspaceState,
 } from "./state.js";
 
@@ -74,21 +73,6 @@ describe("Workspace State", () => {
       const read = await readWorkspaceState(tempDir);
 
       expect(read).toEqual(state);
-    });
-  });
-
-  describe("isSetupComplete", () => {
-    it("returns false when setupCompletedAt is not set", () => {
-      expect(isSetupComplete({ version: 1 })).toBe(false);
-    });
-
-    it("returns true when setupCompletedAt is set", () => {
-      expect(
-        isSetupComplete({
-          version: 1,
-          setupCompletedAt: "2026-04-10T00:00:00.000Z",
-        }),
-      ).toBe(true);
     });
   });
 

--- a/src/workspace/state.ts
+++ b/src/workspace/state.ts
@@ -70,11 +70,6 @@ export async function writeWorkspaceState(
   log.debug(`Wrote workspace state: ${statePath}`);
 }
 
-/** Check if workspace setup (hatch) is complete. */
-export function isSetupComplete(state: WorkspaceState): boolean {
-  return !!state.setupCompletedAt;
-}
-
 /**
  * Reconcile workspace state with the current filesystem.
  *


### PR DESCRIPTION
## Summary
- Remove \`isSetupComplete()\` from \`src/workspace/state.ts\` — only consumer was its own test file.
- Drop the two barrel re-exports and the test block.

\`reconcileWorkspaceState\` (the only real production consumer of this module, called from \`cli.ts\`) checks \`state.setupCompletedAt\` directly — never went through this helper.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`npx vitest run src/workspace/state.test.ts\` — 9 passed (was 11, dropped the 2 orphan tests)
- [x] \`grep -r "isSetupComplete" src\` — no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)