### PR TITLE
chore(release): bump version to 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ghostcomplex/isotopes",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Lightweight, self-hostable AI agent framework",
   "type": "module",
   "bin": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.0.1";
+export const VERSION = "0.0.2";


### PR DESCRIPTION
## Summary
- `package.json`: `0.0.1` → `0.0.2`
- `src/version.ts`: keep `VERSION` constant in sync

## Why
`0.0.1` was unpublished from npm. npm does not allow reusing an unpublished version number, so the next publish must use a fresh slot. Once merged, `npm publish` will put the package back on the registry under `0.0.2` and ship the trimmed README from #405.

## Test plan
- [x] Both version strings stay in sync
- [ ] After merge: `git pull && npm publish` from main, then `npm view @ghostcomplex/isotopes version` returns `0.0.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)