### PR TITLE
feat: ink-based TUI for interactive chat and daemon status

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "build": "tsc",
     "dev": "tsx src/cli.ts",
     "start": "node dist/cli.js",
-    "lint": "eslint src --ext .ts",
-    "lint:fix": "eslint src --ext .ts --fix",
+    "lint": "eslint src --ext .ts,.tsx",
+    "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@eslint/js": "9.27.0",
     "@types/node": "22.15.18",
+    "@types/react": "^19.2.14",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
     "@vitest/coverage-v8": "^3.1.3",
@@ -75,10 +76,12 @@
     "@mariozechner/pi-agent-core": "^0.64.0",
     "@mariozechner/pi-ai": "^0.64.0",
     "discord.js": "^14.18.0",
+    "ink": "^5.2.1",
+    "react": "^18.3.1",
     "yaml": "2.7.1"
   },
   "lint-staged": {
-    "*.ts": [
+    "*.{ts,tsx}": [
       "eslint --fix",
       "bash -c 'pnpm typecheck'"
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       discord.js:
         specifier: ^14.18.0
         version: 14.26.2
+      ink:
+        specifier: ^5.2.1
+        version: 5.2.1(@types/react@19.2.14)(react@18.3.1)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
       yaml:
         specifier: 2.7.1
         version: 2.7.1
@@ -33,6 +39,9 @@ importers:
       '@types/node':
         specifier: 22.15.18
         version: 22.15.18
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
       '@typescript-eslint/eslint-plugin':
         specifier: 8.32.1
         version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.27.0)(typescript@5.8.3))(eslint@9.27.0)(typescript@5.8.3)
@@ -65,6 +74,10 @@ importers:
         version: 3.1.3(@types/node@22.15.18)(tsx@4.19.4)(yaml@2.7.1)
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.1.3':
+    resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
+    engines: {node: '>=14.13.1'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1007,6 +1020,9 @@ packages:
   '@types/node@22.15.18':
     resolution: {integrity: sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==}
 
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
@@ -1167,6 +1183,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
@@ -1239,13 +1259,29 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
   cli-truncate@5.2.0:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1268,9 +1304,16 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -1353,10 +1396,17 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1621,6 +1671,23 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
+  ink@5.2.1:
+    resolution: {integrity: sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+      react-devtools-core: ^4.19.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -1633,6 +1700,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
@@ -1640,6 +1711,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-in-ci@1.0.0:
+    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -1666,6 +1742,9 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -1738,6 +1817,10 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1780,6 +1863,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -1827,6 +1914,10 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -1877,6 +1968,10 @@ packages:
 
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1942,6 +2037,16 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-reconciler@0.29.2:
+    resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1952,6 +2057,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -1978,6 +2087,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -2011,9 +2123,16 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
 
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
@@ -2042,6 +2161,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2145,6 +2268,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typescript-eslint@8.32.1:
     resolution: {integrity: sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==}
@@ -2259,6 +2386,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -2301,6 +2432,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -2310,6 +2444,11 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.1.3':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -3515,6 +3654,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/retry@0.12.0': {}
 
   '@types/ws@8.18.1':
@@ -3712,6 +3855,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  auto-bind@5.0.1: {}
+
   axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
@@ -3782,14 +3927,29 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  cli-boxes@3.0.0: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
+
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
 
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
       string-width: 8.2.0
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -3807,11 +3967,15 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-to-spaces@2.0.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -3891,6 +4055,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  es-toolkit@1.45.1: {}
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -3919,6 +4085,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4217,11 +4385,48 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@5.0.0: {}
+
+  ink@5.2.1(@types/react@19.2.14)(react@18.3.1):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.1.3
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 4.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.45.1
+      indent-string: 5.0.0
+      is-in-ci: 1.0.0
+      patch-console: 2.0.0
+      react: 18.3.1
+      react-reconciler: 0.29.2(react@18.3.1)
+      scheduler: 0.23.2
+      signal-exit: 3.0.7
+      slice-ansi: 7.1.2
+      stack-utils: 2.0.6
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.20.0
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ip-address@10.1.0: {}
 
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@4.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
@@ -4230,6 +4435,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-in-ci@1.0.0: {}
 
   is-number@7.0.0: {}
 
@@ -4261,6 +4468,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -4345,6 +4554,10 @@ snapshots:
 
   long@5.3.2: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -4382,6 +4595,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@2.1.0: {}
+
   mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
@@ -4415,6 +4630,10 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   object-inspect@1.13.4: {}
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   onetime@7.0.0:
     dependencies:
@@ -4472,6 +4691,8 @@ snapshots:
       callsites: 3.1.0
 
   partial-json@0.1.7: {}
+
+  patch-console@2.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -4540,11 +4761,26 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-reconciler@0.29.2(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   restore-cursor@5.1.0:
     dependencies:
@@ -4594,6 +4830,10 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
   semver@7.7.4: {}
 
   shebang-command@2.0.0:
@@ -4632,7 +4872,14 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
+
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
 
   slice-ansi@7.1.2:
     dependencies:
@@ -4663,6 +4910,10 @@ snapshots:
 
   source-map@0.6.1:
     optional: true
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -4756,6 +5007,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   typescript-eslint@8.32.1(eslint@9.27.0)(typescript@5.8.3):
     dependencies:
@@ -4864,6 +5117,10 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
@@ -4891,6 +5148,8 @@ snapshots:
   yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,6 @@ import "./core/claude-settings-init.js";
 import { parseArgs } from "node:util";
 import path from "node:path";
 import { VERSION } from "./version.js";
-import type { Message } from "./core/types.js";
 import {
   loadConfig,
   toAgentConfig,
@@ -116,6 +115,7 @@ const { values, positionals } = parseArgs({
     config: { type: "string", short: "c" },
     agent: { type: "string" },
     json: { type: "boolean" },
+    message: { type: "string" },
     lines: { type: "string" },
     level: { type: "string" },
     follow: { type: "boolean", short: "f" },
@@ -138,8 +138,8 @@ Usage:
   isotopes restart [--config path]   Restart the daemon
   isotopes reload [agentId]          Reload workspace (hot-reload)
 
-  isotopes chat "prompt" [--agent id] [--json]
-                                     One-shot chat with an agent
+  isotopes tui [--agent id] [--message "text"]
+                                     Interactive TUI chat with an agent
 
   isotopes sessions list             List all sessions
   isotopes sessions show <id>        Show session details
@@ -165,8 +165,9 @@ Options:
   -h, --help       Show this help
   -v, --version    Show version
   -c, --config     Path to config file
-  --agent          Agent ID for chat command
-  --json           Output chat response as JSON
+  --agent          Agent ID for tui command
+  --message        Send an initial message in TUI mode
+  --json           Output as JSON (sessions, cron commands)
   --lines          Number of log lines (default: 50)
   --level          Filter logs by level (debug/info/warn/error)
   -f, --follow     Follow log output
@@ -336,93 +337,6 @@ async function handleServiceCommand(): Promise<void> {
           `Usage: isotopes service install|uninstall|enable|disable`,
       );
       process.exit(1);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Chat command — one-shot chat with an agent
-// ---------------------------------------------------------------------------
-
-async function handleChatCommand(): Promise<void> {
-  const prompt = positionals[0];
-
-  if (!prompt) {
-    console.error("Usage: isotopes chat \"your prompt here\" [--agent id] [--json]");
-    process.exit(1);
-  }
-
-  // Load config
-  const configPath = values.config ?? getConfigPath();
-  const config = await loadConfig(configPath);
-
-  if (config.agents.length === 0) {
-    console.error("No agents configured");
-    process.exit(1);
-  }
-
-  // Determine which agent to use
-  const agentId = values.agent ?? config.agents[0]?.id;
-  const agentFile = config.agents.find((a) => a.id === agentId);
-
-  if (!agentFile) {
-    console.error(`Agent not found: ${agentId}`);
-    console.error(`Available agents: ${config.agents.map((a) => a.id).join(", ")}`);
-    process.exit(1);
-  }
-
-  // Convert to agent config and load workspace
-  const agentConfig = toAgentConfig(agentFile, config.agentDefaults, config.provider, config.tools, config.compaction, config.sandbox);
-
-  // Resolve workspace path
-  let workspacePath: string;
-  if (agentFile.workspace) {
-    const resolved = resolveExplicitWorkspacePath(agentFile.workspace);
-    workspacePath = await ensureExplicitWorkspaceDir(resolved);
-  } else {
-    const isSingleAgent = config.agents.length === 1;
-    const workspaceKey = isSingleAgent ? "default" : agentFile.id;
-    workspacePath = await ensureWorkspaceDir(workspaceKey);
-  }
-
-  await ensureWorkspaceStructure(workspacePath);
-  const workspaceContext = await loadWorkspaceContext(workspacePath, { bundledPath: resolveBundledSkillsDir() });
-
-  // Build system prompt (no extra options needed for CLI chat)
-  const agentSystemPrompt = buildSystemPrompt(agentConfig.systemPrompt, workspaceContext);
-
-  // Create agent via PiMonoCore
-  const core = new PiMonoCore();
-  const agentManager = new DefaultAgentManager(core);
-
-  const agent = await agentManager.create({
-    ...agentConfig,
-    systemPrompt: agentSystemPrompt,
-  });
-
-  // Stream the response
-  let responseText = "";
-  const userMessage: Message = {
-    role: "user",
-    content: [{ type: "text", text: prompt }],
-  };
-  const events = agent.prompt([userMessage]);
-
-  for await (const event of events) {
-    if (event.type === "text_delta") {
-      if (!values.json) {
-        process.stdout.write(event.text);
-      }
-      responseText += event.text;
-    }
-  }
-
-  if (values.json) {
-    console.log(JSON.stringify({ agent: agentId, prompt, response: responseText }));
-  } else {
-    // Ensure newline at end
-    if (!responseText.endsWith("\n")) {
-      console.log();
-    }
   }
 }
 
@@ -1241,9 +1155,11 @@ async function run(): Promise<void> {
       await handleServiceCommand();
       break;
 
-    case "chat":
-      await handleChatCommand();
+    case "tui": {
+      const { launchTui } = await import("./tui/index.js");
+      await launchTui({ agent: values.agent, config: values.config, message: values.message });
       break;
+    }
 
     case "sessions":
       await handleSessionsCommand();

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from "react";
+import { ChatScreen } from "./ChatScreen.js";
+import { StatusScreen } from "./StatusScreen.js";
+import type { Screen, TuiOptions } from "./types.js";
+
+interface Props {
+  options: TuiOptions;
+}
+
+export function App({ options }: Props) {
+  const [screen, setScreen] = useState<Screen>("chat");
+
+  if (screen === "status") {
+    return <StatusScreen onSwitchScreen={setScreen} />;
+  }
+
+  return <ChatScreen options={options} onSwitchScreen={setScreen} />;
+}

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -1,0 +1,215 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { Box, Text, useInput, useApp } from "ink";
+import type { Message, AgentInstance } from "../core/types.js";
+import { loadConfig, toAgentConfig } from "../core/config.js";
+import { PiMonoCore } from "../core/pi-mono.js";
+import { DefaultAgentManager } from "../core/agent-manager.js";
+import {
+  getConfigPath,
+  ensureExplicitWorkspaceDir,
+  ensureWorkspaceDir,
+  resolveExplicitWorkspacePath,
+} from "../core/paths.js";
+import {
+  loadWorkspaceContext,
+  buildSystemPrompt,
+  ensureWorkspaceStructure,
+} from "../core/workspace.js";
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
+import { parseSlashCommand, dispatch, HELP_TEXT } from "./commands.js";
+import type { ChatMessage, ToolCallEntry, TuiOptions, Screen } from "./types.js";
+
+const MAX_VISIBLE_MESSAGES = 50;
+
+interface Props {
+  options: TuiOptions;
+  onSwitchScreen: (screen: Screen) => void;
+}
+
+export function ChatScreen({ options, onSwitchScreen }: Props) {
+  const { exit } = useApp();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [agentReady, setAgentReady] = useState(false);
+  const [agentId, setAgentId] = useState(options.agent ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const agentRef = useRef<AgentInstance | null>(null);
+  const historyRef = useRef<Message[]>([]);
+  const autoMessageSent = useRef(false);
+
+  const initAgent = useCallback(async (requestedAgent?: string) => {
+    setAgentReady(false);
+    setError(null);
+    try {
+      const configPath = options.config ?? getConfigPath();
+      const config = await loadConfig(configPath);
+      if (config.agents.length === 0) {
+        setError("No agents configured");
+        return;
+      }
+      const id = requestedAgent ?? config.agents[0]?.id;
+      const agentFile = config.agents.find((a) => a.id === id);
+      if (!agentFile) {
+        setError(`Agent "${id}" not found. Available: ${config.agents.map((a) => a.id).join(", ")}`);
+        return;
+      }
+      setAgentId(agentFile.id);
+      const agentConfig = toAgentConfig(agentFile, config.agentDefaults, config.provider, config.tools, config.compaction, config.sandbox);
+      let workspacePath: string;
+      if (agentFile.workspace) {
+        workspacePath = await ensureExplicitWorkspaceDir(resolveExplicitWorkspacePath(agentFile.workspace));
+      } else {
+        const key = config.agents.length === 1 ? "default" : agentFile.id;
+        workspacePath = await ensureWorkspaceDir(key);
+      }
+      await ensureWorkspaceStructure(workspacePath);
+      const wsCtx = await loadWorkspaceContext(workspacePath, { bundledPath: resolveBundledSkillsDir() });
+      const systemPrompt = buildSystemPrompt(agentConfig.systemPrompt, wsCtx);
+      const core = new PiMonoCore();
+      const mgr = new DefaultAgentManager(core);
+      agentRef.current = await mgr.create({ ...agentConfig, systemPrompt });
+      historyRef.current = [];
+      setAgentReady(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [options.config]);
+
+  useEffect(() => {
+    void initAgent(options.agent);
+  }, []);
+
+  useEffect(() => {
+    if (agentReady && options.message && !autoMessageSent.current) {
+      autoMessageSent.current = true;
+      void sendMessage(options.message);
+    }
+  }, [agentReady]);
+
+  const sendMessage = async (text: string) => {
+    if (!agentRef.current || isStreaming) return;
+    const userMsg: ChatMessage = { role: "user", content: text, timestamp: new Date() };
+    setMessages((prev) => [...prev, userMsg]);
+    historyRef.current.push({ role: "user", content: [{ type: "text", text }] });
+    setIsStreaming(true);
+    let responseText = "";
+    const toolCalls: ToolCallEntry[] = [];
+    try {
+      for await (const event of agentRef.current.prompt(historyRef.current)) {
+        if (event.type === "text_delta") {
+          responseText += event.text;
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.role === "assistant") {
+              return [...prev.slice(0, -1), { ...last, content: responseText, toolCalls: [...toolCalls] }];
+            }
+            return [...prev, { role: "assistant", content: responseText, toolCalls: [...toolCalls], timestamp: new Date() }];
+          });
+        } else if (event.type === "tool_call") {
+          toolCalls.push({ id: event.id, name: event.name, args: typeof event.args === "string" ? event.args : JSON.stringify(event.args) });
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.role === "assistant") {
+              return [...prev.slice(0, -1), { ...last, toolCalls: [...toolCalls] }];
+            }
+            return prev;
+          });
+        } else if (event.type === "tool_result") {
+          const tc = toolCalls.find((t) => t.id === event.id);
+          if (tc) {
+            tc.result = event.output;
+            tc.isError = event.isError;
+          }
+        } else if (event.type === "error") {
+          setMessages((prev) => [...prev, { role: "system", content: `Error: ${event.error}`, timestamp: new Date() }]);
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setMessages((prev) => [...prev, { role: "system", content: `Error: ${msg}`, timestamp: new Date() }]);
+    }
+    if (responseText) {
+      historyRef.current.push({ role: "assistant", content: [{ type: "text", text: responseText }] });
+    }
+    setIsStreaming(false);
+  };
+
+  const handleSubmit = () => {
+    const text = input.trim();
+    if (!text) return;
+    setInput("");
+    const slash = parseSlashCommand(text);
+    if (slash) {
+      const handled = dispatch(slash.command, slash.args, {
+        onNewChat: () => {
+          setMessages([]);
+          historyRef.current = [];
+          setMessages([{ role: "system", content: "New conversation started.", timestamp: new Date() }]);
+        },
+        onSwitchAgent: (id) => void initAgent(id),
+        onExit: () => exit(),
+        onShowStatus: () => onSwitchScreen("status"),
+        onShowChat: () => {},
+        onHelp: () => setMessages((prev) => [...prev, { role: "system", content: HELP_TEXT, timestamp: new Date() }]),
+      });
+      if (!handled) {
+        setMessages((prev) => [...prev, { role: "system", content: `Unknown command: /${slash.command}`, timestamp: new Date() }]);
+      }
+      return;
+    }
+    void sendMessage(text);
+  };
+
+  useInput((ch, key) => {
+    if (isStreaming) return;
+    if (key.return) {
+      handleSubmit();
+    } else if (key.backspace || key.delete) {
+      setInput((prev) => prev.slice(0, -1));
+    } else if (key.ctrl && ch === "c") {
+      exit();
+    } else if (ch && !key.ctrl && !key.meta) {
+      setInput((prev) => prev + ch);
+    }
+  });
+
+  const visible = messages.slice(-MAX_VISIBLE_MESSAGES);
+
+  return (
+    <Box flexDirection="column" height={process.stdout.rows}>
+      <Box borderStyle="single" paddingX={1}>
+        <Text bold>isotopes</Text>
+        <Text> — agent: </Text>
+        <Text color="cyan">{agentId || "loading..."}</Text>
+        {isStreaming && <Text color="yellow"> (streaming...)</Text>}
+      </Box>
+
+      <Box flexDirection="column" flexGrow={1} paddingX={1}>
+        {error && <Text color="red">{error}</Text>}
+        {!agentReady && !error && <Text color="gray">Loading agent...</Text>}
+        {visible.map((msg, i) => (
+          <Box key={i} flexDirection="column">
+            <Text>
+              <Text color={msg.role === "user" ? "green" : msg.role === "assistant" ? "blue" : "gray"} bold>
+                {msg.role === "user" ? "You" : msg.role === "assistant" ? "Agent" : "System"}
+              </Text>
+              <Text>: {msg.content}</Text>
+            </Text>
+            {msg.toolCalls?.map((tc) => (
+              <Text key={tc.id} color="gray" dimColor>
+                {"  "}🔧 {tc.name}{tc.result ? ` → ${tc.result.slice(0, 80)}` : " ..."}
+              </Text>
+            ))}
+          </Box>
+        ))}
+      </Box>
+
+      <Box borderStyle="single" paddingX={1}>
+        <Text color="green">&gt; </Text>
+        <Text>{input}</Text>
+        <Text color="gray">█</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/StatusScreen.tsx
+++ b/src/tui/StatusScreen.tsx
@@ -1,0 +1,129 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+import { fetchStatus, fetchSessions, fetchUsage, isDaemonRunning } from "./api.js";
+import type { DaemonStatus, SessionSummary, UsageStats, Screen } from "./types.js";
+
+interface Props {
+  onSwitchScreen: (screen: Screen) => void;
+}
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86_400);
+  const h = Math.floor((seconds % 86_400) / 3_600);
+  const m = Math.floor((seconds % 3_600) / 60);
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  if (parts.length === 0) parts.push(`${Math.floor(seconds)}s`);
+  return parts.join(" ");
+}
+
+function formatCost(cost: number): string {
+  return cost < 0.01 ? `$${cost.toFixed(4)}` : `$${cost.toFixed(2)}`;
+}
+
+export function StatusScreen({ onSwitchScreen }: Props) {
+  const [status, setStatus] = useState<DaemonStatus | null>(null);
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [usage, setUsage] = useState<UsageStats | null>(null);
+  const [running, setRunning] = useState<boolean | null>(null);
+  const [lastRefresh, setLastRefresh] = useState<Date>(new Date());
+
+  const refresh = async () => {
+    const isUp = await isDaemonRunning();
+    setRunning(isUp);
+    if (isUp) {
+      try {
+        const [s, sess, u] = await Promise.all([fetchStatus(), fetchSessions(), fetchUsage()]);
+        setStatus(s);
+        setSessions(sess);
+        setUsage(u);
+      } catch {
+        // partial failure ok
+      }
+    }
+    setLastRefresh(new Date());
+  };
+
+  useEffect(() => {
+    void refresh();
+    const timer = setInterval(() => void refresh(), 5000);
+    return () => clearInterval(timer);
+  }, []);
+
+  useInput((ch, key) => {
+    if (ch === "q" || ch === "/") {
+      onSwitchScreen("chat");
+    }
+    if (ch === "r") {
+      void refresh();
+    }
+    if (key.ctrl && ch === "c") {
+      process.exit(0);
+    }
+  });
+
+  if (running === null) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="gray">Checking daemon status...</Text>
+      </Box>
+    );
+  }
+
+  if (!running) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text bold color="red">Daemon not running</Text>
+        <Text color="gray">Start with: isotopes start</Text>
+        <Text />
+        <Text dimColor>Press q or / to return to chat</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" height={process.stdout.rows}>
+      <Box borderStyle="single" paddingX={1}>
+        <Text bold>isotopes — status</Text>
+        <Text color="gray"> (refreshed {lastRefresh.toLocaleTimeString()})</Text>
+      </Box>
+
+      <Box flexDirection="column" flexGrow={1} paddingX={1} gap={1}>
+        {status && (
+          <Box flexDirection="column">
+            <Text bold underline>Daemon</Text>
+            <Text>  Version: <Text color="cyan">{status.version}</Text></Text>
+            <Text>  Uptime:  <Text color="cyan">{formatUptime(status.uptime)}</Text></Text>
+            <Text>  Cron:    <Text color="cyan">{status.cronJobs} job(s)</Text></Text>
+          </Box>
+        )}
+
+        {usage && (
+          <Box flexDirection="column">
+            <Text bold underline>Usage</Text>
+            <Text>  Tokens: <Text color="cyan">{usage.totalTokens.toLocaleString()}</Text> ({usage.input.toLocaleString()} in / {usage.output.toLocaleString()} out)</Text>
+            <Text>  Cost:   <Text color="cyan">{formatCost(usage.cost)}</Text> ({usage.turns} turns)</Text>
+          </Box>
+        )}
+
+        <Box flexDirection="column">
+          <Text bold underline>Sessions ({sessions.length})</Text>
+          {sessions.length === 0 && <Text color="gray">  No active sessions</Text>}
+          {sessions.slice(0, 20).map((s) => (
+            <Text key={s.id}>
+              {"  "}<Text color="cyan">{s.agentId}</Text>
+              <Text color="gray"> [{s.source}] {s.id.slice(0, 8)}… {s.lastActivityAt ? new Date(s.lastActivityAt).toLocaleTimeString() : ""}</Text>
+            </Text>
+          ))}
+          {sessions.length > 20 && <Text color="gray">  ... and {sessions.length - 20} more</Text>}
+        </Box>
+      </Box>
+
+      <Box borderStyle="single" paddingX={1}>
+        <Text dimColor>q/← return to chat  r refresh  Ctrl+C quit</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/api.test.ts
+++ b/src/tui/api.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchStatus, fetchSessions, fetchUsage, isDaemonRunning } from "./api.js";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchStatus", () => {
+  it("returns parsed status", async () => {
+    const data = { version: "0.0.2", uptime: 123, cronJobs: 2 };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(data) });
+    const result = await fetchStatus();
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith("http://127.0.0.1:2712/api/status");
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: "Internal" });
+    await expect(fetchStatus()).rejects.toThrow("API /api/status: 500 Internal");
+  });
+});
+
+describe("fetchSessions", () => {
+  it("returns session list", async () => {
+    const data = [{ id: "s1", agentId: "bot", source: "discord", status: "active", lastActivityAt: "" }];
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(data) });
+    const result = await fetchSessions();
+    expect(result).toEqual(data);
+  });
+});
+
+describe("fetchUsage", () => {
+  it("returns usage stats", async () => {
+    const data = { totalTokens: 100, input: 50, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.01, turns: 5 };
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(data) });
+    const result = await fetchUsage();
+    expect(result).toEqual(data);
+  });
+});
+
+describe("isDaemonRunning", () => {
+  it("returns true when daemon responds", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    expect(await isDaemonRunning()).toBe(true);
+  });
+
+  it("returns false when fetch fails", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await isDaemonRunning()).toBe(false);
+  });
+});

