### PR TITLE
chore(release): ship source maps in published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "isotopes.example.yaml",
     "README.md",
     "LICENSE",
-    "!dist/**/*.map",
     "!dist/**/*.test.js",
     "!dist/**/*.test.d.ts",
     "!dist/**/test-helpers.js",


### PR DESCRIPTION
## Summary
- Drop the `!dist/**/*.map` exclusion from `package.json` `files`
- Tarball now includes 145 `.js.map` + 145 `.d.ts.map` files alongside the existing JS

## Why
Source maps make stack traces from npm-installed users point back at `src/*.ts` instead of `dist/*.js` — much easier to file and triage bug reports against. For a CLI tool that may be debugged by end users, that's worth the size bump.

## Size impact
| | Before | After |
|---|---|---|
| Files | 166 | 454 |
| Tarball | 186 KB | 356 KB |
| Unpacked | 736 KB | 1.9 MB |

## Test plan
- [x] `pnpm build && npm pack --dry-run` confirms `.js.map` and `.d.ts.map` files are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)