### PR TITLE
fix(discord): DM support + access control policy

### DIFF
--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -94,7 +94,11 @@ channels:
       main:                              # accountId — referenced by bindings, etc.
         tokenEnv: DISCORD_TOKEN          # or `token: <literal>`
         defaultAgentId: main
-        allowDMs: true
+        # allowDMs: true                  # deprecated — use dm.policy instead
+        dm:
+          policy: disabled               # disabled (default) | open | allowlist
+          # allowlist:                   # Discord user IDs (only when policy=allowlist)
+          #   - "123456789012345678"
         # allowBots: false               # respond to messages from other bots
         # channelAllowlist:
         #   - "channel-id"

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -128,7 +128,8 @@ channels:
         defaultAgentId: assistant
         agentBindings:
           "123456": assistant
-        allowDMs: true
+        dm:
+          policy: open
 `,
       );
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -362,8 +362,13 @@ export interface DiscordAccountConfig {
   defaultAgentId?: string;
   /** Channel/guild ID -> agent ID overrides. */
   agentBindings?: Record<string, string>;
-  /** Whether to accept DMs. Default: true */
-  allowDMs?: boolean;
+  /** DM access control. */
+  dm?: {
+    /** "disabled" (default) = ignore all DMs, "open" = accept all, "allowlist" = only from listed user IDs. */
+    policy?: "disabled" | "open" | "allowlist";
+    /** Discord user IDs allowed to DM when policy is "allowlist". */
+    allowlist?: string[];
+  };
   /** Restrict the bot to a list of channel IDs. */
   channelAllowlist?: string[];
   /** Group join policy (allowlist/denylist semantics, transport-defined). */

--- a/src/init/render.ts
+++ b/src/init/render.ts
@@ -48,7 +48,8 @@ channels:
       main:
         token: ${token}
         defaultAgentId: assistant
-        allowDMs: true
+        dm:
+          policy: disabled
         threadBindings:
           enabled: true
 `;

--- a/src/transports/discord-manager.test.ts
+++ b/src/transports/discord-manager.test.ts
@@ -121,13 +121,13 @@ describe("DiscordTransportManager", () => {
         major: {
           token: "tok-major",
           defaultAgentId: "major",
-          allowDMs: true,
+          dm: { policy: "open" },
           channelAllowlist: ["ch-1"],
         },
         tachikoma: {
           token: "tok-tachi",
           defaultAgentId: "tachikoma",
-          allowDMs: false,
+          dm: { policy: "disabled" },
         },
       },
       shared: { agentManager, sessionStore },

--- a/src/transports/discord-manager.ts
+++ b/src/transports/discord-manager.ts
@@ -36,7 +36,7 @@ export interface DiscordTransportManagerConfig {
  * DiscordTransportManager — creates and manages multiple DiscordTransport instances.
  *
  * Each account in the config gets its own transport with an independent Client,
- * token, and identity. All per-account behavior (allowDMs, allowBots, threadBindings,
+ * token, and identity. All per-account behavior (dm, allowBots, threadBindings,
  * subagentStreaming, context, adminUsers, etc.) is read from the account config.
  */
 export class DiscordTransportManager {
@@ -62,7 +62,7 @@ export class DiscordTransportManager {
         sessionStoreForAgent: shared.sessionStoreForAgent,
         defaultAgentId: account.defaultAgentId,
         agentBindings: account.agentBindings,
-        allowDMs: account.allowDMs,
+        dm: account.dm,
         channelAllowlist: account.channelAllowlist,
         channels: shared.channels,
         accountId,

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -986,7 +986,7 @@ describe("DiscordTransport", () => {
         agentManager,
         sessionStore,
         defaultAgentId: "default",
-        allowDMs: true,
+        dm: { policy: "open" },
       });
 
       const msg: MockIncomingMessage = {
@@ -1516,6 +1516,7 @@ describe("DiscordTransport", () => {
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
+        dm: { policy: "open" },
       });
       await localTransport.start();
 

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -154,8 +154,11 @@ export interface DiscordTransportConfig {
   defaultAgentId?: string;
   /** Map of Discord bot user ID → agent ID for multi-agent routing */
   agentBindings?: Record<string, string>;
-  /** Whether to respond to DMs */
-  allowDMs?: boolean;
+  /** DM access control policy. */
+  dm?: {
+    policy?: "disabled" | "open" | "allowlist";
+    allowlist?: string[];
+  };
   /** Channel IDs to listen to (empty = all) */
   channelAllowlist?: string[];
   /** Channels config for per-guild/group settings (e.g. requireMention) */
@@ -230,7 +233,7 @@ export class DiscordTransport implements Transport {
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.MessageContent,
       ],
-      partials: [Partials.Channel, Partials.Message],
+      partials: [Partials.Channel, Partials.Message, Partials.User, Partials.GuildMember],
     });
   }
 
@@ -238,6 +241,32 @@ export class DiscordTransport implements Transport {
     this.client.on("ready", () => {
       log.info(`Logged in as ${this.client.user?.tag}`);
       this.ready = true;
+    });
+
+    this.client.on("error", (err) => {
+      log.error(`Discord client error: ${err.message}`);
+    });
+
+    // discord.js v14 doesn't reliably emit messageCreate for DMs even with
+    // Partials.Channel. Intercept raw gateway packets and manually fetch the
+    // Message object for DM MESSAGE_CREATE events.
+    this.client.on("raw", async (packet: { t: string; d: unknown }) => {
+      if (packet.t !== "MESSAGE_CREATE") return;
+      const data = packet.d as Record<string, unknown>;
+      if (data.guild_id) return;
+
+      const channelId = data.channel_id as string;
+      try {
+        const channel = await this.client.channels.fetch(channelId);
+        if (!channel?.isTextBased()) return;
+        const message = await channel.messages.fetch(data.id as string);
+        await this.handleMessage(message);
+      } catch (err) {
+        log.warn("Failed to fetch DM message", {
+          channelId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     });
 
     this.client.on("messageCreate", (msg) => this.handleMessage(msg));
@@ -517,10 +546,22 @@ export class DiscordTransport implements Transport {
     await this.runAgentAndRespond(agent, promptInput, msg.channel as SendableChannel, session.id, sessionStore);
   }
 
+  private isDmAllowed(userId: string): boolean {
+    const dm = this.config.dm;
+    if (dm?.policy) {
+      switch (dm.policy) {
+        case "disabled": return false;
+        case "open": return true;
+        case "allowlist": return dm.allowlist?.includes(userId) ?? false;
+      }
+    }
+    return false;
+  }
+
   private shouldRespond(msg: DiscordMessage): boolean {
     // DM handling
     if (!msg.guild) {
-      return this.config.allowDMs !== false;
+      return this.isDmAllowed(msg.author.id);
     }
 
     // Channel allowlist


### PR DESCRIPTION
## Summary

- **Fix DM not working**: discord.js v14 silently drops `messageCreate` for DMs even with `Partials.Channel`. Added raw gateway packet interception to manually fetch and dispatch DM messages.
- **DM access control**: Replaced boolean `allowDMs` with structured `dm.policy` (`disabled` | `open` | `allowlist`), defaulting to `disabled` for security. Allowlist mode restricts DM to specified Discord user IDs.

## Test plan

- [x] All 112 existing tests pass (discord, discord-manager, config)
- [x] Verified DM works end-to-end with live bot
- [x] Guild messages unaffected (still use normal `messageCreate` path)
- [ ] Test `allowlist` mode rejects unlisted users
- [ ] Test `disabled` mode ignores all DMs

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)