### PR TITLE
chore(release): set version to 0.0.1 to signal pre-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ghostcomplex/isotopes",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Lightweight, self-hostable AI agent framework",
   "type": "module",
   "bin": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.1.0";
+export const VERSION = "0.0.1";


### PR DESCRIPTION
## Summary
- Bump `package.json` version from `0.1.0` → `0.0.1`
- Sync `src/version.ts` to match

The package is not ready for production use. Per npm ecosystem convention, `0.0.x` signals "expect breakage at any time" — `0.1.0` would imply the surface is at least usable, which is not yet true.

This buys us room: a `0.1.0` bump later can mark the first "you can actually try this" milestone, and `1.0.0` reserved for an API/CLI we're willing to stand behind.

## Test plan
- [x] `pnpm build` clean
- [x] Both version sources stay in sync (`package.json`, `src/version.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)