### PR TITLE
chore(release): prepare package for npm publish as @ghostcomplex/isotopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,31 +17,39 @@ A lightweight, self-hostable AI agent framework for multi-agent collaboration ac
 - **Workspace hot-reload** — Auto-reload agent config and prompts on file changes
 - **Local-first** — Everything runs on your machine
 
-## Quick Start (from source)
+## Quick Start
 
 ```bash
-# Clone the repo
-git clone https://github.com/GhostComplex/isotopes.git
-cd isotopes
-
-# Install dependencies
-pnpm install
-
-# Build
-pnpm build
+# Install globally from npm
+npm install -g @ghostcomplex/isotopes
 
 # Create config
 mkdir -p ~/.isotopes
-cp isotopes.example.yaml ~/.isotopes/isotopes.yaml
+curl -fsSL https://raw.githubusercontent.com/GhostComplex/isotopes/main/isotopes.example.yaml \
+  -o ~/.isotopes/isotopes.yaml
 # Edit ~/.isotopes/isotopes.yaml with your settings
 
 # Run in foreground
-node dist/cli.js
+isotopes
 
 # Or run as daemon
-node dist/cli.js start
-node dist/cli.js status
-node dist/cli.js stop
+isotopes start
+isotopes status
+isotopes stop
+```
+
+### From source
+
+```bash
+git clone https://github.com/GhostComplex/isotopes.git
+cd isotopes
+pnpm install
+pnpm build
+
+mkdir -p ~/.isotopes
+cp isotopes.example.yaml ~/.isotopes/isotopes.yaml
+
+node dist/cli.js
 ```
 
 ## CLI

--- a/package.json
+++ b/package.json
@@ -1,10 +1,25 @@
 {
-  "name": "isotopes",
+  "name": "@ghostcomplex/isotopes",
   "version": "0.1.0",
   "description": "Lightweight, self-hostable AI agent framework",
   "type": "module",
   "bin": {
     "isotopes": "dist/cli.js"
+  },
+  "files": [
+    "dist/",
+    "skills/",
+    "isotopes.example.yaml",
+    "README.md",
+    "LICENSE",
+    "!dist/**/*.map",
+    "!dist/**/*.test.js",
+    "!dist/**/*.test.d.ts",
+    "!dist/**/test-helpers.js",
+    "!dist/**/test-helpers.d.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc",
@@ -18,7 +33,8 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "tsx tests/integration/discord.test.ts",
     "ci": "npm run lint && npm run typecheck && npm run test",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prepublishOnly": "pnpm run ci && pnpm run build"
   },
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- Rename to `@ghostcomplex/isotopes` and set `publishConfig.access: public` (scoped packages default to private otherwise)
- Add `files` whitelist so `npm publish` ships only `dist/`, `skills/`, `isotopes.example.yaml`, `README.md`, `LICENSE` — excludes `*.map`, `*.test.*`, `test-helpers.*`
- Add `prepublishOnly` running `pnpm ci && pnpm build` to guard against publishing stale/broken artifacts

After merge, `npm install -g @ghostcomplex/isotopes` will install the `isotopes` CLI globally (entry already wired via `bin`).

## Test plan
- [x] `pnpm install && pnpm build` passes
- [x] `npm pack --dry-run` shows 164 files / 186KB, no `.map`, no test files
- [ ] First publish: `npm publish --access public` (manual, requires npm login under ghostcomplex org)
- [ ] Smoke test: `npm i -g @ghostcomplex/isotopes && isotopes --help` on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)