### PR TITLE
feat(subagent): add builtin in-process backend (#399)

### DIFF
--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -158,6 +158,8 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
     subagent?.maxTurns,
     fsImpl,
     agentConfig.id,
+    agentConfig.provider,
+    toolRegistry,
   );
   const filteredTools = applyToolPolicy(workspaceTools, agentConfig.toolSettings);
   for (const { tool, handler } of filteredTools) {

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -323,6 +323,14 @@ export class PiMonoCore implements AgentCore {
     this.toolRegistries.set(agentId, registry);
   }
 
+  /**
+   * Drop the tool registry binding for an agent id. Used by short-lived
+   * subagent runs to release per-spawn registries after the agent exits.
+   */
+  clearToolRegistry(agentId: string): void {
+    this.toolRegistries.delete(agentId);
+  }
+
   createAgent(config: AgentConfig): AgentInstance {
     const model = resolveModel(config);
 

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -63,6 +63,11 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   // SessionStoreManager backs both main-agent transcripts and subagent runs.
   const sessionStoreManager = new SessionStoreManager();
 
+  // Initialize core first — the builtin subagent backend hosts subagents
+  // in-process via this same core.
+  const core = new PiMonoCore();
+  const agentManager = new DefaultAgentManager(core);
+
   // Initialize subagent backend
   if (config.subagent?.enabled) {
     const subagentConfig = resolveSubagentConfig(config.subagent);
@@ -70,16 +75,13 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       permissionMode: subagentConfig.permissionMode,
       allowedTools: subagentConfig.allowedTools,
       claude: subagentConfig.claude,
+      core,
     });
     log.info(`Subagent backend initialized (permissionMode: ${subagentConfig.permissionMode})`);
 
     setSubagentSessionStoreFactory((agentId) => sessionStoreManager.getOrCreate(agentId));
     log.info("Subagent session store factory → shared SessionStoreManager");
   }
-
-  // Initialize core
-  const core = new PiMonoCore();
-  const agentManager = new DefaultAgentManager(core);
 
   const agentWorkspaces = new Map<string, string>();
   const transportContexts = new Map<string, LazyTransportContext>();

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -2,7 +2,7 @@
 // Manages tool definitions and their handlers.
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { AgentToolSettings, Tool } from "./types.js";
+import type { AgentToolSettings, ProviderConfig, Tool } from "./types.js";
 import type { FsLike } from "../sandbox/fs-bridge.js";
 import { spawnSubagent, getSupportedAgents } from "../tools/subagent.js";
 import { createWebFetchTool, createWebSearchTool } from "../tools/web.js";
@@ -156,6 +156,16 @@ export interface SubagentToolOptions {
   maxTurns?: number;
   /** Parent agent id, used as the owner of the persisted subagent run. */
   parentAgentId?: string;
+  /**
+   * Parent agent's provider config — forwarded to the builtin runner so
+   * in-process subagents reuse the parent's LLM credentials.
+   */
+  parentProvider?: ProviderConfig;
+  /**
+   * Parent agent's tool registry — forwarded to the builtin runner, which
+   * filters it by role to derive the subagent's tool set.
+   */
+  parentTools?: ToolRegistry;
 }
 /**
  * Create a sub-agent spawning tool.
@@ -166,9 +176,12 @@ export interface SubagentToolOptions {
  * posted to the main channel when complete.
  */
 export function createSubagentTool(options: SubagentToolOptions): { tool: Tool; handler: ToolHandler } {
-  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns, parentAgentId } = options;
+  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns, parentAgentId, parentProvider, parentTools } = options;
   const supportedAgents = getSupportedAgents();
