### PR TITLE
feat(subagent): persist runs to SessionStore via virtual agentId

### DIFF
--- a/docs/subagent-persistence.md
+++ b/docs/subagent-persistence.md
@@ -1,0 +1,125 @@
+# Subagent run persistence
+
+This doc captures how subagent runs are recorded so future backends (e.g. the
+in-process / built-in backend tracked in #399) can plug in without redoing the
+plumbing. Read this before adding a new subagent backend or changing the event
+schema.
+
+## Goals
+
+- Reuse the existing `SessionStore` rather than introducing a parallel store.
+- One transcript shape across main agents and subagents — downstream consumers
+  (UIs, exports, future analytics) read both the same way.
+- Backend-agnostic: a backend just emits `SubagentEvent`s; persistence is
+  attached by the spawn layer, not the backend.
+- Fail-safe: persistence errors must never break a running subagent.
+
+## Virtual agentId scheme
+
+Each subagent run is its own session, keyed by a virtual agentId derived from
+the parent agent and the run's task ID:
+
+```
+subagent:<parentAgentId>:<taskId>
+```
+
+`subagentAgentId(parent, task)` in `src/subagent/persistence.ts` is the single
+source of truth for this format. Don't reconstruct it inline.
+
+The session is created at run start via `store.create(virtualAgentId, metadata)`
+and gets a fresh JSONL transcript file like any other session.
+
+## Session metadata
+
+`SessionMetadata.transport` includes a `"subagent"` discriminator. The
+subagent-specific payload lives under `metadata.subagent`:
+
+```ts
+interface SubagentSessionMetadata {
+  parentAgentId: string;
+  parentSessionId?: string;  // the session that spawned this run, if any
+  taskId: string;
+  backend: string;           // e.g. "claude-cli", later "builtin"
+  cwd?: string;
+  prompt?: string;
+  exitCode?: number;         // populated on done
+  costUsd?: number;          // populated on done
+  durationMs?: number;       // computed at terminal event
+  error?: string;            // populated on error
+}
+```
+
+Lifecycle metadata (`exitCode`, `costUsd`, `durationMs`, `error`) is patched in
+via `SessionStore.setMetadata` from the recorder when terminal events arrive.
+Use `setMetadata` rather than re-creating the session — it preserves the
+key index and merges shallowly.
+
+## Event → Message mapping
+
+`eventToMessage(event)` in `src/subagent/persistence.ts` is the adapter. Adding
+a new event type? Extend that function in one place.
+
+| `SubagentEvent.type` | Persisted? | Shape |
+|---|---|---|
+| `start`              | no         | drives session creation only |
+| `message`            | yes        | `assistant` text block |
+| `tool_use`           | yes        | `assistant` text `🔧 Name(input)` (truncated to 4 KB) — structured `tool_use` blocks deferred, see "Future work" |
+| `tool_result`        | yes        | `tool_result` block, output truncated to 4 KB |
+| `error`              | yes        | `assistant` text `❌ <message>` + metadata patch |
+| `done`               | no         | drives metadata patch only |
+
+`message.metadata.subagentEvent` is set on tool/error rows so consumers can
+distinguish them from main-agent content if needed.
+
+## Wiring (where things live)
+
+```
+spawnSubagent (src/tools/subagent.ts)
+  └── createSubagentRecorder({ store, parentAgentId, taskId, ... })
+        ├── store.create(virtualAgentId, metadata)   ← at run start
+        ├── recorder.record(event)                   ← on every SubagentEvent
+        └── recorder.patchMetadata(patch)            ← on done / error
+```
+
+The store is injected at app startup:
+
+- `cli.ts` builds a dedicated `DefaultSessionStore` rooted at
+  `getSubagentSessionsDir()` (`~/.isotopes/subagent-sessions`) when
+  `config.subagent.enabled` is true.
+- It calls `setSubagentSessionStore(store)` from `src/tools/subagent.ts`.
+- `parentAgentId` is threaded from `createWorkspaceToolsWithGuards` →
+  `createSubagentTool` → `runSubagent*` → `spawnSubagent`.
+
+If no store is configured, `createSubagentRecorder` returns a no-op recorder so
+the spawn loop has no conditional persistence branches.
+
+## Adding a new backend
+
+A backend (issue #399 will add a built-in one) only needs to:
+
+1. Implement an async iterable that yields `SubagentEvent`s.
+2. Plug into `SubagentBackend` so `backend.spawn(taskId, opts)` returns that
+   iterable.
+
+Persistence is automatic — `spawnSubagent` will record events and patch
+metadata regardless of backend. Set `metadata.subagent.backend` to the new
+backend name (e.g. `"builtin"`) when constructing the recorder so transcripts
+are filterable.
+
+## Fail-safe behaviour
+
+- Store creation failure → log warn, return `NOOP_RECORDER`. The run still
+  proceeds; it just isn't persisted.
+- `addMessage` / `setMetadata` failures inside the recorder → log warn,
+  swallow. Persistence is a best-effort sidecar, never on the critical path.
+
+## Future work (out of scope for #400)
+
+- Structured `tool_use` content blocks (would require extending
+  `MessageContentBlock` and updating every consumer that pattern-matches on
+  block kinds).
+- TTL / GC tuning for the subagent store — currently shares the parent store's
+  defaults via `SessionConfig`.
+- Linking the subagent session back into the parent transcript as a
+  `tool_result` block (today the link is one-way: parent → subagent via
+  `parentSessionId`).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import {
   resolveSubagentConfig,
   resolveSandboxConfigFromFile,
 } from "./core/config.js";
-import { initSubagentBackend } from "./tools/subagent.js";
+import { initSubagentBackend, setSubagentSessionStore } from "./tools/subagent.js";
 import { PiMonoCore } from "./core/pi-mono.js";
 import { DefaultAgentManager } from "./core/agent-manager.js";
 import { DefaultSessionStore } from "./core/session-store.js";
@@ -43,6 +43,7 @@ import {
   ensureExplicitWorkspaceDir,
   ensureWorkspaceDir,
   getSessionsDir,
+  getSubagentSessionsDir,
   getThreadBindingsPath,
   resolveExplicitWorkspacePath,
 } from "./core/paths.js";
@@ -779,6 +780,7 @@ async function main() {
   logger.info(`Loaded ${config.agents.length} agent(s)`);
 
   // Initialize subagent backend with config (M8)
+  let subagentRunStore: DefaultSessionStore | undefined;
   if (config.subagent?.enabled) {
     const subagentConfig = resolveSubagentConfig(config.subagent);
     initSubagentBackend({
@@ -786,6 +788,17 @@ async function main() {
       allowedTools: subagentConfig.allowedTools,
     });
     logger.info(`Subagent backend initialized (permissionMode: ${subagentConfig.permissionMode})`);
+
+    // Persist subagent run transcripts to ~/.isotopes/subagent-sessions.
+    // The store is shared across all parent agents — each run is keyed by
+    // a virtual agentId (`subagent:<parentAgentId>:<taskId>`).
+    const subagentSessionStore = new DefaultSessionStore({
+      dataDir: getSubagentSessionsDir(),
+    });
+    await subagentSessionStore.init();
+    setSubagentSessionStore(subagentSessionStore);
+    subagentRunStore = subagentSessionStore;
+    logger.info(`Subagent session transcripts → ${getSubagentSessionsDir()}`);
   }
 
   // Initialize core with tool registry
@@ -888,6 +901,7 @@ async function main() {
       agentConfig.codingMode,
       config.subagent?.maxTurns,
       fsImpl,
+      agentConfig.id,
     );
 
     // Apply tool policy (allow/deny) before registration
@@ -1170,6 +1184,7 @@ async function main() {
         store.destroy();
       }
     }
+    subagentRunStore?.destroy();
 
     // Kill orphaned background processes (#286, #289)
     for (const registry of processRegistries.values()) {
@@ -1203,6 +1218,7 @@ async function main() {
         store.destroy();
       }
     }
+    subagentRunStore?.destroy();
 
     // Kill orphaned background processes (#286, #289)
     for (const registry of processRegistries.values()) {

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -58,6 +58,15 @@ export function getSessionsDir(agentId: string): string {
   return path.join(getWorkspacePath(agentId), "sessions");
 }
 
+/**
+ * Get the directory holding subagent run transcripts.
+ * One JSONL per run lives under here (keyed by virtual agentId =
+ * `subagent:<parentAgentId>:<taskId>`). See docs/subagent-persistence.md.
+ */
+export function getSubagentSessionsDir(): string {
+  return path.join(getIsotopesHome(), "subagent-sessions");
+}
+
 // ---------------------------------------------------------------------------
 // Config paths
 // ---------------------------------------------------------------------------

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -580,4 +580,53 @@ describe("DefaultSessionStore", () => {
     });
   });
 
+  describe("setMetadata", () => {
+    it("merges patch into existing metadata and persists to index", async () => {
+      const session = await store.create("subagent:dev:task-1", {
+        transport: "subagent",
+        subagent: {
+          parentAgentId: "dev",
+          taskId: "task-1",
+          backend: "claude",
+        },
+      });
+
+      await store.setMetadata(session.id, {
+        subagent: {
+          parentAgentId: "dev",
+          taskId: "task-1",
+          backend: "claude",
+          exitCode: 0,
+          costUsd: 0.42,
+          durationMs: 1234,
+        },
+      });
+
+      const got = await store.get(session.id);
+      expect(got?.metadata?.subagent?.exitCode).toBe(0);
+      expect(got?.metadata?.subagent?.costUsd).toBe(0.42);
+
+      // Reopen the store to confirm the patch survived persistence.
+      const reopened = new DefaultSessionStore({ dataDir: tempDir });
+      await reopened.init();
+      const reloaded = await reopened.get(session.id);
+      expect(reloaded?.metadata?.subagent?.exitCode).toBe(0);
+      expect(reloaded?.metadata?.subagent?.durationMs).toBe(1234);
+      reopened.destroy();
+    });
+
+    it("rejects dropping the required transport field", async () => {
+      const session = await store.create("agent-1");
+      await expect(
+        store.setMetadata(session.id, { transport: undefined }),
+      ).rejects.toThrow(/transport/);
+    });
+
+    it("throws on unknown sessionId", async () => {
+      await expect(store.setMetadata("nope", { transport: "discord" })).rejects.toThrow(
+        /not found/,
+      );
+    });
+  });
+
 });

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -217,6 +217,34 @@ export class DefaultSessionStore implements SessionStore {
     this.debouncedPersistIndex();
   }
 