--- a/src/tui/api.ts
+++ b/src/tui/api.ts
@@ -1,0 +1,37 @@
+import type { DaemonStatus, SessionSummary, UsageStats } from "./types.js";
+
+const DEFAULT_PORT = 2712;
+
+function getBaseUrl(): string {
+  const port = process.env.ISOTOPES_PORT
+    ? parseInt(process.env.ISOTOPES_PORT, 10)
+    : DEFAULT_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${getBaseUrl()}${path}`);
+  if (!res.ok) throw new Error(`API ${path}: ${res.status} ${res.statusText}`);
+  return res.json() as Promise<T>;
+}
+
+export async function fetchStatus(): Promise<DaemonStatus> {
+  return fetchJson<DaemonStatus>("/api/status");
+}
+
+export async function fetchSessions(): Promise<SessionSummary[]> {
+  return fetchJson<SessionSummary[]>("/api/sessions");
+}
+
+export async function fetchUsage(): Promise<UsageStats> {
+  return fetchJson<UsageStats>("/api/usage");
+}
+
+export async function isDaemonRunning(): Promise<boolean> {
+  try {
+    await fetchStatus();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { parseSlashCommand, dispatch } from "./commands.js";
+
+describe("parseSlashCommand", () => {
+  it("returns null for plain text", () => {
+    expect(parseSlashCommand("hello world")).toBeNull();
+  });
+
+  it("parses command without args", () => {
+    expect(parseSlashCommand("/exit")).toEqual({ command: "exit", args: "" });
+  });
+
+  it("parses command with args", () => {
+    expect(parseSlashCommand("/agent mybot")).toEqual({ command: "agent", args: "mybot" });
+  });
+
+  it("trims whitespace", () => {
+    expect(parseSlashCommand("  /help  ")).toEqual({ command: "help", args: "" });
+  });
+
+  it("lowercases command", () => {
+    expect(parseSlashCommand("/EXIT")).toEqual({ command: "exit", args: "" });
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseSlashCommand("")).toBeNull();
+  });
+
+  it("preserves arg casing", () => {
+    expect(parseSlashCommand("/agent MyBot")).toEqual({ command: "agent", args: "MyBot" });
+  });
+});
+
+describe("dispatch", () => {
+  const calls: string[] = [];
+  const callbacks = {
+    onNewChat: () => calls.push("new"),
+    onSwitchAgent: (id: string) => calls.push(`agent:${id}`),
+    onExit: () => calls.push("exit"),
+    onShowStatus: () => calls.push("status"),
+    onShowChat: () => calls.push("chat"),
+    onHelp: () => calls.push("help"),
+  };
+
+  beforeEach(() => { calls.length = 0; });
+
+  it("dispatches /new", () => {
+    expect(dispatch("new", "", callbacks)).toBe(true);
+    expect(calls).toEqual(["new"]);
+  });
+
+  it("dispatches /agent with args", () => {
+    expect(dispatch("agent", "mybot", callbacks)).toBe(true);
+    expect(calls).toEqual(["agent:mybot"]);
+  });
+
+  it("returns false for /agent without args", () => {
+    expect(dispatch("agent", "", callbacks)).toBe(false);
+  });
+
+  it("dispatches /exit and aliases", () => {
+    expect(dispatch("exit", "", callbacks)).toBe(true);
+    expect(dispatch("quit", "", callbacks)).toBe(true);
+    expect(dispatch("q", "", callbacks)).toBe(true);
+    expect(calls).toEqual(["exit", "exit", "exit"]);
+  });
+
+  it("returns false for unknown command", () => {
+    expect(dispatch("unknown", "", callbacks)).toBe(false);
+  });
+});

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -1,0 +1,66 @@
+export interface SlashCommand {
+  command: string;
+  args: string;
+}
+
+export function parseSlashCommand(input: string): SlashCommand | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/")) return null;
+  const spaceIdx = trimmed.indexOf(" ");
+  if (spaceIdx === -1) {
+    return { command: trimmed.slice(1).toLowerCase(), args: "" };
+  }
+  return {
+    command: trimmed.slice(1, spaceIdx).toLowerCase(),
+    args: trimmed.slice(spaceIdx + 1).trim(),
+  };
+}
+
+export interface CommandCallbacks {
+  onNewChat: () => void;
+  onSwitchAgent: (agentId: string) => void;
+  onExit: () => void;
+  onShowStatus: () => void;
+  onShowChat: () => void;
+  onHelp: () => void;
+}
+
+export function dispatch(
+  command: string,
+  args: string,
+  callbacks: CommandCallbacks,
+): boolean {
+  switch (command) {
+    case "new":
+      callbacks.onNewChat();
+      return true;
+    case "agent":
+      if (!args) return false;
+      callbacks.onSwitchAgent(args);
+      return true;
+    case "exit":
+    case "quit":
+    case "q":
+      callbacks.onExit();
+      return true;
+    case "status":
+      callbacks.onShowStatus();
+      return true;
+    case "chat":
+      callbacks.onShowChat();
+      return true;
+    case "help":
+      callbacks.onHelp();
+      return true;
+    default:
+      return false;
+  }
+}
+
+export const HELP_TEXT = [
+  "/new          — Start a new conversation",
+  "/agent <id>   — Switch to a different agent",
+  "/status       — Show daemon status",
+  "/help         — Show this help",
+  "/exit         — Quit the TUI",
+].join("\n");

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render } from "ink";
+import { App } from "./App.js";
+import type { TuiOptions } from "./types.js";
+
+export async function launchTui(values: {
+  agent?: string;
+  config?: string;
+  message?: string;
+}): Promise<void> {
+  const options: TuiOptions = {
+    agent: values.agent,
+    config: values.config,
+    message: values.message,
+  };
+
+  const { waitUntilExit } = render(<App options={options} />);
+  await waitUntilExit();
+}

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -1,0 +1,46 @@
+export interface ChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+  toolCalls?: ToolCallEntry[];
+  timestamp: Date;
+}
+
+export interface ToolCallEntry {
+  id: string;
+  name: string;
+  args: string;
+  result?: string;
+  isError?: boolean;
+}
+
+export interface DaemonStatus {
+  version: string;
+  uptime: number;
+  cronJobs: number;
+}
+
+export interface SessionSummary {
+  id: string;
+  agentId: string;
+  source: string;
+  status: string;
+  lastActivityAt: string;
+}
+
+export interface UsageStats {
+  totalTokens: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: number;
+  turns: number;
+}
+
+export type Screen = "chat" | "status";
+
+export interface TuiOptions {
+  agent?: string;
+  config?: string;
+  message?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Add `isotopes tui` — ink-based terminal UI with two screens:
  - **Chat**: multi-turn streaming, tool call display, slash commands, `--message` auto-send
  - **Status**: read-only daemon monitoring (uptime, sessions, usage, cron)
- Delete `isotopes chat` one-shot command (replaced by `isotopes tui --message`)
- Add ink ^5, react ^18 dependencies; configure JSX in tsconfig
- Extend ESLint/lint-staged to cover `.tsx` files

## Stats

| Area | LOC |
|---|---|
| TUI production code | 530 |
| TUI tests | 128 |
| Deleted (one-shot chat) | -85 |
| **Net new** | ~573 |

## New files

```
src/tui/
├── types.ts          — type definitions (46 LOC)
├── commands.ts       — slash command parser + dispatch (66 LOC)
├── api.ts            — REST client for daemon status (37 LOC)
├── App.tsx           — root component, screen routing (18 LOC)
├── ChatScreen.tsx    — chat with streaming + agent setup (215 LOC)
├── StatusScreen.tsx  — read-only daemon status (129 LOC)
├── index.tsx         — entry point, launchTui() (19 LOC)
├── commands.test.ts  — 12 tests
└── api.test.ts       — 6 tests
```

## Test plan

- [x] `pnpm typecheck` — passes with JSX config
- [x] `pnpm lint` — no warnings (now covers .tsx)
- [x] TUI tests: 18/18 pass (commands + API client)
- [x] Existing tests: 530/530 pass (no regressions)
- [ ] Manual: `isotopes tui` → type message → streamed response
- [ ] Manual: `isotopes tui --message "hello"` → auto-send
- [ ] Manual: `/status` → daemon info, `/new` → reset, `/exit` → quit

Closes #416
Refs #410, #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)