### PR TITLE
chore(npm): add repository, bugs, homepage, and author metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,15 @@
     "discord",
     "openai"
   ],
-  "author": "",
+  "author": "Steins.Z",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GhostComplex/isotopes.git"
+  },
+  "bugs": {
+    "url": "https://github.com/GhostComplex/isotopes/issues"
+  },
+  "homepage": "https://github.com/GhostComplex/isotopes#readme",
   "license": "MIT",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
Add the four standard npm metadata fields that were missing:

- `repository` → `git+https://github.com/GhostComplex/isotopes.git`
- `bugs` → `https://github.com/GhostComplex/isotopes/issues`
- `homepage` → `https://github.com/GhostComplex/isotopes#readme`
- `author` → `Steins.Z` (was empty string)

## Effect
npmjs.com will now render Repository / Homepage / Issues links on the package page, and `npm view @ghostcomplex/isotopes` will surface the same. No functional change — safe to ship with the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)