+  async setMetadata(sessionId: string, patch: Partial<SessionMetadata>): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session "${sessionId}" not found`);
+    }
+
+    const prevKey = session.metadata?.key;
+    const merged = { ...(session.metadata ?? {}), ...patch } as SessionMetadata;
+    if (!merged.transport) {
+      throw new Error(`setMetadata: cannot drop required "transport" field on session "${sessionId}"`);
+    }
+
+    // Maintain key index if the key changed.
+    if (prevKey && prevKey !== merged.key) {
+      this.keyIndex.delete(prevKey);
+    }
+    if (merged.key && merged.key !== prevKey) {
+      const existing = this.keyIndex.get(merged.key);
+      if (existing && existing !== sessionId) {
+        throw new Error(`Session with key already exists: ${merged.key}`);
+      }
+      this.keyIndex.set(merged.key, sessionId);
+    }
+
+    session.metadata = merged;
+    await this.persistIndex();
+  }
+
   // -------------------------------------------------------------------------
   // TTL & cleanup
   // -------------------------------------------------------------------------

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -76,5 +76,6 @@ export function createMockSessionStore(sessionId = "session-123"): SessionStore 
     list: vi.fn().mockResolvedValue([]),
     clearMessages: vi.fn(),
     setMessages: vi.fn(),
+    setMetadata: vi.fn(),
   };
 }

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -154,6 +154,8 @@ export interface SubagentToolOptions {
   timeout?: number;
   /** Maximum number of turns for the sub-agent (default: 50) */
   maxTurns?: number;
+  /** Parent agent id, used as the owner of the persisted subagent run. */
+  parentAgentId?: string;
 }
 /**
  * Create a sub-agent spawning tool.
@@ -164,7 +166,7 @@ export interface SubagentToolOptions {
  * posted to the main channel when complete.
  */
 export function createSubagentTool(options: SubagentToolOptions): { tool: Tool; handler: ToolHandler } {
-  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns } = options;
+  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns, parentAgentId } = options;
   const supportedAgents = getSupportedAgents();
   const agents = allowedAgents ?? [...supportedAgents];
   // Combine workspace path with additional allowed workspaces
@@ -226,10 +228,10 @@ export function createSubagentTool(options: SubagentToolOptions): { tool: Tool; 
         let result: string;
         if (discordContext) {
           // Run with Discord streaming
-          result = await runSubagentWithDiscord(task, agent as SubagentAgent, cwd, timeout, allAllowedWorkspaces, discordContext, maxTurns);
+          result = await runSubagentWithDiscord(task, agent as SubagentAgent, cwd, timeout, allAllowedWorkspaces, discordContext, maxTurns, parentAgentId);
         } else {
           // Run without Discord streaming (original behavior)
-          result = await runSubagentPlain(task, agent as SubagentAgent, cwd, timeout, allAllowedWorkspaces, maxTurns);
+          result = await runSubagentPlain(task, agent as SubagentAgent, cwd, timeout, allAllowedWorkspaces, maxTurns, parentAgentId);
         }
 
         // Record failure if result indicates failure
@@ -259,6 +261,7 @@ async function runSubagentPlain(
   timeout: number | undefined,
   allowedWorkspaces: string[],
   maxTurns?: number,
+  parentAgentId?: string,
 ): Promise<string> {
   const result = await spawnSubagent(task, {
     agent,
@@ -266,6 +269,7 @@ async function runSubagentPlain(
     timeout,
     allowedWorkspaces,
     maxTurns,
+    parentAgentId,
   });
   if (result.success) {
     return result.output ?? "[sub-agent completed with no output]";
@@ -285,6 +289,7 @@ async function runSubagentWithDiscord(
   allowedWorkspaces: string[],
   context: NonNullable<ReturnType<typeof getSubagentContext>>,
   maxTurns?: number,
+  parentAgentId?: string,
 ): Promise<string> {
   const { sendMessage, createThread, channelId, showToolCalls = true, onComplete } = context;
   // Create Discord sink with thread enabled
@@ -318,6 +323,7 @@ async function runSubagentWithDiscord(
       allowedWorkspaces,
       channelId,
       threadId, // Pass threadId for /stop support in threads
+      parentAgentId,
       onEvent: async (event) => {
         events.push(event);
         await sink.sendEvent(event);
@@ -818,6 +824,7 @@ export function createWorkspaceToolsWithGuards(
   codingMode: "subagent" | "direct" | "auto" = "auto",
   subagentMaxTurns?: number,
   fsImpl?: FsLike,
+  parentAgentId?: string,
 ): { tool: Tool; handler: ToolHandler }[] {
   const guards = resolveToolGuards(settings);
   // Always use workspacePath as base for relative path resolution.
@@ -835,7 +842,7 @@ export function createWorkspaceToolsWithGuards(
     createTimeTool(),
   ];
   if (subagentEnabled) {
-    tools.push(createSubagentTool({ workspacePath, allowedWorkspaces, maxTurns: subagentMaxTurns }));
+    tools.push(createSubagentTool({ workspacePath, allowedWorkspaces, maxTurns: subagentMaxTurns, parentAgentId }));
   }
   // Web fetch tool
   if (settings?.web) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -215,16 +215,33 @@ export interface Session {
   lastActiveAt: Date;
 }
 
+/** Per-run metadata for a subagent session (only set when transport === 'subagent'). */
+export interface SubagentSessionMetadata {
+  parentAgentId: string;
+  parentSessionId?: string;
+  taskId: string;
+  backend: string;
+  cwd?: string;
+  prompt?: string;
+  /** Populated on terminal event (done/error). */
+  exitCode?: number;
+  costUsd?: number;
+  durationMs?: number;
+  error?: string;
+}
+
 /** Transport-specific metadata attached to a session (channel, thread, etc.). */
 export interface SessionMetadata {
   key?: string;                        // Unique key for session lookup (e.g., discord:{botId}:channel:{id}:{agentId})
-  transport: 'discord' | 'feishu' | 'web';
+  transport: 'discord' | 'feishu' | 'web' | 'subagent';
   channelId?: string;
   channelName?: string;
   guildName?: string;
   threadId?: string;
   /** If true, session is exempt from TTL-based cleanup */
   persistent?: boolean;
+  /** Subagent run metadata (only present when transport === 'subagent'). */
+  subagent?: SubagentSessionMetadata;
 }
 
 /** Session TTL and cleanup configuration */
@@ -257,6 +274,8 @@ export interface SessionStore {
   clearMessages(sessionId: string): Promise<void>;
   /** Replace all messages in a session (used by compaction) */
   setMessages(sessionId: string, messages: Message[]): Promise<void>;
+  /** Merge fields into the session metadata (e.g. write terminal subagent state). */
+  setMetadata(sessionId: string, patch: Partial<SessionMetadata>): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/subagent/persistence.test.ts
+++ b/src/subagent/persistence.test.ts
@@ -1,0 +1,235 @@
+// src/subagent/persistence.test.ts — adapter + recorder tests.
+import { describe, it, expect, vi } from "vitest";
+import {
+  eventToMessage,
+  terminalEventPatch,
+  createSubagentRecorder,
+  subagentAgentId,
+} from "./persistence.js";
+import type { SubagentEvent } from "./types.js";
+import type { SessionStore, Message, Session } from "../core/types.js";
+
+describe("subagentAgentId", () => {
+  it("namespaces virtual agentId by parent + task", () => {
+    expect(subagentAgentId("dev", "subagent-1-12345")).toBe("subagent:dev:subagent-1-12345");
+  });
+});
+
+describe("eventToMessage", () => {
+  it("returns undefined for control events", () => {
+    expect(eventToMessage({ type: "start" })).toBeUndefined();
+    expect(eventToMessage({ type: "done", exitCode: 0 })).toBeUndefined();
+  });
+
+  it("converts message events to assistant text", () => {
+    const msg = eventToMessage({ type: "message", content: "hello" });
+    expect(msg?.role).toBe("assistant");
+    expect(msg?.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("skips empty messages", () => {
+    expect(eventToMessage({ type: "message", content: "" })).toBeUndefined();
+    expect(eventToMessage({ type: "message" })).toBeUndefined();
+  });
+
+  it("encodes tool_use as text with tool name + input", () => {
+    const msg = eventToMessage({
+      type: "tool_use",
+      toolName: "Read",
+      toolInput: { path: "x" },
+    });
+    expect(msg?.role).toBe("assistant");
+    const text = (msg?.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("🔧 Read(");
+    expect(text).toContain("\"path\"");
+  });
+
+  it("converts tool_result to tool_result block", () => {
+    const msg = eventToMessage({
+      type: "tool_result",
+      toolName: "Read",
+      toolResult: "file contents",
+    });
+    expect(msg?.role).toBe("tool_result");
+    expect(msg?.content[0]).toMatchObject({
+      type: "tool_result",
+      output: "file contents",
+      toolName: "Read",
+    });
+  });
+
+  it("flags error events in metadata", () => {
+    const msg = eventToMessage({ type: "error", error: "boom" });
+    expect(msg?.metadata?.error).toBe(true);
+    const text = (msg?.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("boom");
+  });
+
+  it("truncates oversized tool_result", () => {
+    const long = "x".repeat(10_000);
+    const msg = eventToMessage({ type: "tool_result", toolResult: long });
+    const block = msg?.content[0] as { type: "tool_result"; output: string };
+    expect(block.output.length).toBeLessThan(long.length);
+    expect(block.output.endsWith("…")).toBe(true);
+  });
+});
+
+describe("terminalEventPatch", () => {
+  it("extracts exitCode/cost from done", () => {
+    expect(terminalEventPatch({ type: "done", exitCode: 0, costUsd: 0.42 })).toEqual({
+      exitCode: 0,
+      costUsd: 0.42,
+    });
+  });
+
+  it("captures error from error event", () => {
+    expect(terminalEventPatch({ type: "error", error: "x" })).toEqual({ error: "x" });
+  });
+
+  it("returns undefined for non-terminal events", () => {
+    expect(terminalEventPatch({ type: "message", content: "hi" })).toBeUndefined();
+    expect(terminalEventPatch({ type: "start" })).toBeUndefined();
+  });
+});
+
+function fakeStore(): SessionStore & {
+  __session: Session;
+  __messages: Message[];
+} {
+  const session: Session = {
+    id: "sess-1",
+    agentId: "subagent:dev:task-1",
+    metadata: { transport: "subagent" },
+    lastActiveAt: new Date(),
+  };
+  const messages: Message[] = [];
+  return {
+    __session: session,
+    __messages: messages,
+    create: vi.fn(async (agentId, metadata) => {
+      session.agentId = agentId;
+      session.metadata = metadata;
+      return session;
+    }),
+    get: vi.fn(async () => session),
+    findByKey: vi.fn(async () => undefined),
+    addMessage: vi.fn(async (_id, msg) => {
+      messages.push(msg);
+    }),
+    getMessages: vi.fn(async () => [...messages]),
+    delete: vi.fn(async () => {}),
+    list: vi.fn(async () => [session]),
+    clearMessages: vi.fn(async () => {
+      messages.length = 0;
+    }),
+    setMessages: vi.fn(async (_id, msgs) => {
+      messages.length = 0;
+      messages.push(...msgs);
+    }),
+    setMetadata: vi.fn(async (_id, patch) => {
+      session.metadata = { ...(session.metadata ?? { transport: "subagent" }), ...patch };
+    }),
+  };
+}
+
+describe("createSubagentRecorder", () => {
+  it("is a no-op when no store is provided", async () => {
+    const r = await createSubagentRecorder({
+      parentAgentId: "dev",
+      taskId: "task-1",
+      backend: "claude",
+    });
+    expect(r.sessionId).toBeUndefined();
+    await r.record({ type: "message", content: "hi" });
+    await r.patchMetadata({ exitCode: 0 });
+  });
+
+  it("creates session with subagent metadata and persists events", async () => {
+    const store = fakeStore();
+    const r = await createSubagentRecorder({
+      store,
+      parentAgentId: "dev",
+      parentSessionId: "parent-sess",
+      taskId: "task-1",
+      backend: "claude",
+      cwd: "/work",
+      prompt: "do it",
+      channelId: "C1",
+      threadId: "T1",
+    });
+    expect(r.sessionId).toBe("sess-1");
+    expect(store.create).toHaveBeenCalledWith(
+      "subagent:dev:task-1",
+      expect.objectContaining({
+        transport: "subagent",
+        channelId: "C1",
+        threadId: "T1",
+        subagent: expect.objectContaining({
+          parentAgentId: "dev",
+          parentSessionId: "parent-sess",
+          taskId: "task-1",
+          backend: "claude",
+        }),
+      }),
+    );
+
+    const events: SubagentEvent[] = [
+      { type: "start" }, // skipped
+      { type: "message", content: "hi" },
+      { type: "tool_use", toolName: "Read", toolInput: { path: "x" } },
+      { type: "tool_result", toolName: "Read", toolResult: "ok" },
+      { type: "done", exitCode: 0, costUsd: 0.1 }, // skipped
+    ];
+    for (const e of events) await r.record(e);
+
+    expect(store.__messages).toHaveLength(3);
+    expect(store.__messages[0]?.role).toBe("assistant");
+    expect(store.__messages[2]?.role).toBe("tool_result");
+  });
+
+  it("merges terminal metadata under subagent and computes durationMs", async () => {
+    const store = fakeStore();
+    const r = await createSubagentRecorder({
+      store,
+      parentAgentId: "dev",
+      taskId: "task-9",
+      backend: "claude",
+    });
+    await r.patchMetadata({ exitCode: 0, costUsd: 0.5 });
+    expect(store.setMetadata).toHaveBeenCalled();
+    const patch = (store.setMetadata as ReturnType<typeof vi.fn>).mock.calls[0]![1];
+    expect(patch.subagent.exitCode).toBe(0);
+    expect(patch.subagent.costUsd).toBe(0.5);
+    expect(typeof patch.subagent.durationMs).toBe("number");
+    expect(patch.subagent.parentAgentId).toBe("dev");
+    expect(patch.subagent.taskId).toBe("task-9");
+  });
+
+  it("survives store failures without throwing", async () => {
+    const store = fakeStore();
+    (store.addMessage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("disk full"));
+    (store.setMetadata as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("disk full"));
+    const r = await createSubagentRecorder({
+      store,
+      parentAgentId: "dev",
+      taskId: "task-x",
+      backend: "claude",
+    });
+    await expect(r.record({ type: "message", content: "hi" })).resolves.toBeUndefined();
+    await expect(r.patchMetadata({ exitCode: 1, error: "x" })).resolves.toBeUndefined();
+  });
+
+  it("returns no-op recorder when store.create throws", async () => {
+    const store = fakeStore();
+    (store.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("nope"));
+    const r = await createSubagentRecorder({
+      store,
+      parentAgentId: "dev",
+      taskId: "task-x",
+      backend: "claude",
+    });
+    expect(r.sessionId).toBeUndefined();
+    await r.record({ type: "message", content: "hi" });
+    expect(store.addMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/subagent/persistence.ts
+++ b/src/subagent/persistence.ts
@@ -1,0 +1,237 @@
+// src/subagent/persistence.ts — Subagent run persistence helpers.
+//
+// Bridges the subagent event stream into the shared SessionStore so that
+// each run is recorded as a session keyed by a virtual agentId. See
+// docs/subagent-persistence.md for the design and conventions.
+
+import { createLogger } from "../core/logger.js";
+import type {
+  Message,
+  Session,
+  SessionMetadata,
+  SessionStore,
+  SubagentSessionMetadata,
+} from "../core/types.js";
+import type { SubagentEvent } from "./types.js";
+
+const log = createLogger("subagent:persistence");
+
+/** Build the virtual agentId used to key a subagent run's session. */
+export function subagentAgentId(parentAgentId: string, taskId: string): string {
+  return `subagent:${parentAgentId}:${taskId}`;
+}
+
+/** Maximum length of inlined tool input/output before truncation. */
+const MAX_INLINE_LEN = 4_000;
+
+function truncate(value: string, max = MAX_INLINE_LEN): string {
+  if (value.length <= max) return value;
+  return value.slice(0, max - 1) + "…";
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Convert one SubagentEvent into a Message suitable for SessionStore.
+ *
+ * Returns undefined for control events (start/done) — those drive
+ * session lifecycle and metadata, not transcript content.
+ *
+ * Tool calls are encoded as plain text for now (see issue #400 scope:
+ * structured tool_use blocks deferred). Tool results use the existing
+ * `tool_result` content block so downstream consumers can read them
+ * uniformly with main-agent transcripts.
+ */
+export function eventToMessage(event: SubagentEvent): Message | undefined {
+  const timestamp = Date.now();
+  switch (event.type) {
+    case "start":
+    case "done":
+      return undefined;
+
+    case "message": {
+      const text = event.content;
+      if (!text) return undefined;
+      return {
+        role: "assistant",
+        content: [{ type: "text", text }],
+        timestamp,
+      };
+    }
+
+    case "tool_use": {
+      const name = event.toolName ?? "tool";
+      const input = event.toolInput === undefined ? "" : truncate(safeStringify(event.toolInput));
+      const text = input ? `🔧 ${name}(${input})` : `🔧 ${name}()`;
+      return {
+        role: "assistant",
+        content: [{ type: "text", text }],
+        timestamp,
+        metadata: { subagentEvent: "tool_use", toolName: name },
+      };
+    }
+
+    case "tool_result": {
+      const output = truncate(event.toolResult ?? "");
+      return {
+        role: "tool_result",
+        content: [
+          {
+            type: "tool_result",
+            output,
+            toolName: event.toolName,
+          },
+        ],
+        timestamp,
+        metadata: { subagentEvent: "tool_result" },
+      };
+    }
+
+    case "error": {
+      const text = event.error ?? "Unknown error";
+      return {
+        role: "assistant",
+        content: [{ type: "text", text: `❌ ${text}` }],
+        timestamp,
+        metadata: { subagentEvent: "error", error: true },
+      };
+    }
+
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Extract a metadata patch from a terminal event (`done` / `error`).
+ * Returns undefined for non-terminal events.
+ */
+export function terminalEventPatch(event: SubagentEvent): Partial<SubagentSessionMetadata> | undefined {
+  if (event.type === "done") {
+    return {
+      exitCode: event.exitCode,
+      costUsd: event.costUsd,
+    };
+  }
+  if (event.type === "error") {
+    return {
+      error: event.error,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Bind a subagent run to a SessionStore. Returns helpers for the spawn
+ * loop to record events without leaking persistence concerns.
+ *
+ * If `store` is undefined (no persistence configured), every method
+ * becomes a no-op so callers don't need a null check.
+ */
+export interface SubagentRunRecorder {
+  /** Append one event to the run's transcript (no-op for control events). */
+  record(event: SubagentEvent): Promise<void>;
+  /** Merge fields into the run's session metadata.subagent. */
+  patchMetadata(patch: Partial<SubagentSessionMetadata>): Promise<void>;
+  /** sessionId of the underlying transcript, or undefined if disabled. */
+  sessionId?: string;
+}
+
+const NOOP_RECORDER: SubagentRunRecorder = {
+  async record() {},
+  async patchMetadata() {},
+};
+
+export interface CreateRecorderOptions {
+  store?: SessionStore;
+  parentAgentId: string;
+  parentSessionId?: string;
+  taskId: string;
+  backend: string;
+  cwd?: string;
+  prompt?: string;
+  channelId?: string;
+  threadId?: string;
+}
+
+export async function createSubagentRecorder(
+  options: CreateRecorderOptions,
+): Promise<SubagentRunRecorder> {
+  const { store } = options;
+  if (!store) return NOOP_RECORDER;
+
+  const subagentMeta: SubagentSessionMetadata = {
+    parentAgentId: options.parentAgentId,
+    parentSessionId: options.parentSessionId,
+    taskId: options.taskId,
+    backend: options.backend,
+    cwd: options.cwd,
+    prompt: options.prompt,
+  };
+  const metadata: SessionMetadata = {
+    transport: "subagent",
+    subagent: subagentMeta,
+    channelId: options.channelId,
+    threadId: options.threadId,
+  };
+
+  let session: Session;
+  try {
+    session = await store.create(subagentAgentId(options.parentAgentId, options.taskId), metadata);
+  } catch (err) {
+    log.warn("Failed to create subagent session, persistence disabled for this run", {
+      taskId: options.taskId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NOOP_RECORDER;
+  }
+
+  const sessionId = session.id;
+  const startedAt = Date.now();
+
+  return {
+    sessionId,
+    async record(event) {
+      const message = eventToMessage(event);
+      if (!message) return;
+      try {
+        await store.addMessage(sessionId, message);
+      } catch (err) {
+        log.warn("Failed to persist subagent event", {
+          sessionId,
+          taskId: options.taskId,
+          eventType: event.type,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    async patchMetadata(patch) {
+      try {
+        const current = await store.get(sessionId);
+        const prev = current?.metadata?.subagent ?? subagentMeta;
+        const durationMs =
+          patch.durationMs === undefined && (patch.exitCode !== undefined || patch.error !== undefined)
+            ? Date.now() - startedAt
+            : patch.durationMs;
+        const merged: SubagentSessionMetadata = {
+          ...prev,
+          ...patch,
+          ...(durationMs !== undefined ? { durationMs } : {}),
+        };
+        await store.setMetadata(sessionId, { subagent: merged });
+      } catch (err) {
+        log.warn("Failed to patch subagent metadata", {
+          sessionId,
+          taskId: options.taskId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+  };
+}

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -10,6 +10,8 @@ import {
   type SubagentEvent,
 } from "../subagent/index.js";
 import { taskRegistry } from "../subagent/task-registry.js";
+import { createSubagentRecorder } from "../subagent/persistence.js";
+import type { SessionStore } from "../core/types.js";
 import type { SubagentPermissionMode } from "../core/config.js";
 
 const log = createLogger("tools:subagent");
@@ -48,6 +50,8 @@ export interface SpawnSubagentOptions {
   channelId?: string;
   /** Thread ID where subagent streams output (for /stop support) */
   threadId?: string;
+  /** Parent agent id, used as the owner of the persisted subagent session. */
+  parentAgentId?: string;
 }
 
 /** Result from spawning a sub-agent */
@@ -71,6 +75,18 @@ let sharedBackendKey: string | undefined;
 
 /** Cached backend config */
 let backendConfig: SubagentBackendConfig = {};
+
+/** Optional SessionStore for persisting subagent runs (set by app startup). */
+let subagentSessionStore: SessionStore | undefined;
+
+/**
+ * Register the SessionStore used to persist subagent run transcripts.
+ * Pass `undefined` to disable persistence (default). Calling without
+ * a store leaves spawnSubagent() functionally unchanged.
+ */
+export function setSubagentSessionStore(store: SessionStore | undefined): void {
+  subagentSessionStore = store;
+}
 
 /**
  * Initialize the subagent backend with configuration.
@@ -157,6 +173,21 @@ export async function spawnSubagent(
     taskRegistry.setThreadId(taskId, options.threadId);
   }
 
+  // Bind to SessionStore (no-op when no store has been registered).
+  const recorder = await createSubagentRecorder({
+    store: subagentSessionStore,
+    parentAgentId: options.parentAgentId ?? "unknown",
+    parentSessionId: options.sessionId,
+    taskId,
+    backend: agent,
+    cwd: options.cwd,
+    prompt,
+    channelId: options.channelId,
+    threadId: options.threadId,
+  });
+
+  const startedAt = Date.now();
+
   try {
     const events = backend.spawn(taskId, {
       agent,
@@ -172,6 +203,7 @@ export async function spawnSubagent(
     for await (const event of events) {
       collected.push(event);
       options.onEvent?.(event);
+      await recorder.record(event);
     }
 
     // Build result from collected events
@@ -181,6 +213,13 @@ export async function spawnSubagent(
       taskId,
       success: result.success,
       exitCode: result.exitCode,
+    });
+
+    await recorder.patchMetadata({
+      exitCode: result.exitCode,
+      costUsd: collected.find((e) => e.costUsd !== undefined)?.costUsd,
+      durationMs: Date.now() - startedAt,
+      ...(result.error ? { error: result.error } : {}),
     });
 
     taskRegistry.unregister(taskId);
@@ -195,6 +234,12 @@ export async function spawnSubagent(
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     log.error("Sub-agent failed", { taskId, error });
+
+    await recorder.patchMetadata({
+      exitCode: 1,
+      error,
+      durationMs: Date.now() - startedAt,
+    });
 
     taskRegistry.unregister(taskId);
 


### PR DESCRIPTION
## Summary
- Records each subagent run as its own session keyed by `subagent:<parentAgentId>:<taskId>`, reusing `DefaultSessionStore` (openclaw-style virtual agentId) so subagent and main-agent transcripts share one storage path.
- Adds a `SubagentEvent → Message` adapter and a fail-safe recorder; lifecycle metadata (`exitCode`, `costUsd`, `durationMs`, `error`) lands via the new `SessionStore.setMetadata`.
- `cli.ts` mounts a dedicated store at `~/.isotopes/subagent-sessions` when `config.subagent.enabled` is true. Future backends (e.g. the built-in one in #399) inherit persistence for free — they just emit `SubagentEvent`s.
- See `docs/subagent-persistence.md` for the design and conventions.

Closes #400

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `npx vitest run src/subagent/persistence.test.ts src/core/session-store.test.ts` — 58 tests pass (16 new persistence + 42 session-store including new setMetadata block)
- [x] Full `npx vitest run` — all test files green

🤖 Generated with [Claude Code](https://claude.com/claude-code)