-  const agents = allowedAgents ?? [...supportedAgents];
+  // Builtin requires parent provider + tools; drop it from the menu when those aren't wired.
+  const builtinAvailable = parentProvider !== undefined && parentTools !== undefined;
+  const supported = builtinAvailable ? supportedAgents : supportedAgents.filter((a) => a !== "builtin");
+  const agents = allowedAgents ?? [...supported];
   // Combine workspace path with additional allowed workspaces
   const allAllowedWorkspaces = [workspacePath, ...allowedWorkspaces];
   return {
@@ -225,13 +238,16 @@ export function createSubagentTool(options: SubagentToolOptions): { tool: Tool; 
       }
 
       try {
+        const builtin = agent === "builtin" && parentProvider && parentTools
+          ? { provider: parentProvider, tools: parentTools }
+          : undefined;
         let result: string;
         if (discordContext) {
           // Run with Discord streaming
-          result = await runSubagentWithDiscord(task, agent as SubagentAgent, cwd, timeout, allAllowedWorkspaces, discordContext, maxTurns, parentAgentId);
+          result = await runSubagentWithDiscord(task, agent as SubagentAgent, cwd, timeout, allAllowedWorkspaces, discordContext, maxTurns, parentAgentId, builtin);
         } else {
           // Run without Discord streaming (original behavior)
-          result = await runSubagentPlain(task, agent as SubagentAgent, cwd, timeout, allAllowedWorkspaces, maxTurns, parentAgentId);
+          result = await runSubagentPlain(task, agent as SubagentAgent, cwd, timeout, allAllowedWorkspaces, maxTurns, parentAgentId, builtin);
         }
 
         // Record failure if result indicates failure
@@ -262,6 +278,7 @@ async function runSubagentPlain(
   allowedWorkspaces: string[],
   maxTurns?: number,
   parentAgentId?: string,
+  builtin?: { provider: ProviderConfig; tools: ToolRegistry },
 ): Promise<string> {
   const result = await spawnSubagent(task, {
     agent,
@@ -270,6 +287,7 @@ async function runSubagentPlain(
     allowedWorkspaces,
     maxTurns,
     parentAgentId,
+    ...(builtin ? { builtin } : {}),
   });
   if (result.success) {
     return result.output ?? "[sub-agent completed with no output]";
@@ -290,6 +308,7 @@ async function runSubagentWithDiscord(
   context: NonNullable<ReturnType<typeof getSubagentContext>>,
   maxTurns?: number,
   parentAgentId?: string,
+  builtin?: { provider: ProviderConfig; tools: ToolRegistry },
 ): Promise<string> {
   const { sendMessage, createThread, channelId, showToolCalls = true, onComplete } = context;
   // Create Discord sink with thread enabled
@@ -324,6 +343,7 @@ async function runSubagentWithDiscord(
       channelId,
       threadId, // Pass threadId for /stop support in threads
       parentAgentId,
+      ...(builtin ? { builtin } : {}),
       onEvent: async (event) => {
         events.push(event);
         await sink.sendEvent(event);
@@ -825,6 +845,8 @@ export function createWorkspaceToolsWithGuards(
   subagentMaxTurns?: number,
   fsImpl?: FsLike,
   parentAgentId?: string,
+  parentProvider?: ProviderConfig,
+  parentTools?: ToolRegistry,
 ): { tool: Tool; handler: ToolHandler }[] {
   const guards = resolveToolGuards(settings);
   // Always use workspacePath as base for relative path resolution.
@@ -842,7 +864,7 @@ export function createWorkspaceToolsWithGuards(
     createTimeTool(),
   ];
   if (subagentEnabled) {
-    tools.push(createSubagentTool({ workspacePath, allowedWorkspaces, maxTurns: subagentMaxTurns, parentAgentId }));
+    tools.push(createSubagentTool({ workspacePath, allowedWorkspaces, maxTurns: subagentMaxTurns, parentAgentId, parentProvider, parentTools }));
   }
   // Web fetch tool
   if (settings?.web) {

--- a/src/subagent/backend.test.ts
+++ b/src/subagent/backend.test.ts
@@ -12,6 +12,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 }));
 
 import { SubagentBackend, mapSdkMessage, collectResult, MAX_CONCURRENT_AGENTS } from "./backend.js";
+import { ClaudeRunner } from "./runners/claude.js";
 import type { SubagentEvent } from "./types.js";
 
 describe("mapSdkMessage", () => {
@@ -177,10 +178,10 @@ describe("SubagentBackend", () => {
   });
 });
 
-describe("SubagentBackend.buildSdkOptions claude env", () => {
+describe("ClaudeRunner.buildSdkOptions claude env", () => {
   it("does not set env when no claude config given", () => {
-    const backend = new SubagentBackend({});
-    const opts = backend.buildSdkOptions(
+    const runner = new ClaudeRunner({});
+    const opts = runner.buildSdkOptions(
       { agent: "claude", cwd: "/tmp", prompt: "hi" },
       new AbortController(),
     );
@@ -190,24 +191,23 @@ describe("SubagentBackend.buildSdkOptions claude env", () => {
 
   it("injects ANTHROPIC_AUTH_TOKEN/BASE_URL via Options.env without mutating process.env", () => {
     const before = process.env.ANTHROPIC_AUTH_TOKEN;
-    const backend = new SubagentBackend({
+    const runner = new ClaudeRunner({
       claude: { authToken: "sk-test-123", baseUrl: "https://proxy.example/v1" },
     });
-    const opts = backend.buildSdkOptions(
+    const opts = runner.buildSdkOptions(
       { agent: "claude", cwd: "/tmp", prompt: "hi" },
       new AbortController(),
     );
     expect(opts.env?.ANTHROPIC_AUTH_TOKEN).toBe("sk-test-123");
     expect(opts.env?.ANTHROPIC_BASE_URL).toBe("https://proxy.example/v1");
-    // process.env is NOT mutated
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe(before);
   });
 
   it("forwards pathToClaudeCodeExecutable", () => {
-    const backend = new SubagentBackend({
+    const runner = new ClaudeRunner({
       claude: { pathToClaudeCodeExecutable: "/custom/claude" },
     });
-    const opts = backend.buildSdkOptions(
+    const opts = runner.buildSdkOptions(
       { agent: "claude", cwd: "/tmp", prompt: "hi" },
       new AbortController(),
     );

--- a/src/subagent/backend.ts
+++ b/src/subagent/backend.ts
@@ -1,139 +1,33 @@
-// src/subagent/backend.ts — Subagent spawning backend via @anthropic-ai/claude-agent-sdk
-// Wraps the SDK's query() so the main agent can delegate tasks to Claude Code
-// as a one-shot run, producing an event stream consumed by discord-sink, iteration, etc.
+// src/subagent/backend.ts — Subagent dispatcher
+// Validates the request, manages concurrency / timeout / abort, and delegates
+// the body of a run to the per-backend SubagentRunner registered for the
+// requested `agent`.
 
 import { existsSync, statSync, realpathSync } from "node:fs";
 import { resolve, normalize } from "node:path";
-import { query, type Options, type PermissionMode, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { createLogger } from "../core/logger.js";
 import {
   SUBAGENT_AGENTS,
+  type SubagentAgent,
   type SubagentEvent,
   type SubagentResult,
   type SubagentSpawnOptions,
 } from "./types.js";
 import type { SubagentClaudeConfigFile, SubagentPermissionMode } from "../core/config.js";
-import { DEFAULT_SUBAGENT_ALLOWED_TOOLS } from "../core/config.js";
+import type { SubagentRunner } from "./runner.js";
+import { ClaudeRunner } from "./runners/claude.js";
+import { BuiltinRunner, type BuiltinAgentCore } from "./runners/builtin.js";
 
 const log = createLogger("subagent:backend");
 
 /** Maximum concurrent sub-agent runs allowed */
 export const MAX_CONCURRENT_AGENTS = 5;
 
-// ---------------------------------------------------------------------------
-// SDK message → SubagentEvent mapping
-// ---------------------------------------------------------------------------
+// Re-exported for backward compatibility with consumers that imported
+// `mapSdkMessage` from this module before the runner split.
+export { mapSdkMessage } from "./runners/claude.js";
 
-/**
- * Map a single SDK message into zero or more SubagentEvents.
- *
- * Pass a persistent `toolNameById` map across calls to resolve `tool_result`
- * blocks back to the real tool name (Read/Edit/...): tool_use blocks carry
- * both id and name; tool_result blocks only carry the id. Without the map,
- * tool_result events fall back to the opaque `tool_use_id`.
- *
- * Exported for unit testing.
- */
-export function mapSdkMessage(
-  msg: SDKMessage,
-  toolNameById?: Map<string, string>,
-): SubagentEvent[] {
-  const events: SubagentEvent[] = [];
-
-  switch (msg.type) {
-    case "assistant": {
-      const content = msg.message?.content;
-      if (Array.isArray(content)) {
-        for (const block of content) {
-          if (block.type === "text" && typeof block.text === "string" && block.text.length > 0) {
-            events.push({ type: "message", content: block.text });
-          } else if (block.type === "tool_use") {
-            const name = String(block.name ?? "");
-            if (toolNameById && typeof block.id === "string") toolNameById.set(block.id, name);
-            events.push({
-              type: "tool_use",
-              toolName: name,
-              toolInput: block.input,
-            });
-          }
-        }
-      }
-      return events;
-    }
-
-    case "user": {
-      // SDKUserMessageReplay has isReplay:true — skip those (they're just history echoes)
-      if ("isReplay" in msg && msg.isReplay) return events;
-
-      const content = msg.message?.content;
-      if (Array.isArray(content)) {
-        for (const block of content) {
-          if (
-            typeof block === "object" &&
-            block !== null &&
-            "type" in block &&
-            block.type === "tool_result"
-          ) {
-            const b = block as { tool_use_id?: string; content?: unknown };
-            const id = String(b.tool_use_id ?? "");
-            events.push({
-              type: "tool_result",
-              toolName: toolNameById?.get(id) ?? id,
-              toolResult: typeof b.content === "string" ? b.content : JSON.stringify(b.content),
-            });
-          }
-        }
-      }
-      return events;
-    }
-
-    case "result": {
-      if (msg.subtype === "success") {
-        events.push({ type: "done", exitCode: 0, costUsd: msg.total_cost_usd });
-      } else {
-        // error subtypes: error_during_execution | error_max_turns | error_max_budget_usd | error_max_structured_output_retries
-        const errMsg = msg.errors?.join("; ") ?? msg.subtype;
-        events.push({ type: "error", error: errMsg });
-        events.push({ type: "done", exitCode: 1, costUsd: msg.total_cost_usd });
-      }
-      return events;
-    }
-
-    default:
-      // system/stream_event/tool_progress/auth_status — ignored (init/partials/progress)
-      return events;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Permission mode translation
-// ---------------------------------------------------------------------------
-
-/**
- * Translate isotopes' permission mode into SDK options.
- * - skip → bypassPermissions (no gating)
- * - allowlist → default mode + allowedTools
- * - default → default mode (no allowedTools restriction)
- */
-function translatePermissionMode(
-  mode: SubagentPermissionMode,
-  allowedTools: string[],
-): { permissionMode: PermissionMode; allowedTools?: string[] } {
-  switch (mode) {
-    case "skip":
-      return { permissionMode: "bypassPermissions" };
-    case "allowlist":
-      return { permissionMode: "default", allowedTools };
-    case "default":
-      return { permissionMode: "default" };
-  }
-}
-
-// ---------------------------------------------------------------------------
-// SubagentBackend
-// ---------------------------------------------------------------------------
-
-/** Tracks an in-flight SDK run so it can be cancelled. */
+/** Tracks an in-flight run so it can be cancelled. */
 interface RunHandle {
   abort: AbortController;
 }
@@ -144,40 +38,57 @@ const runs = new Map<string, RunHandle>();
 export interface SubagentBackendOptions {
   /** Allowed workspace roots for cwd validation. Empty = unrestricted. */
   allowedWorkspaceRoots?: string[];
-  /** Permission mode for tool execution. Default: "allowlist" */
+  /** Default permission mode for the Claude runner. Default: "allowlist" */
   permissionMode?: SubagentPermissionMode;
-  /** Tool allowlist for "allowlist" mode. Default: DEFAULT_SUBAGENT_ALLOWED_TOOLS */
+  /** Default tool allowlist for the Claude runner. */
   allowedTools?: string[];
-  /** Claude-specific settings (auth, base URL, executable path) */
+  /** Claude-specific settings (auth, base URL, executable path). */
   claude?: SubagentClaudeConfigFile;
+  /**
+   * Core used to host in-process builtin subagents. When provided, a
+   * BuiltinRunner is registered for the "builtin" agent. When omitted,
+   * spawning a "builtin" agent throws.
+   */
+  core?: BuiltinAgentCore;
+  /**
+   * Pre-built runners. When provided, replaces the runners that would have
+   * been built from the other options. Primarily a hook for tests.
+   */
+  runners?: Partial<Record<SubagentAgent, SubagentRunner>>;
 }
 
 /**
- * Backend for running Claude as a sub-agent via @anthropic-ai/claude-agent-sdk.
- *
- * Each task runs one `query()` call and streams SDK messages, which are mapped
- * to the existing SubagentEvent union consumed by discord-sink, iteration, etc.
+ * Dispatcher that routes subagent spawn requests to the runner registered
+ * for the requested {@link SubagentAgent}. Owns cwd validation, concurrency
+ * limiting, timeouts, and the abort handle map.
  */
 export class SubagentBackend {
   private allowedRoots: string[];
-  private permissionMode: SubagentPermissionMode;
-  private allowedTools: string[];
-  private claude?: SubagentClaudeConfigFile;
+  private runners: Partial<Record<SubagentAgent, SubagentRunner>>;
   /** Workspace key for singleton comparison (used by getBackend cache) */
   public workspacesKey: string;
 
   constructor(options?: string[] | SubagentBackendOptions) {
-    if (Array.isArray(options) || options === undefined) {
-      this.allowedRoots = options ?? [];
-      this.permissionMode = "allowlist";
-      this.allowedTools = [...DEFAULT_SUBAGENT_ALLOWED_TOOLS];
-    } else {
-      this.allowedRoots = options.allowedWorkspaceRoots ?? [];
-      this.permissionMode = options.permissionMode ?? "allowlist";
-      this.allowedTools = options.allowedTools ?? [...DEFAULT_SUBAGENT_ALLOWED_TOOLS];
-      this.claude = options.claude;
-    }
+    const opts: SubagentBackendOptions = Array.isArray(options) || options === undefined
+      ? { allowedWorkspaceRoots: options ?? [] }
+      : options;
+
+    this.allowedRoots = opts.allowedWorkspaceRoots ?? [];
     this.workspacesKey = this.allowedRoots.slice().sort().join(":");
+
+    if (opts.runners) {
+      this.runners = { ...opts.runners };
+    } else {
+      const claude = new ClaudeRunner({
+        permissionMode: opts.permissionMode,
+        allowedTools: opts.allowedTools,
+        claude: opts.claude,
+      });
+      this.runners = { claude };
+      if (opts.core) {
+        this.runners.builtin = new BuiltinRunner(opts.core);
+      }
+    }
   }
 
   /**
@@ -224,48 +135,11 @@ export class SubagentBackend {
   }
 
   /**
-   * Build the SDK Options object for this spawn, combining backend defaults
-   * with per-spawn overrides.
-   */
-  buildSdkOptions(
-    options: SubagentSpawnOptions,
-    abortController: AbortController,
-  ): Options {
-    const permissionMode = options.permissionMode ?? this.permissionMode;
-    const allowedTools = options.allowedTools ?? this.allowedTools;
-    const translated = translatePermissionMode(permissionMode, allowedTools);
-
-    const sdkOptions: Options = {
-      cwd: options.cwd,
-      abortController,
-      permissionMode: translated.permissionMode,
-    };
-    if (translated.allowedTools) sdkOptions.allowedTools = translated.allowedTools;
-    if (options.model) sdkOptions.model = options.model;
-    if (options.maxTurns !== undefined) sdkOptions.maxTurns = options.maxTurns;
-    if (this.claude?.pathToClaudeCodeExecutable) {
-      sdkOptions.pathToClaudeCodeExecutable = this.claude.pathToClaudeCodeExecutable;
-    }
-
-    // Inject Claude credentials into the spawned process's env without
-    // mutating the parent's process.env. Only set when configured — if
-    // unset, the SDK falls back to its normal process.env defaults.
-    const envOverrides: Record<string, string> = {};
-    if (this.claude?.authToken) envOverrides.ANTHROPIC_AUTH_TOKEN = this.claude.authToken;
-    if (this.claude?.baseUrl) envOverrides.ANTHROPIC_BASE_URL = this.claude.baseUrl;
-    if (Object.keys(envOverrides).length > 0) {
-      sdkOptions.env = { ...process.env, ...envOverrides };
-    }
-
-    return sdkOptions;
-  }
-
-  /**
    * Spawn a sub-agent and yield events as they arrive.
    *
-   * Yields a "start" event immediately, then message/tool_use/tool_result events
-   * mapped from the SDK stream, and a final "done" (and optional "error") event
-   * when the run completes.
+   * Yields a leading "start" event, delegates the body to the runner
+   * registered for `options.agent`, and ensures a terminal "done" event
+   * is emitted even if the runner exits without one.
    */
   async *spawn(
     taskId: string,
@@ -273,6 +147,16 @@ export class SubagentBackend {
   ): AsyncGenerator<SubagentEvent> {
     this.validateAgent(options.agent);
     this.validateCwd(options.cwd);
+
+    const runner = this.runners[options.agent];
+    if (!runner) {
+      throw new Error(
+        `No runner registered for agent "${options.agent}". ` +
+          (options.agent === "builtin"
+            ? "Pass `core` when constructing SubagentBackend to enable builtin subagents."
+            : "Check SubagentBackend configuration."),
+      );
+    }
 
     if (runs.size >= MAX_CONCURRENT_AGENTS) {
       throw new Error(
@@ -287,30 +171,18 @@ export class SubagentBackend {
 
     yield { type: "start" };
 
-    // Timeout: abort after N seconds. Default 900s (15 min) — single source of truth.
     const timeoutSec = options.timeout ?? 900;
     const timeoutHandle = setTimeout(() => abortController.abort(), timeoutSec * 1000);
     timeoutHandle.unref();
 
     let sawDone = false;
-    // tool_use blocks carry name+id; tool_result blocks only carry the id.
-    // Per-spawn map shared with mapSdkMessage so consumers see real tool names.
-    const toolNameById = new Map<string, string>();
     try {
-      const iterator = query({
-        prompt: options.prompt,
-        options: this.buildSdkOptions(options, abortController),
-      });
-
-      for await (const msg of iterator) {
-        for (const ev of mapSdkMessage(msg, toolNameById)) {
-          if (ev.type === "done") sawDone = true;
-          yield ev;
-        }
+      for await (const ev of runner.run(taskId, options, { abort: abortController.signal })) {
+        if (ev.type === "done") sawDone = true;
+        yield ev;
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // AbortError is expected on cancel; translate to a clean error event.
       yield { type: "error", error: msg };
       if (!sawDone) {
         yield { type: "done", exitCode: 1 };
@@ -321,7 +193,6 @@ export class SubagentBackend {
       runs.delete(taskId);
     }
 
-    // Safety net: ensure at least one done event was emitted.
     if (!sawDone) {
       yield { type: "done", exitCode: 0 };
     }
@@ -330,7 +201,7 @@ export class SubagentBackend {
   }
 
   /**
-   * Cancel a running sub-agent by aborting its SDK query.
+   * Cancel a running sub-agent by aborting its run.
    * Returns true if a task was found and aborted.
    */
   cancel(taskId: string): boolean {

--- a/src/subagent/builtin/event-bridge.test.ts
+++ b/src/subagent/builtin/event-bridge.test.ts
@@ -1,0 +1,91 @@
+// src/subagent/builtin/event-bridge.test.ts — Tests for AgentEvent → SubagentEvent bridge
+
+import { describe, it, expect } from "vitest";
+import type { AgentEvent } from "../../core/types.js";
+import type { SubagentEvent } from "../types.js";
+import { bridgeAgentEvents } from "./event-bridge.js";
+
+async function* fromArray<T>(items: T[]): AsyncGenerator<T, void, void> {
+  for (const item of items) yield item;
+}
+
+async function collect(events: AgentEvent[]): Promise<SubagentEvent[]> {
+  const out: SubagentEvent[] = [];
+  for await (const e of bridgeAgentEvents(fromArray(events))) out.push(e);
+  return out;
+}
+
+describe("bridgeAgentEvents", () => {
+  it("buffers text_delta and emits a single message at turn_end", async () => {
+    const out = await collect([
+      { type: "turn_start" },
+      { type: "text_delta", text: "Hello, " },
+      { type: "text_delta", text: "world." },
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    expect(out).toEqual([
+      { type: "message", content: "Hello, world." },
+      { type: "done", exitCode: 0 },
+    ]);
+  });
+
+  it("skips empty messages", async () => {
+    const out = await collect([
+      { type: "turn_start" },
+      { type: "text_delta", text: "   " },
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    expect(out).toEqual([{ type: "done", exitCode: 0 }]);
+  });
+
+  it("translates tool_call → tool_use", async () => {
+    const out = await collect([
+      { type: "tool_call", id: "1", name: "shell", args: { cmd: "ls" } },
+      { type: "agent_end", messages: [] },
+    ]);
+    expect(out[0]).toEqual({ type: "tool_use", toolName: "shell", toolInput: { cmd: "ls" } });
+  });
+
+  it("translates tool_result and surfaces error flag", async () => {
+    const out = await collect([
+      { type: "tool_result", id: "1", output: "ok" },
+      { type: "tool_result", id: "2", output: "boom", isError: true },
+      { type: "agent_end", messages: [] },
+    ]);
+    expect(out[0]).toEqual({ type: "tool_result", toolResult: "ok" });
+    expect(out[1]).toEqual({ type: "tool_result", toolResult: "boom", error: "tool error" });
+  });
+
+  it("emits error+done(1) when agent_end carries errorMessage", async () => {
+    const out = await collect([
+      { type: "agent_end", messages: [], errorMessage: "boom" },
+    ]);
+    expect(out).toEqual([
+      { type: "error", error: "boom" },
+      { type: "done", exitCode: 1 },
+    ]);
+  });
+
+  it("emits error+done(1) for an error event", async () => {
+    const out = await collect([
+      { type: "error", error: new Error("kaboom") },
+    ]);
+    expect(out).toEqual([
+      { type: "error", error: "kaboom" },
+      { type: "done", exitCode: 1 },
+    ]);
+  });
+
+  it("flushes trailing text and emits done if stream ends without agent_end", async () => {
+    const out = await collect([
+      { type: "turn_start" },
+      { type: "text_delta", text: "tail" },
+    ]);
+    expect(out).toEqual([
+      { type: "message", content: "tail" },
+      { type: "done", exitCode: 0 },
+    ]);
+  });
+});

--- a/src/subagent/builtin/event-bridge.ts
+++ b/src/subagent/builtin/event-bridge.ts
@@ -1,0 +1,77 @@
+// src/subagent/builtin/event-bridge.ts — Bridge AgentEvent stream to SubagentEvent stream
+// AgentEvent (pi-mono) is delta-oriented; SubagentEvent is message-oriented. The bridge
+// buffers text deltas across a turn and emits a single "message" event at turn_end.
+
+import type { AgentEvent } from "../../core/types.js";
+import type { SubagentEvent } from "../types.js";
+
+/**
+ * Translate a stream of {@link AgentEvent}s from {@link AgentInstance.prompt}
+ * into a stream of {@link SubagentEvent}s used by the subagent backend.
+ *
+ * - text_delta: buffered, flushed as "message" on turn_end (only if non-empty).
+ * - tool_call → tool_use; tool_result → tool_result.
+ * - agent_end → "done" with exitCode 0 (or 1 if `errorMessage` set).
+ * - error → "error" + "done" exitCode 1.
+ */
+export async function* bridgeAgentEvents(
+  events: AsyncIterable<AgentEvent>,
+): AsyncGenerator<SubagentEvent, void, void> {
+  let buffer = "";
+  let endedNormally = false;
+
+  for await (const event of events) {
+    switch (event.type) {
+      case "turn_start":
+        buffer = "";
+        break;
+      case "text_delta":
+        buffer += event.text;
+        break;
+      case "turn_end": {
+        const text = buffer.trim();
+        if (text.length > 0) yield { type: "message", content: text };
+        buffer = "";
+        break;
+      }
+      case "tool_call":
+        yield {
+          type: "tool_use",
+          toolName: event.name,
+          toolInput: event.args,
+        };
+        break;
+      case "tool_result":
+        yield {
+          type: "tool_result",
+          toolResult: event.output,
+          ...(event.isError ? { error: "tool error" } : {}),
+        };
+        break;
+      case "agent_end": {
+        const trailing = buffer.trim();
+        if (trailing.length > 0) yield { type: "message", content: trailing };
+        buffer = "";
+        if (event.errorMessage) {
+          yield { type: "error", error: event.errorMessage };
+          yield { type: "done", exitCode: 1 };
+        } else {
+          yield { type: "done", exitCode: 0 };
+        }
+        endedNormally = true;
+        break;
+      }
+      case "error":
+        yield { type: "error", error: event.error.message };
+        yield { type: "done", exitCode: 1 };
+        endedNormally = true;
+        break;
+    }
+  }
+
+  if (!endedNormally) {
+    const trailing = buffer.trim();
+    if (trailing.length > 0) yield { type: "message", content: trailing };
+    yield { type: "done", exitCode: 0 };
+  }
+}

--- a/src/subagent/builtin/system-prompt.test.ts
+++ b/src/subagent/builtin/system-prompt.test.ts
@@ -1,0 +1,45 @@
+// src/subagent/builtin/system-prompt.test.ts — Tests for builtin subagent prompt builder
+
+import { describe, it, expect } from "vitest";
+import { buildBuiltinSubagentSystemPrompt } from "./system-prompt.js";
+
+describe("buildBuiltinSubagentSystemPrompt", () => {
+  it("includes the task body", () => {
+    const out = buildBuiltinSubagentSystemPrompt({ task: "Find all TODOs in src/", role: "leaf" });
+    expect(out).toContain("Find all TODOs in src/");
+    expect(out).toContain("Task:");
+  });
+
+  it("frames leaf role with read-only capabilities", () => {
+    const out = buildBuiltinSubagentSystemPrompt({ task: "x", role: "leaf" });
+    expect(out).toContain("read-only");
+    expect(out).toContain("cannot spawn further subagents");
+  });
+
+  it("frames orchestrator role with delegation language", () => {
+    const out = buildBuiltinSubagentSystemPrompt({ task: "x", role: "orchestrator" });
+    expect(out).toContain("delegate");
+    expect(out).not.toContain("cannot spawn further subagents");
+  });
+
+  it("appends extra system prompt when provided", () => {
+    const out = buildBuiltinSubagentSystemPrompt({
+      task: "x",
+      role: "leaf",
+      extraSystemPrompt: "Workspace lives at /repo.",
+    });
+    expect(out).toContain("Workspace lives at /repo.");
+  });
+
+  it("omits extra section when extraSystemPrompt is empty/whitespace", () => {
+    const out = buildBuiltinSubagentSystemPrompt({ task: "x", role: "leaf", extraSystemPrompt: "  " });
+    const dividers = out.split("---").length - 1;
+    expect(dividers).toBe(1);
+  });
+
+  it("trims the task body", () => {
+    const out = buildBuiltinSubagentSystemPrompt({ task: "  hello  ", role: "leaf" });
+    expect(out).toContain("\nhello");
+    expect(out).not.toContain("  hello  ");
+  });
+});

--- a/src/subagent/builtin/system-prompt.ts
+++ b/src/subagent/builtin/system-prompt.ts
@@ -1,0 +1,59 @@
+// src/subagent/builtin/system-prompt.ts — System prompt builder for builtin subagents
+// A builtin subagent gets a focused, task-scoped prompt — NOT the parent's SOUL.
+
+import type { SubagentRole } from "../types.js";
+
+/** Inputs for building a builtin subagent system prompt. */
+export interface BuildPromptOptions {
+  /** The task to perform — supplied by the caller (typically the parent agent). */
+  task: string;
+  /** The subagent's role; controls capability framing in the prompt. */
+  role: SubagentRole;
+  /** Optional fragment appended after the base prompt (e.g. workspace hints). */
+  extraSystemPrompt?: string;
+}
+
+/**
+ * Build the system prompt for a builtin (in-process) subagent run.
+ *
+ * The prompt is intentionally short and capability-aware. It does NOT inherit
+ * the parent agent's SOUL — a subagent is a focused worker, not a continuation
+ * of the parent persona.
+ */
+export function buildBuiltinSubagentSystemPrompt(options: BuildPromptOptions): string {
+  const { task, role, extraSystemPrompt } = options;
+  const sections: string[] = [];
+
+  sections.push(
+    "You are a focused subagent spawned to complete a single task and then exit.",
+  );
+
+  if (role === "leaf") {
+    sections.push(
+      "Capabilities: read-only inspection plus shell. You cannot spawn further subagents, " +
+        "write or edit files, or fetch from the web. If the task requires those, return a " +
+        "concise explanation of what is needed and stop.",
+    );
+  } else {
+    sections.push(
+      "Capabilities: you may delegate sub-tasks to further subagents. Prefer doing the work " +
+        "yourself when reasonable; nest only when a sub-task is genuinely independent.",
+    );
+  }
+
+  sections.push(
+    "Be terse. Report findings or completion in plain text. Do not narrate plans before acting; " +
+      "just act and then summarize the result.",
+  );
+
+  sections.push("---");
+  sections.push("Task:");
+  sections.push(task.trim());
+
+  if (extraSystemPrompt && extraSystemPrompt.trim().length > 0) {
+    sections.push("---");
+    sections.push(extraSystemPrompt.trim());
+  }
+
+  return sections.join("\n\n");
+}

--- a/src/subagent/builtin/tool-policy.test.ts
+++ b/src/subagent/builtin/tool-policy.test.ts
@@ -1,0 +1,76 @@
+// src/subagent/builtin/tool-policy.test.ts — Unit tests for builtin tool policy
+
+import { describe, it, expect } from "vitest";
+import { ToolRegistry } from "../../core/tools.js";
+import {
+  DENY_ALWAYS,
+  DENY_LEAF,
+  resolveBuiltinToolPolicy,
+  filterToolRegistry,
+} from "./tool-policy.js";
+
+function makeRegistry(names: string[]): ToolRegistry {
+  const r = new ToolRegistry();
+  for (const name of names) {
+    r.register(
+      { name, description: name, parameters: { type: "object", properties: {} } },
+      async () => `result of ${name}`,
+    );
+  }
+  return r;
+}
+
+describe("resolveBuiltinToolPolicy", () => {
+  it("returns DENY_LEAF for leaf role", () => {
+    const policy = resolveBuiltinToolPolicy("leaf");
+    expect(policy.deny).toBe(DENY_LEAF);
+    expect(policy.deny.has("spawn_subagent")).toBe(true);
+    expect(policy.deny.has("write_file")).toBe(true);
+  });
+
+  it("returns DENY_ALWAYS (no spawn_subagent block) for orchestrator role", () => {
+    const policy = resolveBuiltinToolPolicy("orchestrator");
+    expect(policy.deny).toBe(DENY_ALWAYS);
+    expect(policy.deny.has("spawn_subagent")).toBe(false);
+    expect(policy.deny.has("write_file")).toBe(true);
+  });
+});
+
+describe("filterToolRegistry", () => {
+  it("removes denied tools and keeps the rest", () => {
+    const parent = makeRegistry([
+      "read_file",
+      "write_file",
+      "edit",
+      "web_fetch",
+      "web_search",
+      "spawn_subagent",
+      "shell",
+      "list_dir",
+    ]);
+    const filtered = filterToolRegistry(parent, resolveBuiltinToolPolicy("leaf"));
+    const names = filtered.list().map((t) => t.name).sort();
+    expect(names).toEqual(["list_dir", "read_file", "shell"]);
+  });
+
+  it("does not mutate the parent registry", () => {
+    const parent = makeRegistry(["read_file", "write_file"]);
+    filterToolRegistry(parent, resolveBuiltinToolPolicy("leaf"));
+    expect(parent.has("write_file")).toBe(true);
+    expect(parent.has("read_file")).toBe(true);
+  });
+
+  it("preserves tool handlers on the filtered registry", async () => {
+    const parent = makeRegistry(["read_file"]);
+    const filtered = filterToolRegistry(parent, resolveBuiltinToolPolicy("leaf"));
+    expect(await filtered.execute("read_file", {})).toBe("result of read_file");
+  });
+
+  it("orchestrator policy keeps spawn_subagent available", () => {
+    const parent = makeRegistry(["spawn_subagent", "write_file", "shell"]);
+    const filtered = filterToolRegistry(parent, resolveBuiltinToolPolicy("orchestrator"));
+    expect(filtered.has("spawn_subagent")).toBe(true);
+    expect(filtered.has("write_file")).toBe(false);
+    expect(filtered.has("shell")).toBe(true);
+  });
+});

--- a/src/subagent/builtin/tool-policy.ts
+++ b/src/subagent/builtin/tool-policy.ts
@@ -1,0 +1,54 @@
+// src/subagent/builtin/tool-policy.ts — Role-based tool capability policy
+// Decides which tools a builtin subagent may use, based on its role.
+
+import { ToolRegistry, type ToolHandler } from "../../core/tools.js";
+import type { SubagentRole } from "../types.js";
+
+/** Tools never exposed to a builtin subagent regardless of role. */
+export const DENY_ALWAYS: ReadonlySet<string> = new Set<string>([
+  "write_file",
+  "edit",
+  "web_fetch",
+  "web_search",
+]);
+
+/** Additional tools denied for "leaf" subagents (no nested spawning). */
+export const DENY_LEAF: ReadonlySet<string> = new Set<string>([
+  ...DENY_ALWAYS,
+  "spawn_subagent",
+]);
+
+/** Resolved tool policy for a given subagent role. */
+export interface BuiltinToolPolicy {
+  /** Tool names denied for this role. */
+  deny: ReadonlySet<string>;
+}
+
+/** Resolve the deny-list for a subagent role. */
+export function resolveBuiltinToolPolicy(role: SubagentRole): BuiltinToolPolicy {
+  switch (role) {
+    case "leaf":
+      return { deny: DENY_LEAF };
+    case "orchestrator":
+      return { deny: DENY_ALWAYS };
+  }
+}
+
+/**
+ * Build a new {@link ToolRegistry} containing only the tools from `parent`
+ * that are not blocked by `policy`. The parent registry is left untouched.
+ */
+export function filterToolRegistry(
+  parent: ToolRegistry,
+  policy: BuiltinToolPolicy,
+): ToolRegistry {
+  const filtered = new ToolRegistry();
+  for (const tool of parent.list()) {
+    if (policy.deny.has(tool.name)) continue;
+    const entry = parent.get(tool.name);
+    if (!entry) continue;
+    const handler: ToolHandler = entry.handler;
+    filtered.register(tool, handler);
+  }
+  return filtered;
+}

--- a/src/subagent/runner.ts
+++ b/src/subagent/runner.ts
@@ -1,0 +1,33 @@
+// src/subagent/runner.ts — Pluggable runner interface for subagent backends
+// One runner per backend. The dispatcher (SubagentBackend) picks a runner
+// based on options.agent and delegates the body of a run to it.
+
+import type { SubagentAgent, SubagentEvent, SubagentSpawnOptions } from "./types.js";
+
+/** Signals passed into a runner — currently just an abort handle. */
+export interface RunnerSignals {
+  /** Aborted by the dispatcher on cancel or timeout. */
+  abort: AbortSignal;
+}
+
+/**
+ * A runner executes a single subagent task.
+ *
+ * Conventions:
+ * - The runner does NOT yield the leading "start" event — the dispatcher
+ *   yields it before delegating.
+ * - The runner SHOULD yield a terminal "done" event. The dispatcher provides
+ *   a safety-net "done" if the runner exits without one.
+ * - Cancellation is observed via `signals.abort`. The runner is responsible
+ *   for translating an abort into a clean termination.
+ */
+export interface SubagentRunner {
+  /** Backend identifier this runner serves. */
+  readonly agent: SubagentAgent;
+  /** Run the task, yielding events as they occur. */
+  run(
+    taskId: string,
+    options: SubagentSpawnOptions,
+    signals: RunnerSignals,
+  ): AsyncGenerator<SubagentEvent>;
+}

--- a/src/subagent/runners/builtin.test.ts
+++ b/src/subagent/runners/builtin.test.ts
@@ -1,0 +1,197 @@
+// src/subagent/runners/builtin.test.ts — Tests for BuiltinRunner
+
+import { describe, it, expect } from "vitest";
+import type { AgentConfig, AgentEvent, AgentInstance, ProviderConfig } from "../../core/types.js";
+import { ToolRegistry } from "../../core/tools.js";
+import type { SubagentEvent } from "../types.js";
+import { BuiltinRunner, type BuiltinAgentCore } from "./builtin.js";
+
+function makeRegistry(names: string[]): ToolRegistry {
+  const r = new ToolRegistry();
+  for (const name of names) {
+    r.register(
+      { name, description: name, parameters: { type: "object", properties: {} } },
+      async () => `result of ${name}`,
+    );
+  }
+  return r;
+}
+
+function fakeProvider(): ProviderConfig {
+  return { type: "anthropic", model: "claude-sonnet-4-5" };
+}
+
+function makeCore(events: AgentEvent[]): {
+  core: BuiltinAgentCore;
+  setIds: string[];
+  clearedIds: string[];
+  capturedConfig: AgentConfig | undefined;
+  abortCalled: number;
+} {
+  const setIds: string[] = [];
+  const clearedIds: string[] = [];
+  let capturedConfig: AgentConfig | undefined;
+  let abortCalled = 0;
+
+  const instance: AgentInstance = {
+    async *[Symbol.asyncIterator]() {
+      // unused
+    },
+    prompt: () =>
+      (async function* () {
+        for (const e of events) yield e;
+      })(),
+    abort: () => {
+      abortCalled++;
+    },
+    steer: () => {},
+    followUp: () => {},
+  } as unknown as AgentInstance;
+
+  const core: BuiltinAgentCore = {
+    setToolRegistry: (id) => {
+      setIds.push(id);
+    },
+    clearToolRegistry: (id) => {
+      clearedIds.push(id);
+    },
+    createAgent: (config) => {
+      capturedConfig = config;
+      return instance;
+    },
+  };
+
+  return {
+    core,
+    setIds,
+    clearedIds,
+    get capturedConfig() {
+      return capturedConfig;
+    },
+    get abortCalled() {
+      return abortCalled;
+    },
+  };
+}
+
+async function collect(gen: AsyncGenerator<SubagentEvent>): Promise<SubagentEvent[]> {
+  const out: SubagentEvent[] = [];
+  for await (const e of gen) out.push(e);
+  return out;
+}
+
+describe("BuiltinRunner", () => {
+  it("yields error+done(1) when options.builtin is missing", async () => {
+    const harness = makeCore([]);
+    const runner = new BuiltinRunner(harness.core);
+    const out = await collect(
+      runner.run(
+        "task-1",
+        { agent: "builtin", prompt: "hi", cwd: "/tmp" },
+        { abort: new AbortController().signal },
+      ),
+    );
+    expect(out[0].type).toBe("error");
+    expect(out.at(-1)).toEqual({ type: "done", exitCode: 1 });
+  });
+
+  it("registers a filtered tool registry, runs, and clears it", async () => {
+    const harness = makeCore([
+      { type: "turn_start" },
+      { type: "text_delta", text: "ok" },
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    const runner = new BuiltinRunner(harness.core);
+    const tools = makeRegistry(["read_file", "write_file", "shell"]);
+
+    const out = await collect(
+      runner.run(
+        "task-2",
+        {
+          agent: "builtin",
+          prompt: "do thing",
+          cwd: "/tmp",
+          builtin: { provider: fakeProvider(), tools },
+        },
+        { abort: new AbortController().signal },
+      ),
+    );
+
+    expect(harness.setIds).toHaveLength(1);
+    expect(harness.setIds[0]).toMatch(/^subagent-builtin-task-2-/);
+    expect(harness.clearedIds).toEqual(harness.setIds);
+
+    expect(harness.capturedConfig?.systemPrompt).toContain("do thing");
+    expect(harness.capturedConfig?.compaction).toEqual({ mode: "off" });
+    expect(harness.capturedConfig?.provider?.type).toBe("anthropic");
+
+    expect(out).toEqual([
+      { type: "message", content: "ok" },
+      { type: "done", exitCode: 0 },
+    ]);
+  });
+
+  it("aborts the underlying instance when the abort signal fires", async () => {
+    const harness = makeCore([
+      { type: "turn_start" },
+      { type: "agent_end", messages: [] },
+    ]);
+    const runner = new BuiltinRunner(harness.core);
+    const ac = new AbortController();
+    ac.abort();
+
+    await collect(
+      runner.run(
+        "task-3",
+        {
+          agent: "builtin",
+          prompt: "p",
+          cwd: "/tmp",
+          builtin: { provider: fakeProvider(), tools: makeRegistry([]) },
+        },
+        { abort: ac.signal },
+      ),
+    );
+
+    expect(harness.abortCalled).toBeGreaterThanOrEqual(1);
+  });
+
+  it("clears the tool registry even if the agent throws", async () => {
+    const setIds: string[] = [];
+    const clearedIds: string[] = [];
+    const errInstance: AgentInstance = {
+      prompt: () =>
+        (async function* () {
+          throw new Error("boom");
+          yield undefined as never;
+        })(),
+      abort: () => {},
+      steer: () => {},
+      followUp: () => {},
+    } as unknown as AgentInstance;
+    const core: BuiltinAgentCore = {
+      setToolRegistry: (id) => setIds.push(id),
+      clearToolRegistry: (id) => clearedIds.push(id),
+      createAgent: () => errInstance,
+    };
+    const runner = new BuiltinRunner(core);
+
+    await expect(
+      collect(
+        runner.run(
+          "task-4",
+          {
+            agent: "builtin",
+            prompt: "p",
+            cwd: "/tmp",
+            builtin: { provider: fakeProvider(), tools: makeRegistry([]) },
+          },
+          { abort: new AbortController().signal },
+        ),
+      ),
+    ).rejects.toThrow("boom");
+
+    expect(clearedIds).toEqual(setIds);
+  });
+});

--- a/src/subagent/runners/builtin.ts
+++ b/src/subagent/runners/builtin.ts
@@ -1,0 +1,76 @@
+// src/subagent/runners/builtin.ts — In-process subagent runner backed by AgentCore
+// Reuses the parent agent's pi-mono core, provider config, and (filtered) tool
+// registry — no separate API key, no separate SDK process.
+
+import { randomUUID } from "node:crypto";
+import { createLogger } from "../../core/logger.js";
+import type { AgentCore } from "../../core/types.js";
+import type { ToolRegistry } from "../../core/tools.js";
+import { bridgeAgentEvents } from "../builtin/event-bridge.js";
+import { buildBuiltinSubagentSystemPrompt } from "../builtin/system-prompt.js";
+import { filterToolRegistry, resolveBuiltinToolPolicy } from "../builtin/tool-policy.js";
+import type { RunnerSignals, SubagentRunner } from "../runner.js";
+import type { SubagentAgent, SubagentEvent, SubagentSpawnOptions } from "../types.js";
+
+const log = createLogger("subagent:runner:builtin");
+
+/**
+ * Narrow shape over {@link AgentCore} that supports per-agent tool registries.
+ * `PiMonoCore` satisfies this interface.
+ */
+export interface BuiltinAgentCore extends AgentCore {
+  setToolRegistry(agentId: string, registry: ToolRegistry): void;
+  clearToolRegistry(agentId: string): void;
+}
+
+/** Runner that runs a subagent in-process via the supplied AgentCore. */
+export class BuiltinRunner implements SubagentRunner {
+  readonly agent: SubagentAgent = "builtin";
+
+  constructor(private readonly core: BuiltinAgentCore) {}
+
+  async *run(
+    taskId: string,
+    options: SubagentSpawnOptions,
+    signals: RunnerSignals,
+  ): AsyncGenerator<SubagentEvent> {
+    if (!options.builtin) {
+      yield { type: "error", error: "builtin runner requires options.builtin" };
+      yield { type: "done", exitCode: 1 };
+      return;
+    }
+
+    const role = options.builtin.role ?? "leaf";
+    const policy = resolveBuiltinToolPolicy(role);
+    const tools = filterToolRegistry(options.builtin.tools, policy);
+
+    const subagentId = `subagent-builtin-${taskId}-${randomUUID().slice(0, 8)}`;
+    const systemPrompt = buildBuiltinSubagentSystemPrompt({
+      task: options.prompt,
+      role,
+      extraSystemPrompt: options.builtin.extraSystemPrompt,
+    });
+
+    log.info("BuiltinRunner.run", { taskId, subagentId, role, toolCount: tools.list().length });
+
+    this.core.setToolRegistry(subagentId, tools);
+
+    const instance = this.core.createAgent({
+      id: subagentId,
+      systemPrompt,
+      provider: options.builtin.provider,
+      compaction: { mode: "off" },
+    });
+
+    const onAbort = () => instance.abort();
+    signals.abort.addEventListener("abort", onAbort, { once: true });
+    if (signals.abort.aborted) instance.abort();
+
+    try {
+      yield* bridgeAgentEvents(instance.prompt(options.prompt));
+    } finally {
+      signals.abort.removeEventListener("abort", onAbort);
+      this.core.clearToolRegistry(subagentId);
+    }
+  }
+}

--- a/src/subagent/runners/claude.ts
+++ b/src/subagent/runners/claude.ts
@@ -1,0 +1,207 @@
+// src/subagent/runners/claude.ts — Runner for the Claude Agent SDK backend
+// Extracted from the previous monolithic SubagentBackend.spawn so the
+// dispatcher can route agents by type.
+
+import { query, type Options, type PermissionMode, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { createLogger } from "../../core/logger.js";
+import {
+  DEFAULT_SUBAGENT_ALLOWED_TOOLS,
+  type SubagentClaudeConfigFile,
+  type SubagentPermissionMode,
+} from "../../core/config.js";
+import type { SubagentAgent, SubagentEvent, SubagentSpawnOptions } from "../types.js";
+import type { RunnerSignals, SubagentRunner } from "../runner.js";
+
+const log = createLogger("subagent:runner:claude");
+
+/** Configuration for {@link ClaudeRunner}. */
+export interface ClaudeRunnerOptions {
+  /** Default permission mode if a spawn doesn't override. */
+  permissionMode?: SubagentPermissionMode;
+  /** Default allowlist used when permissionMode is "allowlist". */
+  allowedTools?: string[];
+  /** Claude-specific settings (auth, base URL, executable path). */
+  claude?: SubagentClaudeConfigFile;
+}
+
+// ---------------------------------------------------------------------------
+// SDK message → SubagentEvent mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a single SDK message into zero or more SubagentEvents.
+ *
+ * Pass a persistent `toolNameById` map across calls to resolve `tool_result`
+ * blocks back to the real tool name (Read/Edit/...): tool_use blocks carry
+ * both id and name; tool_result blocks only carry the id.
+ */
+export function mapSdkMessage(
+  msg: SDKMessage,
+  toolNameById?: Map<string, string>,
+): SubagentEvent[] {
+  const events: SubagentEvent[] = [];
+
+  switch (msg.type) {
+    case "assistant": {
+      const content = msg.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === "text" && typeof block.text === "string" && block.text.length > 0) {
+            events.push({ type: "message", content: block.text });
+          } else if (block.type === "tool_use") {
+            const name = String(block.name ?? "");
+            if (toolNameById && typeof block.id === "string") toolNameById.set(block.id, name);
+            events.push({
+              type: "tool_use",
+              toolName: name,
+              toolInput: block.input,
+            });
+          }
+        }
+      }
+      return events;
+    }
+
+    case "user": {
+      if ("isReplay" in msg && msg.isReplay) return events;
+      const content = msg.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            typeof block === "object" &&
+            block !== null &&
+            "type" in block &&
+            block.type === "tool_result"
+          ) {
+            const b = block as { tool_use_id?: string; content?: unknown };
+            const id = String(b.tool_use_id ?? "");
+            events.push({
+              type: "tool_result",
+              toolName: toolNameById?.get(id) ?? id,
+              toolResult: typeof b.content === "string" ? b.content : JSON.stringify(b.content),
+            });
+          }
+        }
+      }
+      return events;
+    }
+
+    case "result": {
+      if (msg.subtype === "success") {
+        events.push({ type: "done", exitCode: 0, costUsd: msg.total_cost_usd });
+      } else {
+        const errMsg = msg.errors?.join("; ") ?? msg.subtype;
+        events.push({ type: "error", error: errMsg });
+        events.push({ type: "done", exitCode: 1, costUsd: msg.total_cost_usd });
+      }
+      return events;
+    }
+
+    default:
+      return events;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Permission mode translation
+// ---------------------------------------------------------------------------
+
+function translatePermissionMode(
+  mode: SubagentPermissionMode,
+  allowedTools: string[],
+): { permissionMode: PermissionMode; allowedTools?: string[] } {
+  switch (mode) {
+    case "skip":
+      return { permissionMode: "bypassPermissions" };
+    case "allowlist":
+      return { permissionMode: "default", allowedTools };
+    case "default":
+      return { permissionMode: "default" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ClaudeRunner
+// ---------------------------------------------------------------------------
+
+/** Runner backed by `@anthropic-ai/claude-agent-sdk`. */
+export class ClaudeRunner implements SubagentRunner {
+  readonly agent: SubagentAgent = "claude";
+
+  private permissionMode: SubagentPermissionMode;
+  private allowedTools: string[];
+  private claude?: SubagentClaudeConfigFile;
+
+  constructor(options?: ClaudeRunnerOptions) {
+    this.permissionMode = options?.permissionMode ?? "allowlist";
+    this.allowedTools = options?.allowedTools ?? [...DEFAULT_SUBAGENT_ALLOWED_TOOLS];
+    this.claude = options?.claude;
+  }
+
+  /** Build the SDK Options object for one spawn. */
+  buildSdkOptions(options: SubagentSpawnOptions, abort: AbortController): Options {
+    const permissionMode = options.permissionMode ?? this.permissionMode;
+    const allowedTools = options.allowedTools ?? this.allowedTools;
+    const translated = translatePermissionMode(permissionMode, allowedTools);
+
+    const sdkOptions: Options = {
+      cwd: options.cwd,
+      abortController: abort,
+      permissionMode: translated.permissionMode,
+    };
+    if (translated.allowedTools) sdkOptions.allowedTools = translated.allowedTools;
+    if (options.model) sdkOptions.model = options.model;
+    if (options.maxTurns !== undefined) sdkOptions.maxTurns = options.maxTurns;
+    if (this.claude?.pathToClaudeCodeExecutable) {
+      sdkOptions.pathToClaudeCodeExecutable = this.claude.pathToClaudeCodeExecutable;
+    }
+
+    const envOverrides: Record<string, string> = {};
+    if (this.claude?.authToken) envOverrides.ANTHROPIC_AUTH_TOKEN = this.claude.authToken;
+    if (this.claude?.baseUrl) envOverrides.ANTHROPIC_BASE_URL = this.claude.baseUrl;
+    if (Object.keys(envOverrides).length > 0) {
+      sdkOptions.env = { ...process.env, ...envOverrides };
+    }
+
+    return sdkOptions;
+  }
+
+  async *run(
+    taskId: string,
+    options: SubagentSpawnOptions,
+    signals: RunnerSignals,
+  ): AsyncGenerator<SubagentEvent> {
+    log.info("ClaudeRunner.run", { taskId, cwd: options.cwd });
+
+    // Bridge external AbortSignal into the SDK's AbortController.
+    const sdkAbort = new AbortController();
+    const onAbort = () => sdkAbort.abort();
+    signals.abort.addEventListener("abort", onAbort, { once: true });
+    if (signals.abort.aborted) sdkAbort.abort();
+
+    const toolNameById = new Map<string, string>();
+    let sawDone = false;
+
+    try {
+      const iterator = query({
+        prompt: options.prompt,
+        options: this.buildSdkOptions(options, sdkAbort),
+      });
+
+      for await (const msg of iterator) {
+        for (const ev of mapSdkMessage(msg, toolNameById)) {
+          if (ev.type === "done") sawDone = true;
+          yield ev;
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      yield { type: "error", error: msg };
+      if (!sawDone) {
+        yield { type: "done", exitCode: 1 };
+      }
+    } finally {
+      signals.abort.removeEventListener("abort", onAbort);
+    }
+  }
+}

--- a/src/subagent/types.ts
+++ b/src/subagent/types.ts
@@ -2,16 +2,37 @@
 // Defines agent types, spawn options, event types, and result structures.
 
 import type { SubagentPermissionMode } from "../core/config.js";
+import type { ProviderConfig } from "../core/types.js";
+import type { ToolRegistry } from "../core/tools.js";
 
 // ---------------------------------------------------------------------------
 // Agent types
 // ---------------------------------------------------------------------------
 
-/** Supported subagent backends. MVP: claude only. */
-export type SubagentAgent = "claude";
+/** Supported subagent backends. */
+export type SubagentAgent = "claude" | "builtin";
 
 /** All known subagent values for validation */
-export const SUBAGENT_AGENTS: ReadonlySet<string> = new Set<string>(["claude"]);
+export const SUBAGENT_AGENTS: ReadonlySet<string> = new Set<string>(["claude", "builtin"]);
+
+/**
+ * Role of a builtin subagent run. Drives tool capabilities.
+ * - "leaf"         — terminal worker; cannot spawn nested subagents.
+ * - "orchestrator" — reserved for future nesting; currently unused in v1.
+ */
+export type SubagentRole = "leaf" | "orchestrator";
+
+/** Builtin-backend-specific spawn options. */
+export interface BuiltinSubagentOptions {
+  /** Provider config inherited from the parent agent. */
+  provider: ProviderConfig;
+  /** Parent agent's tool registry; the runner filters this by role. */
+  tools: ToolRegistry;
+  /** Role for capability gating. Default: "leaf". */
+  role?: SubagentRole;
+  /** Optional extra system prompt fragment appended after the base subagent prompt. */
+  extraSystemPrompt?: string;
+}
 
 // ---------------------------------------------------------------------------
 // Spawn options
@@ -40,6 +61,8 @@ export interface SubagentSpawnOptions {
   timeout?: number;
   /** Maximum number of agent turns */
   maxTurns?: number;
+  /** Builtin-backend-specific options. Required when agent === "builtin". */
+  builtin?: BuiltinSubagentOptions;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/subagent.test.ts
+++ b/src/tools/subagent.test.ts
@@ -116,8 +116,8 @@ describe("spawnSubagent", () => {
 });
 
 describe("getSupportedAgents", () => {
-  it("returns claude only (MVP)", async () => {
+  it("returns claude and builtin", async () => {
     const { getSupportedAgents } = await import("./subagent.js");
-    expect(getSupportedAgents()).toEqual(["claude"]);
+    expect(getSupportedAgents()).toEqual(["claude", "builtin"]);
   });
 });

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -9,6 +9,8 @@ import {
   type SubagentAgent,
   type SubagentEvent,
 } from "../subagent/index.js";
+import type { BuiltinSubagentOptions } from "../subagent/types.js";
+import type { BuiltinAgentCore } from "../subagent/runners/builtin.js";
 import { taskRegistry } from "../subagent/task-registry.js";
 import { createSubagentRecorder } from "../subagent/persistence.js";
 import type { SessionStore } from "../core/types.js";
@@ -28,6 +30,8 @@ export interface SubagentBackendConfig {
   allowedTools?: string[];
   /** Claude-specific settings (auth, base URL, executable path) */
   claude?: SubagentClaudeConfigFile;
+  /** AgentCore used to host in-process builtin subagents. */
+  core?: BuiltinAgentCore;
 }
 
 /** Options for spawning a sub-agent */
@@ -61,6 +65,8 @@ export interface SpawnSubagentOptions {
    * docs/subagent-architecture.md §4.4.
    */
   targetAgentId?: string;
+  /** Builtin-backend-specific options. Required when agent === "builtin". */
+  builtin?: BuiltinSubagentOptions;
 }
 
 /** Result from spawning a sub-agent */
@@ -127,6 +133,7 @@ function getBackend(allowedWorkspaces?: string[]): SubagentBackend {
       permissionMode: backendConfig.permissionMode,
       allowedTools: backendConfig.allowedTools,
       claude: backendConfig.claude,
+      core: backendConfig.core,
     });
     sharedBackendKey = key;
   }
@@ -215,6 +222,7 @@ export async function spawnSubagent(
       model: options.model,
       timeout: options.timeout,
       maxTurns: options.maxTurns ?? 50,
+      ...(options.builtin ? { builtin: options.builtin } : {}),
     });
 
     // Collect events, optionally streaming via callback


### PR DESCRIPTION
## Summary

- Adds a second subagent backend (`agent: "builtin"`) that runs in-process via `PiMonoCore`, alongside the existing Claude SDK backend. Builtin runs inherit the parent's `ProviderConfig` and a role-filtered view of the parent's `ToolRegistry` — no separate API key, no separate process.
- Refactors `SubagentBackend` into a thin dispatcher (cwd validation, concurrency, timeout, abort) plus per-backend `SubagentRunner`s. `ClaudeRunner` is the old behavior; `BuiltinRunner` is new.
- Builtin runs use a role-based tool policy (default `leaf`: no write/edit, no web, no nested spawning) and a dedicated subagent system-prompt builder — they do not inherit the parent SOUL.

Closes #399.

## Architecture

```
SubagentBackend (dispatcher)
├── ClaudeRunner   → @anthropic-ai/claude-agent-sdk (out-of-process)
└── BuiltinRunner  → AgentCore.createAgent + bridgeAgentEvents (in-process)

src/subagent/
├── runner.ts                 — SubagentRunner interface
├── runners/claude.ts         — ClaudeRunner + mapSdkMessage
├── runners/builtin.ts        — BuiltinRunner
└── builtin/
    ├── tool-policy.ts        — role → deny-list, filterToolRegistry
    ├── system-prompt.ts      — focused, capability-aware prompt
    └── event-bridge.ts       — AgentEvent → SubagentEvent
```

The dispatcher emits the leading `start` and the safety-net `done`; each runner yields the body events.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `npx vitest run src/subagent src/core/tools.test.ts` — 182 tests pass (10 files)
- [ ] Manual run with a config that has `subagent.enabled: true`, trigger a `spawn_subagent` with `agent: "builtin"` from a parent agent, verify it streams to Discord and persists under `~/.isotopes/agents/<parent>/sessions/`.
- [ ] Verify `agent: "claude"` path is unchanged (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)