### PR TITLE
chore(release): narrow prepublishOnly to build-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:integration": "tsx tests/integration/discord.test.ts",
     "ci": "npm run lint && npm run typecheck && npm run test",
     "prepare": "husky",
-    "prepublishOnly": "pnpm run ci && pnpm run build"
+    "prepublishOnly": "pnpm run build"
   },
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- `prepublishOnly`: `pnpm run ci && pnpm run build` → `pnpm run build`

## Why
Running the full `ci` (lint + typecheck + 1358-test vitest suite) inside `prepublishOnly` makes local publishing infeasible. Heavy tests — `src/tools/exec.test.ts`, `tests/e2e-smoke.test.ts`, the filesystem-watcher tests — hang or get OOM-killed on dev machines, leaving nothing publishable.

`prepublishOnly` should be a fast safety net guarding against shipping unbuilt artifacts. CI on the merged commit is the right place for full validation, and it already runs there.

## Test plan
- [x] `npm publish --dry-run` will now only invoke `tsc`, no test runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)