### PR TITLE
refactor(storage): align session storage with openclaw layout

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,10 +12,11 @@ import {
   resolveSubagentConfig,
   resolveSandboxConfigFromFile,
 } from "./core/config.js";
-import { initSubagentBackend, setSubagentSessionStore } from "./tools/subagent.js";
+import { initSubagentBackend, setSubagentSessionStoreFactory } from "./tools/subagent.js";
 import { PiMonoCore } from "./core/pi-mono.js";
 import { DefaultAgentManager } from "./core/agent-manager.js";
 import { DefaultSessionStore } from "./core/session-store.js";
+import { SessionStoreManager } from "./core/session-store-manager.js";
 import { DiscordTransportManager } from "./transports/discord-manager.js";
 import { ThreadBindingManager } from "./core/thread-bindings.js";
 import { logger } from "./core/logger.js";
@@ -37,8 +38,6 @@ import {
   ensureDirectories,
   ensureExplicitWorkspaceDir,
   ensureWorkspaceDir,
-  getSessionsDir,
-  getSubagentSessionsDir,
   getThreadBindingsPath,
   resolveExplicitWorkspacePath,
 } from "./core/paths.js";
@@ -689,8 +688,13 @@ async function main() {
   const config = await loadConfig(configPath);
   logger.info(`Loaded ${config.agents.length} agent(s)`);
 
+  // Single SessionStoreManager backs both main-agent transcripts and
+  // subagent run transcripts. Each store lives at
+  // ~/.isotopes/agents/<normalizedAgentId>/sessions/. See
+  // docs/subagent-architecture.md §4.4.
+  const sessionStoreManager = new SessionStoreManager();
+
   // Initialize subagent backend with config (M8)
-  let subagentRunStore: DefaultSessionStore | undefined;
   if (config.subagent?.enabled) {
     const subagentConfig = resolveSubagentConfig(config.subagent);
     initSubagentBackend({
@@ -700,16 +704,10 @@ async function main() {
     });
     logger.info(`Subagent backend initialized (permissionMode: ${subagentConfig.permissionMode})`);
 
-    // Persist subagent run transcripts to ~/.isotopes/subagent-sessions.
-    // The store is shared across all parent agents — each run is keyed by
-    // a virtual agentId (`subagent:<parentAgentId>:<taskId>`).
-    const subagentSessionStore = new DefaultSessionStore({
-      dataDir: getSubagentSessionsDir(),
-    });
-    await subagentSessionStore.init();
-    setSubagentSessionStore(subagentSessionStore);
-    subagentRunStore = subagentSessionStore;
-    logger.info(`Subagent session transcripts → ${getSubagentSessionsDir()}`);
+    // Subagent runs are persisted in their target agent's sessions dir;
+    // the factory resolves the right store on each spawn.
+    setSubagentSessionStoreFactory((agentId) => sessionStoreManager.getOrCreate(agentId));
+    logger.info("Subagent session transcripts → ~/.isotopes/agents/<targetAgentId>/sessions/");
   }
 
   // Initialize core with tool registry
@@ -986,32 +984,19 @@ async function main() {
     if (Object.keys(accounts).length === 0) {
       logger.warn("channels.discord present but no accounts configured — skipping");
     } else {
-      // Create session store per agent (sessions live in workspace)
+      // Pre-warm one store per configured agent via the manager so the
+      // sync sessionStoreForAgent callback always finds a store.
       const sessionStores = new Map<string, DefaultSessionStore>();
-
       for (const agentFile of config.agents) {
-        const workspacePath = agentWorkspaces.get(agentFile.id);
-        const sessionsDir = workspacePath ? path.join(workspacePath, "sessions") : getSessionsDir(agentFile.id);
-        sessionStores.set(agentFile.id, new DefaultSessionStore({ dataDir: sessionsDir }));
+        sessionStores.set(agentFile.id, await sessionStoreManager.getOrCreate(agentFile.id));
       }
-
-      await Promise.all([...sessionStores.values()].map((store) => store.init()));
       discordSessionStores = sessionStores;
 
       // Pick a default session store: first account's defaultAgentId, else first agent
       const firstAccount = Object.values(accounts)[0];
-      const defaultAgentId = firstAccount?.defaultAgentId || config.agents[0]?.id;
-      let defaultSessionStore = sessionStores.get(defaultAgentId);
-      if (!defaultSessionStore) {
-        const fallbackWorkspace = agentWorkspaces.get(defaultAgentId || "default");
-        const fallbackSessionsDir = fallbackWorkspace
-          ? path.join(fallbackWorkspace, "sessions")
-          : getSessionsDir(defaultAgentId || "default");
-        defaultSessionStore = new DefaultSessionStore({
-          dataDir: fallbackSessionsDir,
-        });
-        await defaultSessionStore.init();
-      }
+      const defaultAgentId = firstAccount?.defaultAgentId || config.agents[0]?.id || "default";
+      const defaultSessionStore =
+        sessionStores.get(defaultAgentId) ?? (await sessionStoreManager.getOrCreate(defaultAgentId));
 
       // Create and load persistent thread binding manager (shared across accounts)
       const threadBindingManager = new ThreadBindingManager({
@@ -1027,7 +1012,8 @@ async function main() {
         shared: {
           agentManager,
           sessionStore: defaultSessionStore,
-          sessionStoreForAgent: (agentId) => sessionStores.get(agentId) || defaultSessionStore,
+          sessionStoreForAgent: (agentId) =>
+            sessionStoreManager.peek(agentId) ?? sessionStores.get(agentId) ?? defaultSessionStore,
           channels: config.channels,
           threadBindingManager,
           usageTracker,
@@ -1077,12 +1063,7 @@ async function main() {
     await apiServer.stop();
 
     // Clean up session stores (#286)
-    if (discordSessionStores) {
-      for (const store of discordSessionStores.values()) {
-        store.destroy();
-      }
-    }
-    subagentRunStore?.destroy();
+    sessionStoreManager.destroyAll();
 
     // Kill orphaned background processes (#286, #289)
     for (const registry of processRegistries.values()) {
@@ -1110,12 +1091,7 @@ async function main() {
     await apiServer.stop();
 
     // Clean up session stores (#286)
-    if (discordSessionStores) {
-      for (const store of discordSessionStores.values()) {
-        store.destroy();
-      }
-    }
-    subagentRunStore?.destroy();
+    sessionStoreManager.destroyAll();
 
     // Kill orphaned background processes (#286, #289)
     for (const registry of processRegistries.values()) {

--- a/src/core/paths.test.ts
+++ b/src/core/paths.test.ts
@@ -8,12 +8,14 @@ import {
   getIsotopesHome,
   getLogsDir,
   getWorkspacePath,
-  getSessionsDir,
+  getAgentSessionsDir,
+  normalizeAgentId,
   getConfigPath,
   getThreadBindingsPath,
   ensureDirectories,
   ensureWorkspaceDir,
   ensureExplicitWorkspaceDir,
+  ensureAgentSessionsDir,
   resolveExplicitWorkspacePath,
 } from "./paths.js";
 
@@ -57,15 +59,22 @@ describe("paths", () => {
     });
   });
 
-  describe("getSessionsDir", () => {
-    it("returns sessions dir inside default workspace", () => {
-      const expected = path.join(os.homedir(), ".isotopes", "workspace", "sessions");
-      expect(getSessionsDir("default")).toBe(expected);
+  describe("normalizeAgentId", () => {
+    it("lowercases and replaces unsafe chars", () => {
+      expect(normalizeAgentId("Alice")).toBe("alice");
+      expect(normalizeAgentId("a/b:c")).toBe("a-b-c");
+    });
+  });
+
+  describe("getAgentSessionsDir", () => {
+    it("returns ~/.isotopes/agents/<id>/sessions", () => {
+      const expected = path.join(os.homedir(), ".isotopes", "agents", "alice", "sessions");
+      expect(getAgentSessionsDir("alice")).toBe(expected);
     });
 
-    it("returns sessions dir inside named workspace", () => {
-      const expected = path.join(os.homedir(), ".isotopes", "workspace-assistant", "sessions");
-      expect(getSessionsDir("assistant")).toBe(expected);
+    it("normalizes the agent id segment", () => {
+      const expected = path.join(os.homedir(), ".isotopes", "agents", "code-reviewer-v2", "sessions");
+      expect(getAgentSessionsDir("Code:Reviewer/v2")).toBe(expected);
     });
   });
 
@@ -145,7 +154,7 @@ describe("paths", () => {
   });
 
   describe("ensureWorkspaceDir", () => {
-    it("creates workspace and sessions dirs for default agent and returns workspace path", async () => {
+    it("creates workspace dir for default agent and returns its path", async () => {
       const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "isotopes-paths-"));
       const home = path.join(tmp, "home");
       vi.stubEnv("ISOTOPES_HOME", home);
@@ -153,7 +162,6 @@ describe("paths", () => {
         const ws = await ensureWorkspaceDir("default");
         expect(ws).toBe(path.join(home, "workspace"));
         await expect(fs.stat(ws)).resolves.toMatchObject({});
-        await expect(fs.stat(path.join(ws, "sessions"))).resolves.toMatchObject({});
       } finally {
         await fs.rm(tmp, { recursive: true, force: true });
       }
@@ -166,7 +174,7 @@ describe("paths", () => {
       try {
         const ws = await ensureWorkspaceDir("assistant");
         expect(ws).toBe(path.join(home, "workspace-assistant"));
-        await expect(fs.stat(path.join(ws, "sessions"))).resolves.toMatchObject({});
+        await expect(fs.stat(ws)).resolves.toMatchObject({});
       } finally {
         await fs.rm(tmp, { recursive: true, force: true });
       }
@@ -174,14 +182,28 @@ describe("paths", () => {
   });
 
   describe("ensureExplicitWorkspaceDir", () => {
-    it("creates the resolved path and a sessions/ subdirectory", async () => {
+    it("creates the resolved path", async () => {
       const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "isotopes-paths-"));
       const ws = path.join(tmp, "explicit-ws");
       try {
         const result = await ensureExplicitWorkspaceDir(ws);
         expect(result).toBe(ws);
         await expect(fs.stat(ws)).resolves.toMatchObject({});
-        await expect(fs.stat(path.join(ws, "sessions"))).resolves.toMatchObject({});
+      } finally {
+        await fs.rm(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("ensureAgentSessionsDir", () => {
+    it("creates ~/.isotopes/agents/<id>/sessions and returns it", async () => {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "isotopes-paths-"));
+      const home = path.join(tmp, "home");
+      vi.stubEnv("ISOTOPES_HOME", home);
+      try {
+        const dir = await ensureAgentSessionsDir("alice");
+        expect(dir).toBe(path.join(home, "agents", "alice", "sessions"));
+        await expect(fs.stat(dir)).resolves.toMatchObject({});
       } finally {
         await fs.rm(tmp, { recursive: true, force: true });
       }

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -52,19 +52,29 @@ export function getWorkspacePath(agentId: string): string {
 }
 
 /**
- * Get the sessions directory for an agent (inside workspace).
+ * Normalize an agentId for use as a filesystem directory name.
+ * Lowercases and replaces any character outside `[a-z0-9_-]` with `-`.
  */
-export function getSessionsDir(agentId: string): string {
-  return path.join(getWorkspacePath(agentId), "sessions");
+export function normalizeAgentId(agentId: string): string {
+  return agentId.toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
 }
 
 /**
- * Get the directory holding subagent run transcripts.
- * One JSONL per run lives under here (keyed by virtual agentId =
- * `subagent:<parentAgentId>:<taskId>`). See docs/subagent-persistence.md.
+ * Get the sessions directory for an agent.
+ *
+ * All transcripts (main agent + subagent runs targeting this agent) live
+ * under `~/.isotopes/agents/<normalizedAgentId>/sessions/`. See
+ * docs/subagent-architecture.md §4.4.
  */
-export function getSubagentSessionsDir(): string {
-  return path.join(getIsotopesHome(), "subagent-sessions");
+export function getAgentSessionsDir(agentId: string): string {
+  return path.join(getIsotopesHome(), "agents", normalizeAgentId(agentId), "sessions");
+}
+
+/** Ensure an agent's sessions directory exists, returning its absolute path. */
+export async function ensureAgentSessionsDir(agentId: string): Promise<string> {
+  const dir = getAgentSessionsDir(agentId);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,17 +126,14 @@ export function resolveExplicitWorkspacePath(workspacePath: string): string {
 export async function ensureWorkspaceDir(agentId: string): Promise<string> {
   const workspacePath = getWorkspacePath(agentId);
   await fs.mkdir(workspacePath, { recursive: true });
-  await fs.mkdir(getSessionsDir(agentId), { recursive: true });
   return workspacePath;
 }
 
 /**
  * Ensure an explicit workspace directory exists (#214).
- * Creates the workspace and a sessions/ subdirectory.
  */
 export async function ensureExplicitWorkspaceDir(resolvedPath: string): Promise<string> {
   await fs.mkdir(resolvedPath, { recursive: true });
-  await fs.mkdir(path.join(resolvedPath, "sessions"), { recursive: true });
   return resolvedPath;
 }
 

--- a/src/core/session-store-manager.test.ts
+++ b/src/core/session-store-manager.test.ts
@@ -1,0 +1,105 @@
+// src/core/session-store-manager.test.ts
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+import { SessionStoreManager } from "./session-store-manager.js";
+import { getAgentSessionsDir, normalizeAgentId } from "./paths.js";
+
+let tmpRoot: string;
+let originalHome: string | undefined;
+
+beforeEach(async () => {
+  originalHome = process.env.ISOTOPES_HOME;
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "isotopes-store-mgr-"));
+  process.env.ISOTOPES_HOME = tmpRoot;
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) {
+    delete process.env.ISOTOPES_HOME;
+  } else {
+    process.env.ISOTOPES_HOME = originalHome;
+  }
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("normalizeAgentId", () => {
+  it("lowercases and replaces unsafe chars with -", () => {
+    expect(normalizeAgentId("Alice")).toBe("alice");
+    expect(normalizeAgentId("subagent:dev:task")).toBe("subagent-dev-task");
+    expect(normalizeAgentId("a/b\\c")).toBe("a-b-c");
+    expect(normalizeAgentId("code-reviewer_v2")).toBe("code-reviewer_v2");
+  });
+});
+
+describe("SessionStoreManager.getOrCreate", () => {
+  it("creates a store rooted at the per-agent sessions dir", async () => {
+    const mgr = new SessionStoreManager();
+    const store = await mgr.getOrCreate("alice");
+    const expected = getAgentSessionsDir("alice");
+    expect(expected).toBe(path.join(tmpRoot, "agents", "alice", "sessions"));
+    const stat = await fs.stat(expected);
+    expect(stat.isDirectory()).toBe(true);
+    expect(store).toBeDefined();
+    mgr.destroyAll();
+  });
+
+  it("memoizes by normalized id", async () => {
+    const mgr = new SessionStoreManager();
+    const a = await mgr.getOrCreate("Alice");
+    const b = await mgr.getOrCreate("ALICE");
+    const c = await mgr.getOrCreate("alice");
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    mgr.destroyAll();
+  });
+
+  it("coalesces concurrent inits for the same id", async () => {
+    const mgr = new SessionStoreManager();
+    const [a, b] = await Promise.all([
+      mgr.getOrCreate("bob"),
+      mgr.getOrCreate("bob"),
+    ]);
+    expect(a).toBe(b);
+    mgr.destroyAll();
+  });
+
+  it("isolates stores per agent", async () => {
+    const mgr = new SessionStoreManager();
+    const alice = await mgr.getOrCreate("alice");
+    const bob = await mgr.getOrCreate("bob");
+    expect(alice).not.toBe(bob);
+    mgr.destroyAll();
+  });
+});
+
+describe("SessionStoreManager.peek + all + destroyAll", () => {
+  it("peek returns undefined before getOrCreate", async () => {
+    const mgr = new SessionStoreManager();
+    expect(mgr.peek("alice")).toBeUndefined();
+    await mgr.getOrCreate("alice");
+    expect(mgr.peek("Alice")).toBeDefined();
+    mgr.destroyAll();
+  });
+
+  it("all() snapshots initialized stores", async () => {
+    const mgr = new SessionStoreManager();
+    await mgr.getOrCreate("alice");
+    await mgr.getOrCreate("bob");
+    const snap = mgr.all();
+    expect(snap.size).toBe(2);
+    expect(snap.has("alice")).toBe(true);
+    expect(snap.has("bob")).toBe(true);
+    mgr.destroyAll();
+  });
+
+  it("destroyAll empties the registry", async () => {
+    const mgr = new SessionStoreManager();
+    await mgr.getOrCreate("alice");
+    mgr.destroyAll();
+    expect(mgr.all().size).toBe(0);
+    expect(mgr.peek("alice")).toBeUndefined();
+  });
+});

--- a/src/core/session-store-manager.ts
+++ b/src/core/session-store-manager.ts
@@ -1,0 +1,98 @@
+// src/core/session-store-manager.ts — Per-agentId SessionStore registry
+//
+// One DefaultSessionStore per agentId, rooted at
+// ~/.isotopes/agents/<normalizedAgentId>/sessions/. Used by both the main
+// agent write path (via DiscordTransport / sessionStoreForAgent) and the
+// subagent write path (via createSubagentRecorder). See
+// docs/subagent-architecture.md §4.4.
+
+import { DefaultSessionStore } from "./session-store.js";
+import {
+  ensureAgentSessionsDir,
+  getAgentSessionsDir,
+  normalizeAgentId,
+} from "./paths.js";
+import type { SessionConfig } from "./types.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("session-store-manager");
+
+export interface SessionStoreManagerOptions {
+  /** Per-store session config (TTL, cleanup interval). */
+  session?: SessionConfig;
+  /** Per-store maxSessions cap (defaults to DefaultSessionStore default). */
+  maxSessions?: number;
+  /** Per-store maxTotalSizeMB cap (defaults to DefaultSessionStore default). */
+  maxTotalSizeMB?: number;
+}
+
+/**
+ * Lazily creates and memoizes one DefaultSessionStore per normalized
+ * agentId. Stores are not init()'d until requested.
+ */
+export class SessionStoreManager {
+  private stores = new Map<string, DefaultSessionStore>();
+  private inits = new Map<string, Promise<DefaultSessionStore>>();
+
+  constructor(private readonly opts: SessionStoreManagerOptions = {}) {}
+
+  /**
+   * Get or create the store for an agentId. Returns a fully init()'d store.
+   * Concurrent calls for the same agentId share one initialization.
+   */
+  async getOrCreate(agentId: string): Promise<DefaultSessionStore> {
+    const key = normalizeAgentId(agentId);
+
+    const existing = this.stores.get(key);
+    if (existing) return existing;
+
+    const pending = this.inits.get(key);
+    if (pending) return pending;
+
+    const init = (async () => {
+      const dataDir = await ensureAgentSessionsDir(agentId);
+      const store = new DefaultSessionStore({
+        dataDir,
+        ...(this.opts.maxSessions !== undefined ? { maxSessions: this.opts.maxSessions } : {}),
+        ...(this.opts.maxTotalSizeMB !== undefined ? { maxTotalSizeMB: this.opts.maxTotalSizeMB } : {}),
+        ...(this.opts.session ? { session: this.opts.session } : {}),
+      });
+      await store.init();
+      this.stores.set(key, store);
+      this.inits.delete(key);
+      log.debug(`Initialized session store for agent ${agentId} at ${dataDir}`);
+      return store;
+    })();
+
+    this.inits.set(key, init);
+    return init;
+  }
+
+  /**
+   * Synchronous lookup — returns the store if it has already been created,
+   * otherwise undefined. Use this in hot paths that already know the store
+   * exists; otherwise prefer getOrCreate().
+   */
+  peek(agentId: string): DefaultSessionStore | undefined {
+    return this.stores.get(normalizeAgentId(agentId));
+  }
+
+  /** Snapshot of all currently-initialized stores keyed by normalizedId. */
+  all(): Map<string, DefaultSessionStore> {
+    return new Map(this.stores);
+  }
+
+  /** Tear down every initialized store. Safe to call multiple times. */
+  destroyAll(): void {
+    for (const store of this.stores.values()) {
+      store.destroy();
+    }
+    this.stores.clear();
+    this.inits.clear();
+  }
+
+  /** Convenience: directory path the store for `agentId` would use. */
+  static dirFor(agentId: string): string {
+    return getAgentSessionsDir(agentId);
+  }
+}

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -582,8 +582,7 @@ describe("DefaultSessionStore", () => {
 
   describe("setMetadata", () => {
     it("merges patch into existing metadata and persists to index", async () => {
-      const session = await store.create("subagent:dev:task-1", {
-        transport: "subagent",
+      const session = await store.create("dev", {
         subagent: {
           parentAgentId: "dev",
           taskId: "task-1",
@@ -613,13 +612,6 @@ describe("DefaultSessionStore", () => {
       expect(reloaded?.metadata?.subagent?.exitCode).toBe(0);
       expect(reloaded?.metadata?.subagent?.durationMs).toBe(1234);
       reopened.destroy();
-    });
-
-    it("rejects dropping the required transport field", async () => {
-      const session = await store.create("agent-1");
-      await expect(
-        store.setMetadata(session.id, { transport: undefined }),
-      ).rejects.toThrow(/transport/);
     });
 
     it("throws on unknown sessionId", async () => {

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -225,9 +225,6 @@ export class DefaultSessionStore implements SessionStore {
 
     const prevKey = session.metadata?.key;
     const merged = { ...(session.metadata ?? {}), ...patch } as SessionMetadata;
-    if (!merged.transport) {
-      throw new Error(`setMetadata: cannot drop required "transport" field on session "${sessionId}"`);
-    }
 
     // Maintain key index if the key changed.
     if (prevKey && prevKey !== merged.key) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -215,7 +215,7 @@ export interface Session {
   lastActiveAt: Date;
 }
 
-/** Per-run metadata for a subagent session (only set when transport === 'subagent'). */
+/** Per-run metadata for a subagent session (presence flags this as a subagent run). */
 export interface SubagentSessionMetadata {
   parentAgentId: string;
   parentSessionId?: string;
@@ -230,17 +230,22 @@ export interface SubagentSessionMetadata {
   error?: string;
 }
 
-/** Transport-specific metadata attached to a session (channel, thread, etc.). */
+/**
+ * Session metadata. `transport` is set for sessions originating from a chat
+ * transport (discord/feishu/web). Subagent runs have `subagent` populated
+ * and no `transport` — use `metadata.subagent !== undefined` as the
+ * discriminator.
+ */
 export interface SessionMetadata {
   key?: string;                        // Unique key for session lookup (e.g., discord:{botId}:channel:{id}:{agentId})
-  transport: 'discord' | 'feishu' | 'web' | 'subagent';
+  transport?: 'discord' | 'feishu' | 'web';
   channelId?: string;
   channelName?: string;
   guildName?: string;
   threadId?: string;
   /** If true, session is exempt from TTL-based cleanup */
   persistent?: boolean;
-  /** Subagent run metadata (only present when transport === 'subagent'). */
+  /** Subagent run metadata; presence indicates the session backs a subagent run. */
   subagent?: SubagentSessionMetadata;
 }
 

--- a/src/subagent/persistence.test.ts
+++ b/src/subagent/persistence.test.ts
@@ -4,14 +4,22 @@ import {
   eventToMessage,
   terminalEventPatch,
   createSubagentRecorder,
-  subagentAgentId,
+  buildSubagentSessionKey,
 } from "./persistence.js";
 import type { SubagentEvent } from "./types.js";
 import type { SessionStore, Message, Session } from "../core/types.js";
 
-describe("subagentAgentId", () => {
-  it("namespaces virtual agentId by parent + task", () => {
-    expect(subagentAgentId("dev", "subagent-1-12345")).toBe("subagent:dev:subagent-1-12345");
+describe("buildSubagentSessionKey", () => {
+  it("produces the openclaw-style sessionKey", () => {
+    const key = buildSubagentSessionKey("code-reviewer");
+    expect(key.startsWith("agent:code-reviewer:subagent:")).toBe(true);
+    // suffix should be a UUID-shaped string (8-4-4-4-12)
+    const uuid = key.slice("agent:code-reviewer:subagent:".length);
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it("produces a fresh uuid each call", () => {
+    expect(buildSubagentSessionKey("alice")).not.toBe(buildSubagentSessionKey("alice"));
   });
 });
 
@@ -98,8 +106,8 @@ function fakeStore(): SessionStore & {
 } {
   const session: Session = {
     id: "sess-1",
-    agentId: "subagent:dev:task-1",
-    metadata: { transport: "subagent" },
+    agentId: "dev",
+    metadata: {},
     lastActiveAt: new Date(),
   };
   const messages: Message[] = [];
@@ -127,7 +135,7 @@ function fakeStore(): SessionStore & {
       messages.push(...msgs);
     }),
     setMetadata: vi.fn(async (_id, patch) => {
-      session.metadata = { ...(session.metadata ?? { transport: "subagent" }), ...patch };
+      session.metadata = { ...(session.metadata ?? {}), ...patch };
     }),
   };
 }
@@ -135,6 +143,7 @@ function fakeStore(): SessionStore & {
 describe("createSubagentRecorder", () => {
   it("is a no-op when no store is provided", async () => {
     const r = await createSubagentRecorder({
+      targetAgentId: "dev",
       parentAgentId: "dev",
       taskId: "task-1",
       backend: "claude",
@@ -144,10 +153,11 @@ describe("createSubagentRecorder", () => {
     await r.patchMetadata({ exitCode: 0 });
   });
 
-  it("creates session with subagent metadata and persists events", async () => {
+  it("creates session under the target agentId with subagent metadata", async () => {
     const store = fakeStore();
     const r = await createSubagentRecorder({
       store,
+      targetAgentId: "code-reviewer",
       parentAgentId: "dev",
       parentSessionId: "parent-sess",
       taskId: "task-1",
@@ -159,9 +169,9 @@ describe("createSubagentRecorder", () => {
     });
     expect(r.sessionId).toBe("sess-1");
     expect(store.create).toHaveBeenCalledWith(
-      "subagent:dev:task-1",
+      "code-reviewer",
       expect.objectContaining({
-        transport: "subagent",
+        key: expect.stringMatching(/^agent:code-reviewer:subagent:/),
         channelId: "C1",
         threadId: "T1",
         subagent: expect.objectContaining({
@@ -172,6 +182,7 @@ describe("createSubagentRecorder", () => {
         }),
       }),
     );
+    expect(store.__session.metadata?.transport).toBeUndefined();
 
     const events: SubagentEvent[] = [
       { type: "start" }, // skipped
@@ -187,10 +198,27 @@ describe("createSubagentRecorder", () => {
     expect(store.__messages[2]?.role).toBe("tool_result");
   });
 
+  it("respects a caller-provided sessionKey", async () => {
+    const store = fakeStore();
+    await createSubagentRecorder({
+      store,
+      targetAgentId: "alice",
+      parentAgentId: "alice",
+      taskId: "task-2",
+      backend: "claude",
+      sessionKey: "agent:alice:subagent:fixed-key",
+    });
+    expect(store.create).toHaveBeenCalledWith(
+      "alice",
+      expect.objectContaining({ key: "agent:alice:subagent:fixed-key" }),
+    );
+  });
+
   it("merges terminal metadata under subagent and computes durationMs", async () => {
     const store = fakeStore();
     const r = await createSubagentRecorder({
       store,
+      targetAgentId: "dev",
       parentAgentId: "dev",
       taskId: "task-9",
       backend: "claude",
@@ -211,6 +239,7 @@ describe("createSubagentRecorder", () => {
     (store.setMetadata as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("disk full"));
     const r = await createSubagentRecorder({
       store,
+      targetAgentId: "dev",
       parentAgentId: "dev",
       taskId: "task-x",
       backend: "claude",
@@ -224,6 +253,7 @@ describe("createSubagentRecorder", () => {
     (store.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("nope"));
     const r = await createSubagentRecorder({
       store,
+      targetAgentId: "dev",
       parentAgentId: "dev",
       taskId: "task-x",
       backend: "claude",

--- a/src/subagent/persistence.ts
+++ b/src/subagent/persistence.ts
@@ -1,8 +1,12 @@
 // src/subagent/persistence.ts — Subagent run persistence helpers.
 //
 // Bridges the subagent event stream into the shared SessionStore so that
-// each run is recorded as a session keyed by a virtual agentId. See
-// docs/subagent-persistence.md for the design and conventions.
+// each run is recorded as a session under the **target agent's** sessions
+// directory (real agentId, not a synthetic one). The "this is a subagent
+// run" signal lives in `sessionKey` (`agent:<targetId>:subagent:<uuid>`)
+// and in `metadata.subagent`. See docs/subagent-architecture.md §4.4.
+
+import { randomUUID } from "node:crypto";
 
 import { createLogger } from "../core/logger.js";
 import type {
@@ -16,9 +20,9 @@ import type { SubagentEvent } from "./types.js";
 
 const log = createLogger("subagent:persistence");
 
-/** Build the virtual agentId used to key a subagent run's session. */
-export function subagentAgentId(parentAgentId: string, taskId: string): string {
-  return `subagent:${parentAgentId}:${taskId}`;
+/** Build the default sessionKey for a subagent run. */
+export function buildSubagentSessionKey(targetAgentId: string): string {
+  return `agent:${targetAgentId}:subagent:${randomUUID()}`;
 }
 
 /** Maximum length of inlined tool input/output before truncation. */
@@ -149,7 +153,23 @@ const NOOP_RECORDER: SubagentRunRecorder = {
 };
 
 export interface CreateRecorderOptions {
+  /**
+   * Pre-resolved SessionStore for `targetAgentId`. Caller is responsible for
+   * obtaining this from the SessionStoreManager. Pass undefined to disable
+   * persistence for this run.
+   */
   store?: SessionStore;
+  /**
+   * Real agentId the run is recorded against. For named subagents this is
+   * the subagent's own id (e.g. `code-reviewer`); for anonymous/dynamic
+   * subagents the caller falls back to the parent agentId.
+   */
+  targetAgentId: string;
+  /**
+   * sessionKey to assign to the persisted session. Defaults to
+   * `agent:<targetAgentId>:subagent:<uuid>`.
+   */
+  sessionKey?: string;
   parentAgentId: string;
   parentSessionId?: string;
   taskId: string;
@@ -175,7 +195,7 @@ export async function createSubagentRecorder(
     prompt: options.prompt,
   };
   const metadata: SessionMetadata = {
-    transport: "subagent",
+    key: options.sessionKey ?? buildSubagentSessionKey(options.targetAgentId),
     subagent: subagentMeta,
     channelId: options.channelId,
     threadId: options.threadId,
@@ -183,10 +203,11 @@ export async function createSubagentRecorder(
 
   let session: Session;
   try {
-    session = await store.create(subagentAgentId(options.parentAgentId, options.taskId), metadata);
+    session = await store.create(options.targetAgentId, metadata);
   } catch (err) {
     log.warn("Failed to create subagent session, persistence disabled for this run", {
       taskId: options.taskId,
+      targetAgentId: options.targetAgentId,
       error: err instanceof Error ? err.message : String(err),
     });
     return NOOP_RECORDER;

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -54,6 +54,13 @@ export interface SpawnSubagentOptions {
   threadId?: string;
   /** Parent agent id, used as the owner of the persisted subagent session. */
   parentAgentId?: string;
+  /**
+   * Real agentId to record this run under. Named subagents pass their own
+   * id (e.g. `code-reviewer`); anonymous/dynamic subagents leave this
+   * unset and the recorder falls back to `parentAgentId`. See
+   * docs/subagent-architecture.md §4.4.
+   */
+  targetAgentId?: string;
 }
 
 /** Result from spawning a sub-agent */
@@ -78,16 +85,20 @@ let sharedBackendKey: string | undefined;
 /** Cached backend config */
 let backendConfig: SubagentBackendConfig = {};
 
-/** Optional SessionStore for persisting subagent runs (set by app startup). */
-let subagentSessionStore: SessionStore | undefined;
+/** Optional factory for resolving the SessionStore to use for a given target agentId. */
+let subagentStoreFactory: ((agentId: string) => Promise<SessionStore | undefined> | SessionStore | undefined) | undefined;
 
 /**
- * Register the SessionStore used to persist subagent run transcripts.
- * Pass `undefined` to disable persistence (default). Calling without
- * a store leaves spawnSubagent() functionally unchanged.
+ * Register a factory that resolves the SessionStore for a target agent's
+ * subagent runs. The factory is called once per spawn with the resolved
+ * `targetAgentId` (defaulted to `parentAgentId` for anonymous runs).
+ *
+ * Pass `undefined` to disable persistence (default).
  */
-export function setSubagentSessionStore(store: SessionStore | undefined): void {
-  subagentSessionStore = store;
+export function setSubagentSessionStoreFactory(
+  factory: ((agentId: string) => Promise<SessionStore | undefined> | SessionStore | undefined) | undefined,
+): void {
+  subagentStoreFactory = factory;
 }
 
 /**
@@ -176,10 +187,15 @@ export async function spawnSubagent(
     taskRegistry.setThreadId(taskId, options.threadId);
   }
 
-  // Bind to SessionStore (no-op when no store has been registered).
+  // Bind to SessionStore (no-op when no factory has been registered).
+  const parentAgentId = options.parentAgentId ?? "unknown";
+  const targetAgentId = options.targetAgentId ?? parentAgentId;
+  const store = subagentStoreFactory ? await subagentStoreFactory(targetAgentId) : undefined;
+
   const recorder = await createSubagentRecorder({
-    store: subagentSessionStore,
-    parentAgentId: options.parentAgentId ?? "unknown",
+    store,
+    targetAgentId,
+    parentAgentId,
     parentSessionId: options.sessionId,
     taskId,
     backend: agent,


### PR DESCRIPTION
## Summary
- Drop the parallel `~/.isotopes/subagent-sessions/` root and synthetic `subagent:<parent>:<task>` agentIds. All sessions now live under `~/.isotopes/agents/<normalizedAgentId>/sessions/`, owned by a single `SessionStoreManager` with per-agentId memoization.
- Subagent runs land in the target agent's directory (named subagents) or fall back to the parent agent's directory (anonymous). The "this is a subagent run" discriminator moves into `sessionKey` (`agent:<targetId>:subagent:<uuid>`) and `metadata.subagent`, replacing the old `transport === 'subagent'` branch.
- Prerequisite for the builtin subagent backend (#399) — once merged, builtin runs persist via the same path with no extra plumbing.

Closes #418

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] All refactor-touched tests pass: `paths.test.ts`, `session-store.test.ts`, `session-store-manager.test.ts` (new), `persistence.test.ts`, `tools/subagent.test.ts`
- [x] Grep confirms zero leftover references to `subagent-sessions`, `subagentAgentId`, `setSubagentSessionStore` (non-Factory), or `transport === 'subagent'`
- [ ] Manual: run `pnpm dev` against a config with one agent + subagent enabled; verify a JSONL appears under `~/.isotopes/agents/<agent-id>/sessions/` with `sessionKey: "agent:<agent-id>:subagent:<uuid>"`
- [ ] Manual: confirm `~/.isotopes/subagent-sessions/` is no longer created on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)