### PR TITLE
feat(plugins): add plugin system with hooks, WebUI, and Chat API

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,0 +1,280 @@
+// src/api/chat.ts — Chat API routes (SSE streaming + REST actions)
+// Provides interactive chat capability over HTTP for WebUI plugins.
+
+import { addRoute } from "./routes.js";
+import { sendJson, sendError } from "./middleware.js";
+import { textContent } from "../core/types.js";
+import { createLogger } from "../core/logger.js";
+import { randomUUID } from "node:crypto";
+
+const log = createLogger("api:chat");
+
+interface ChatSession {
+  id: string;
+  agentId: string;
+  createdAt: Date;
+  abortController?: AbortController;
+}
+
+const chatSessions = new Map<string, ChatSession>();
+
+// ---------------------------------------------------------------------------
+// POST /api/chat/sessions — create a chat session
+// ---------------------------------------------------------------------------
+
+addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
+  const body = req.body as { agentId?: string } | undefined;
+  if (!deps.agentManager) {
+    sendError(res, 503, "Agent manager not available");
+    return;
+  }
+
+  const agents = deps.agentManager.list();
+  const agentId = body?.agentId ?? agents[0]?.id;
+  if (!agentId) {
+    sendError(res, 400, "No agent available");
+    return;
+  }
+
+  const agent = deps.agentManager.get(agentId);
+  if (!agent) {
+    sendError(res, 404, `Agent "${agentId}" not found`);
+    return;
+  }
+
+  let sessionId: string;
+  if (deps.sessionStoreManager) {
+    const store = await deps.sessionStoreManager.getOrCreate(agentId);
+    const session = await store.create(agentId, { key: `chat:${agentId}:${randomUUID()}` });
+    sessionId = session.id;
+  } else {
+    sessionId = randomUUID();
+  }
+
+  chatSessions.set(sessionId, { id: sessionId, agentId, createdAt: new Date() });
+
+  log.info(`Chat session created: ${sessionId} (agent: ${agentId})`);
+  sendJson(res, 201, { sessionId, agentId });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/chat/sessions/:id/message — send message, stream response via SSE
+// ---------------------------------------------------------------------------
+
+addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
+  const sessionId = req.params.id;
+  const session = chatSessions.get(sessionId);
+  if (!session) {
+    sendError(res, 404, `Chat session "${sessionId}" not found`);
+    return;
+  }
+
+  const body = req.body as { message?: string } | undefined;
+  if (!body?.message) {
+    sendError(res, 400, "Request body must include 'message'");
+    return;
+  }
+
+  if (!deps.agentManager) {
+    sendError(res, 503, "Agent manager not available");
+    return;
+  }
+
+  const agent = deps.agentManager.get(session.agentId);
+  if (!agent) {
+    sendError(res, 404, `Agent "${session.agentId}" not found`);
+    return;
+  }
+
+  // Store user message
+  if (deps.sessionStoreManager) {
+    const store = await deps.sessionStoreManager.getOrCreate(session.agentId);
+    await store.addMessage(sessionId, {
+      role: "user",
+      content: textContent(body.message),
+      timestamp: Date.now(),
+    });
+  }
+
+  // Set up SSE
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+  });
+
+  const ac = new AbortController();
+  session.abortController = ac;
+
+  const writeEvent = (event: string, data: unknown) => {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  };
+
+  try {
+    let responseText = "";
+
+    for await (const event of agent.prompt(body.message)) {
+      if (ac.signal.aborted) break;
+
+      switch (event.type) {
+        case "text_delta":
+          responseText += event.text;
+          writeEvent("text_delta", { text: event.text });
+          break;
+        case "tool_call":
+          writeEvent("tool_call", { id: event.id, name: event.name, args: event.args });
+          break;
+        case "tool_result":
+          writeEvent("tool_result", { id: event.id, output: event.output, isError: event.isError });
+          break;
+        case "turn_start":
+          writeEvent("turn_start", {});
+          break;
+        case "turn_end":
+          writeEvent("turn_end", { usage: event.usage });
+          break;
+        case "agent_end":
+          // Persist assistant response
+          if (deps.sessionStoreManager && responseText) {
+            const store = await deps.sessionStoreManager.getOrCreate(session.agentId);
+            await store.addMessage(sessionId, {
+              role: "assistant",
+              content: textContent(responseText),
+              timestamp: Date.now(),
+            });
+          }
+          writeEvent("agent_end", { stopReason: event.stopReason });
+          break;
+        case "error":
+          writeEvent("error", { message: event.error.message });
+          break;
+      }
+    }
+  } catch (err) {
+    writeEvent("error", { message: err instanceof Error ? err.message : String(err) });
+  } finally {
+    session.abortController = undefined;
+    res.end();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/chat/sessions/:id/abort — abort current response
+// ---------------------------------------------------------------------------
+
+addRoute("POST", "/api/chat/sessions/:id/abort", (req, res) => {
+  const session = chatSessions.get(req.params.id);
+  if (!session) {
+    sendError(res, 404, `Chat session "${req.params.id}" not found`);
+    return;
+  }
+
+  session.abortController?.abort();
+  sendJson(res, 200, { ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/chat/sessions/:id/steer — inject steering message
+// ---------------------------------------------------------------------------
+
+addRoute("POST", "/api/chat/sessions/:id/steer", (req, res, deps) => {
+  const session = chatSessions.get(req.params.id);
+  if (!session) {
+    sendError(res, 404, `Chat session "${req.params.id}" not found`);
+    return;
+  }
+
+  const body = req.body as { message?: string } | undefined;
+  if (!body?.message) {
+    sendError(res, 400, "Request body must include 'message'");
+    return;
+  }
+
+  const agent = deps.agentManager?.get(session.agentId);
+  if (!agent) {
+    sendError(res, 404, `Agent "${session.agentId}" not found`);
+    return;
+  }
+
+  agent.steer({ role: "user", content: textContent(body.message) });
+  sendJson(res, 200, { ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/chat/sessions/:id/followup — append follow-up message
+// ---------------------------------------------------------------------------
+
+addRoute("POST", "/api/chat/sessions/:id/followup", (req, res, deps) => {
+  const session = chatSessions.get(req.params.id);
+  if (!session) {
+    sendError(res, 404, `Chat session "${req.params.id}" not found`);
+    return;
+  }
+
+  const body = req.body as { message?: string } | undefined;
+  if (!body?.message) {
+    sendError(res, 400, "Request body must include 'message'");
+    return;
+  }
+
+  const agent = deps.agentManager?.get(session.agentId);
+  if (!agent) {
+    sendError(res, 404, `Agent "${session.agentId}" not found`);
+    return;
+  }
+
+  agent.followUp({ role: "user", content: textContent(body.message) });
+  sendJson(res, 200, { ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/chat/sessions/:id/messages — get message history
+// ---------------------------------------------------------------------------
+
+addRoute("GET", "/api/chat/sessions/:id/messages", async (req, res, deps) => {
+  const session = chatSessions.get(req.params.id);
+  if (!session) {
+    sendError(res, 404, `Chat session "${req.params.id}" not found`);
+    return;
+  }
+
+  if (!deps.sessionStoreManager) {
+    sendJson(res, 200, { messages: [] });
+    return;
+  }
+
+  const store = await deps.sessionStoreManager.getOrCreate(session.agentId);
+  const messages = await store.getMessages(req.params.id);
+  sendJson(res, 200, {
+    messages: messages.map((m) => ({
+      role: m.role,
+      content: Array.isArray(m.content)
+        ? m.content.map((b) => ("text" in b ? b.text : JSON.stringify(b))).join("")
+        : String(m.content),
+      timestamp: m.timestamp ? new Date(m.timestamp).toISOString() : undefined,
+    })),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/chat/sessions/:id — delete chat session
+// ---------------------------------------------------------------------------
+
+addRoute("DELETE", "/api/chat/sessions/:id", async (req, res, deps) => {
+  const sessionId = req.params.id;
+  const session = chatSessions.get(sessionId);
+  if (!session) {
+    sendError(res, 404, `Chat session "${sessionId}" not found`);
+    return;
+  }
+
+  session.abortController?.abort();
+  chatSessions.delete(sessionId);
+
+  if (deps.sessionStoreManager) {
+    const store = await deps.sessionStoreManager.getOrCreate(session.agentId);
+    await store.delete(sessionId);
+  }
+
+  sendJson(res, 200, { ok: true });
+});

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -13,10 +13,33 @@ interface ChatSession {
   id: string;
   agentId: string;
   createdAt: Date;
+  lastActivity: number;
   abortController?: AbortController;
 }
 
 const chatSessions = new Map<string, ChatSession>();
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const MAX_SESSIONS = 100;
+
+function evictStaleSessions() {
+  const now = Date.now();
+  for (const [id, session] of chatSessions) {
+    if (now - session.lastActivity > SESSION_TTL_MS) {
+      session.abortController?.abort();
+      chatSessions.delete(id);
+      log.debug(`Evicted stale chat session: ${id}`);
+    }
+  }
+  if (chatSessions.size > MAX_SESSIONS) {
+    const sorted = [...chatSessions.entries()].sort((a, b) => a[1].lastActivity - b[1].lastActivity);
+    const toRemove = sorted.slice(0, chatSessions.size - MAX_SESSIONS);
+    for (const [id, session] of toRemove) {
+      session.abortController?.abort();
+      chatSessions.delete(id);
+      log.debug(`Evicted chat session (capacity): ${id}`);
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // POST /api/chat/sessions — create a chat session
@@ -51,7 +74,8 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
     sessionId = randomUUID();
   }
 
-  chatSessions.set(sessionId, { id: sessionId, agentId, createdAt: new Date() });
+  evictStaleSessions();
+  chatSessions.set(sessionId, { id: sessionId, agentId, createdAt: new Date(), lastActivity: Date.now() });
 
   log.info(`Chat session created: ${sessionId} (agent: ${agentId})`);
   sendJson(res, 201, { sessionId, agentId });
@@ -68,6 +92,7 @@ addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
     sendError(res, 404, `Chat session "${sessionId}" not found`);
     return;
   }
+  session.lastActivity = Date.now();
 
   const body = req.body as { message?: string } | undefined;
   if (!body?.message) {

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -111,14 +111,14 @@ addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
     return;
   }
 
-  // Store user message
+  // Store user message + emit hook
+  const userMessage = { role: "user" as const, content: textContent(body.message), timestamp: Date.now() };
   if (deps.sessionStoreManager) {
     const store = await deps.sessionStoreManager.getOrCreate(session.agentId);
-    await store.addMessage(sessionId, {
-      role: "user",
-      content: textContent(body.message),
-      timestamp: Date.now(),
-    });
+    await store.addMessage(sessionId, userMessage);
+  }
+  if (deps.hooks) {
+    await deps.hooks.emit("message_received", { agentId: session.agentId, sessionId, message: { role: "user", content: textContent(body.message) } });
   }
 
   // Set up SSE
@@ -159,21 +159,30 @@ addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
           writeEvent("turn_end", { usage: event.usage });
           break;
         case "agent_end":
-          // Persist assistant response
-          if (deps.sessionStoreManager && responseText) {
-            const store = await deps.sessionStoreManager.getOrCreate(session.agentId);
-            await store.addMessage(sessionId, {
-              role: "assistant",
-              content: textContent(responseText),
-              timestamp: Date.now(),
-            });
-          }
           writeEvent("agent_end", { stopReason: event.stopReason });
           break;
         case "error":
           writeEvent("error", { message: event.error.message });
           break;
       }
+    }
+
+    // Persist assistant response and emit hooks
+    if (responseText) {
+      if (deps.sessionStoreManager) {
+        const store = await deps.sessionStoreManager.getOrCreate(session.agentId);
+        await store.addMessage(sessionId, {
+          role: "assistant",
+          content: textContent(responseText),
+          timestamp: Date.now(),
+        });
+      }
+      if (deps.hooks) {
+        await deps.hooks.emit("message_sending", { agentId: session.agentId, sessionId, message: { role: "assistant", content: textContent(responseText) } });
+      }
+    }
+    if (deps.hooks) {
+      await deps.hooks.emit("agent_end", { agentId: session.agentId });
     }
   } catch (err) {
     writeEvent("error", { message: err instanceof Error ? err.message : String(err) });

--- a/src/api/routes.test.ts
+++ b/src/api/routes.test.ts
@@ -55,7 +55,7 @@ describe("API routes", () => {
 
   beforeEach(async () => {
     cronScheduler = new CronScheduler();
-    server = new ApiServer({ port: 0 }, cronScheduler);
+    server = new ApiServer({ port: 0 }, { cronScheduler });
     await server.start();
   });
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -11,6 +11,7 @@ import type { CronScheduler, CronJobInput } from "../automation/cron-job.js";
 import type { ConfigReloader } from "../workspace/config-reloader.js";
 import type { AgentManager, SessionStore } from "../core/types.js";
 import type { UsageTracker } from "../core/usage-tracker.js";
+import type { SessionStoreManager } from "../core/session-store-manager.js";
 import { getIsotopesHome, getLogsDir } from "../core/paths.js";
 import { sendJson, sendError, handleRouteError, type ApiRequest } from "./middleware.js";
 
@@ -23,10 +24,9 @@ export interface RouteDeps {
   cronScheduler: CronScheduler;
   configReloader?: ConfigReloader;
   agentManager?: AgentManager;
-  /** Per-agent session stores for Discord sessions */
   discordSessionStores?: Map<string, SessionStore>;
-  /** Usage tracker for token/cost accumulation */
   usageTracker?: UsageTracker;
+  sessionStoreManager?: SessionStoreManager;
 }
 
 /** Handler function for a matched API route. */

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -12,6 +12,7 @@ import type { ConfigReloader } from "../workspace/config-reloader.js";
 import type { AgentManager, SessionStore } from "../core/types.js";
 import type { UsageTracker } from "../core/usage-tracker.js";
 import type { SessionStoreManager } from "../core/session-store-manager.js";
+import type { HookRegistry } from "../plugins/hooks.js";
 import { getIsotopesHome, getLogsDir } from "../core/paths.js";
 import { sendJson, sendError, handleRouteError, type ApiRequest } from "./middleware.js";
 
@@ -27,6 +28,7 @@ export interface RouteDeps {
   discordSessionStores?: Map<string, SessionStore>;
   usageTracker?: UsageTracker;
   sessionStoreManager?: SessionStoreManager;
+  hooks?: HookRegistry;
 }
 
 /** Handler function for a matched API route. */

--- a/src/api/server.test.ts
+++ b/src/api/server.test.ts
@@ -60,7 +60,7 @@ describe("ApiServer", () => {
   beforeEach(async () => {
     cronScheduler = new CronScheduler();
     // Use port 0 so the OS assigns a free port
-    server = new ApiServer({ port: 0 }, cronScheduler);
+    server = new ApiServer({ port: 0 }, { cronScheduler });
     await server.start();
   });
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -2,11 +2,13 @@
 // Minimal server built on Node.js built-in http module (no Express).
 
 import http from "node:http";
+import path from "node:path";
 import { createLogger } from "../core/logger.js";
 import type { CronScheduler } from "../automation/cron-job.js";
 import type { ConfigReloader } from "../workspace/config-reloader.js";
 import type { AgentManager, SessionStore } from "../core/types.js";
 import type { UsageTracker } from "../core/usage-tracker.js";
+import type { SessionStoreManager } from "../core/session-store-manager.js";
 import {
   applyCors,
   parseJsonBody,
@@ -16,9 +18,13 @@ import {
   type ApiRequest,
 } from "./middleware.js";
 import { matchRoute, type RouteDeps } from "./routes.js";
+import { serveStaticFile } from "./static.js";
+import type { UIRegistry } from "../plugins/ui-registry.js";
 
 // Register subagent routes (side-effect import)
 import "./subagents.js";
+// Register chat API routes (side-effect import)
+import "./chat.js";
 
 const log = createLogger("api:server");
 
@@ -57,8 +63,10 @@ export class ApiServer {
     agentManager?: AgentManager,
     usageTracker?: UsageTracker,
     discordSessionStores?: Map<string, SessionStore>,
+    private uiRegistry?: UIRegistry,
+    sessionStoreManager?: SessionStoreManager,
   ) {
-    this.deps = { cronScheduler, configReloader, agentManager, usageTracker, discordSessionStores };
+    this.deps = { cronScheduler, configReloader, agentManager, usageTracker, discordSessionStores, sessionStoreManager };
   }
 
   /**
@@ -93,6 +101,32 @@ export class ApiServer {
       if (bodyError) {
         sendError(res, 400, bodyError);
         return;
+      }
+
+      // Plugin UI static files
+      if (this.uiRegistry) {
+        // Navigation shell
+        if (req.pathname === "/ui" || req.pathname === "/ui/") {
+          const entries = this.uiRegistry.list();
+          const links = entries
+            .map((e) => `<li><a href="${e.mountPath}">${e.label}</a></li>`)
+            .join("\n");
+          const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Isotopes UI</title></head><body><h1>Isotopes UI Plugins</h1><ul>${links}</ul></body></html>`;
+          res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+          res.end(html);
+          return;
+        }
+
+        const uiMatch = this.uiRegistry.match(req.pathname);
+        if (uiMatch) {
+          const mount = uiMatch.mountPath!;
+          const relativePath = req.pathname.slice(mount.length) || "/index.html";
+          const filePath = path.join(uiMatch.staticDir, relativePath);
+          const served = await serveStaticFile(res, filePath, uiMatch.staticDir);
+          if (served) return;
+          sendError(res, 404, `Not found: ${req.pathname}`);
+          return;
+        }
       }
 
       // Route matching

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -52,21 +52,34 @@ export interface ApiServerConfig {
  * Exposes endpoints for managing Discord sessions, cron jobs, config, and
  * daemon status. Supports CORS, JSON body parsing, and parameterized routes.
  */
+export interface ApiServerDeps {
+  cronScheduler: CronScheduler;
+  configReloader?: ConfigReloader;
+  agentManager?: AgentManager;
+  usageTracker?: UsageTracker;
+  discordSessionStores?: Map<string, SessionStore>;
+  uiRegistry?: UIRegistry;
+  sessionStoreManager?: SessionStoreManager;
+}
+
 export class ApiServer {
   private server: http.Server | null = null;
   private deps: RouteDeps;
+  private uiRegistry?: UIRegistry;
 
   constructor(
     private config: ApiServerConfig,
-    cronScheduler: CronScheduler,
-    configReloader?: ConfigReloader,
-    agentManager?: AgentManager,
-    usageTracker?: UsageTracker,
-    discordSessionStores?: Map<string, SessionStore>,
-    private uiRegistry?: UIRegistry,
-    sessionStoreManager?: SessionStoreManager,
+    deps: ApiServerDeps,
   ) {
-    this.deps = { cronScheduler, configReloader, agentManager, usageTracker, discordSessionStores, sessionStoreManager };
+    this.uiRegistry = deps.uiRegistry;
+    this.deps = {
+      cronScheduler: deps.cronScheduler,
+      configReloader: deps.configReloader,
+      agentManager: deps.agentManager,
+      usageTracker: deps.usageTracker,
+      discordSessionStores: deps.discordSessionStores,
+      sessionStoreManager: deps.sessionStoreManager,
+    };
   }
 
   /**
@@ -122,7 +135,7 @@ export class ApiServer {
           const mount = uiMatch.mountPath!;
           const relativePath = req.pathname.slice(mount.length) || "/index.html";
           const filePath = path.join(uiMatch.staticDir, relativePath);
-          const served = await serveStaticFile(res, filePath, uiMatch.staticDir);
+          const served = await serveStaticFile(res, filePath, uiMatch.staticDir, uiMatch.spaFallback ?? false);
           if (served) return;
           sendError(res, 404, `Not found: ${req.pathname}`);
           return;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -19,6 +19,7 @@ import {
 } from "./middleware.js";
 import { matchRoute, type RouteDeps } from "./routes.js";
 import { serveStaticFile } from "./static.js";
+import type { HookRegistry } from "../plugins/hooks.js";
 import type { UIRegistry } from "../plugins/ui-registry.js";
 
 // Register subagent routes (side-effect import)
@@ -60,6 +61,7 @@ export interface ApiServerDeps {
   discordSessionStores?: Map<string, SessionStore>;
   uiRegistry?: UIRegistry;
   sessionStoreManager?: SessionStoreManager;
+  hooks?: HookRegistry;
 }
 
 export class ApiServer {
@@ -79,6 +81,7 @@ export class ApiServer {
       usageTracker: deps.usageTracker,
       discordSessionStores: deps.discordSessionStores,
       sessionStoreManager: deps.sessionStoreManager,
+      hooks: deps.hooks,
     };
   }
 
@@ -120,9 +123,10 @@ export class ApiServer {
       if (this.uiRegistry) {
         // Navigation shell
         if (req.pathname === "/ui" || req.pathname === "/ui/") {
+          const escHtml = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
           const entries = this.uiRegistry.list();
           const links = entries
-            .map((e) => `<li><a href="${e.mountPath}">${e.label}</a></li>`)
+            .map((e) => `<li><a href="${escHtml(e.mountPath!)}">${escHtml(e.label)}</a></li>`)
             .join("\n");
           const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Isotopes UI</title></head><body><h1>Isotopes UI Plugins</h1><ul>${links}</ul></body></html>`;
           res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });

--- a/src/api/static.ts
+++ b/src/api/static.ts
@@ -1,0 +1,65 @@
+// src/api/static.ts — Static file server for plugin UIs
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type http from "node:http";
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".map": "application/json",
+};
+
+export async function serveStaticFile(
+  res: http.ServerResponse,
+  filePath: string,
+  rootDir: string,
+): Promise<boolean> {
+  const resolved = path.resolve(filePath);
+  if (!resolved.startsWith(path.resolve(rootDir))) {
+    res.writeHead(403, { "Content-Type": "text/plain" });
+    res.end("Forbidden");
+    return true;
+  }
+
+  try {
+    const stat = await fs.stat(resolved);
+    if (stat.isDirectory()) {
+      return serveStaticFile(res, path.join(resolved, "index.html"), rootDir);
+    }
+
+    const data = await fs.readFile(resolved);
+    const ext = path.extname(resolved).toLowerCase();
+    const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
+
+    res.writeHead(200, { "Content-Type": contentType });
+    res.end(data);
+    return true;
+  } catch {
+    // SPA fallback: if no extension, try index.html
+    if (!path.extname(resolved)) {
+      const indexPath = path.join(rootDir, "index.html");
+      try {
+        const data = await fs.readFile(indexPath);
+        res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(data);
+        return true;
+      } catch {
+        // fall through
+      }
+    }
+    return false;
+  }
+}

--- a/src/api/static.ts
+++ b/src/api/static.ts
@@ -26,6 +26,7 @@ export async function serveStaticFile(
   res: http.ServerResponse,
   filePath: string,
   rootDir: string,
+  spaFallback = false,
 ): Promise<boolean> {
   const resolved = path.resolve(filePath);
   if (!resolved.startsWith(path.resolve(rootDir))) {
@@ -48,8 +49,7 @@ export async function serveStaticFile(
     res.end(data);
     return true;
   } catch {
-    // SPA fallback: if no extension, try index.html
-    if (!path.extname(resolved)) {
+    if (spaFallback && !path.extname(resolved)) {
       const indexPath = path.join(rootDir, "index.html");
       try {
         const data = await fs.readFile(indexPath);

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -138,7 +138,7 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
 
   // 7. Create tool registry and process registry
   const resolvedToolGuards = resolveToolGuards(agentConfig.toolSettings);
-  const toolRegistry = new ToolRegistry();
+  const toolRegistry = new ToolRegistry(agentConfig.id);
   const processRegistry = new ProcessRegistry();
   const subagentEnabled = subagent?.enabled === true;
   const agentAllowedWorkspaces = agentFile.allowedWorkspaces ?? [];

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -39,6 +39,7 @@ import type { PiMonoCore } from "./pi-mono.js";
 import type { DefaultAgentManager } from "./agent-manager.js";
 import type { AgentConfig, AgentInstance } from "./types.js";
 import { createLogger } from "./logger.js";
+import type { HookRegistry } from "../plugins/hooks.js";
 
 const log = createLogger("agent-init");
 
@@ -71,6 +72,8 @@ export interface InitAgentOptions {
   sandboxExecutor?: SandboxExecutor;
   /** Transport context for reply/react tools (optional — skipped if omitted) */
   transportContext?: LazyTransportContext;
+  /** Hook registry for lifecycle events (optional) */
+  hooks?: HookRegistry;
 }
 
 export interface InitAgentResult {
@@ -199,6 +202,10 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
 
   // 13. Wire up tool registry and create agent
   core.setToolRegistry(agentConfig.id, toolRegistry);
+  if (opts.hooks) {
+    toolRegistry.setHooks(opts.hooks);
+    await opts.hooks.emit("before_agent_start", { agentId: agentConfig.id });
+  }
   const instance = await agentManager.create(agentConfig, { workspacePath, toolGuardPrompt, baseSystemPrompt });
   log.info(`Created agent: ${agentConfig.id} (workspace: ${workspacePath}, tools: ${toolRegistry.list().length})`);
 

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -4,6 +4,7 @@
 import { textContent, type AgentInstance, type Message, type SessionStore } from "./types.js";
 import type { Logger } from "./logger.js";
 import type { UsageTracker } from "./usage-tracker.js";
+import type { HookRegistry } from "../plugins/hooks.js";
 
 /** Result of running an agent prompt to completion */
 export interface AgentRunResult {
@@ -27,12 +28,11 @@ export interface RunAgentOptions {
   sessionId: string;
   sessionStore: SessionStore;
   log: Logger;
-  /** Optional callback fired after each text_delta */
   onTextDelta?: OnTextDelta;
-  /** Optional usage tracker for per-session/global accumulation */
   usageTracker?: UsageTracker;
-  /** Called after turn_end events to check for pending messages */
   onToolComplete?: () => Promise<string | null>;
+  agentId?: string;
+  hooks?: HookRegistry;
 }
 
 /**
@@ -49,7 +49,17 @@ export interface RunAgentOptions {
  * stay in the transport layer via the onTextDelta callback.
  */
 export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResult> {
-  const { agent, input, sessionId, sessionStore, log, onTextDelta, usageTracker, onToolComplete } = opts;
+  const { agent, input, sessionId, sessionStore, log, onTextDelta, usageTracker, onToolComplete, agentId, hooks } = opts;
+
+  if (hooks && agentId) {
+    await hooks.emit("message_received", {
+      agentId,
+      sessionId,
+      message: typeof input === "string"
+        ? { role: "user", content: textContent(input) }
+        : input[input.length - 1],
+    });
+  }
 
   let responseText = "";
   let errorMessage: string | null = null;
@@ -74,6 +84,14 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
         }
       }
     } else if (event.type === "agent_end") {
+      if (hooks && agentId && responseText) {
+        await hooks.emit("message_sending", {
+          agentId,
+          sessionId,
+          message: { role: "assistant", content: textContent(responseText) },
+        });
+      }
+
       // Store final assistant message
       if (responseText) {
         await sessionStore.addMessage(sessionId, {
@@ -87,6 +105,10 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
         const msg = event.errorMessage ?? "Unknown agent error";
         log.error(`Agent ended with error: ${msg}`);
         errorMessage = msg;
+      }
+
+      if (hooks && agentId) {
+        await hooks.emit("agent_end", { agentId, stopReason: event.stopReason });
       }
     }
   }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -19,6 +19,7 @@ import type {
   SessionConfig,
 } from "./types.js";
 import { resolveSandboxConfig, type SandboxConfig } from "../sandbox/config.js";
+import type { PluginConfigEntry } from "../plugins/types.js";
 import { createLogger } from "./logger.js";
 
 const log = createLogger("config");
@@ -304,6 +305,8 @@ export interface IsotopesConfigFileRaw {
   subagent?: SubagentConfigFile;
   /** Channel-level cron job definitions */
   cron?: CronJobConfigFile[];
+  /** Plugin configurations */
+  plugins?: Record<string, PluginConfigEntry>;
 }
 
 /** Normalized config — agents is always an array, agentDefaults extracted */

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -198,13 +198,13 @@ describe("PiMonoCore.createAgent", () => {
   it("binds tool registries per agent instead of reusing the last one globally", () => {
     const core = new PiMonoCore();
 
-    const registryA = new ToolRegistry();
+    const registryA = new ToolRegistry("test");
     registryA.register(
       { name: "read_file", description: "Read file", parameters: {} },
       async () => "a",
     );
 
-    const registryB = new ToolRegistry();
+    const registryB = new ToolRegistry("test");
     registryB.register(
       { name: "list_dir", description: "List dir", parameters: {} },
       async () => "b",

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -341,6 +341,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       usageTracker,
       uiRegistry: pluginManager.getUIRegistry(),
       sessionStoreManager,
+      hooks: pluginManager.getHooks(),
     },
   );
   await apiServer.start();

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -8,6 +8,7 @@ import {
   resolveSandboxConfigFromFile,
   type IsotopesConfigFile,
 } from "./config.js";
+import path from "node:path";
 import { initSubagentBackend, setSubagentSessionStoreFactory } from "../tools/subagent.js";
 import { PiMonoCore } from "./pi-mono.js";
 import { DefaultAgentManager } from "./agent-manager.js";
@@ -29,6 +30,8 @@ import { ApiServer } from "../api/server.js";
 import { CronScheduler } from "../automation/cron-job.js";
 import { HeartbeatManager } from "../automation/heartbeat.js";
 import { UsageTracker } from "./usage-tracker.js";
+import { PluginManager } from "../plugins/manager.js";
+import { getIsotopesHome } from "./paths.js";
 
 const log = createLogger("runtime");
 
@@ -46,6 +49,7 @@ export interface Runtime {
   agentWorkspaces: Map<string, string>;
   cronScheduler: CronScheduler;
   usageTracker: UsageTracker;
+  pluginManager: PluginManager;
   discordManager?: DiscordTransportManager;
   apiServer: ApiServer;
   shutdown: () => Promise<void>;
@@ -139,6 +143,16 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
 
   // Hot-reload workspace files
   const hotReload = new HotReloadManager(agentManager, { enabled: true, debounceMs: 500 });
+
+  // Plugin system
+  const pluginManager = new PluginManager();
+  const pluginDirs = [
+    path.join(import.meta.dirname, "../../plugins"),
+    path.join(getIsotopesHome(), "plugins"),
+    ...[...agentWorkspaces.values()].map((w) => path.join(w, "plugins")),
+  ];
+  await pluginManager.discoverAndLoad(pluginDirs, config.plugins);
+
   for (const [agentId, workspacePath] of agentWorkspaces) {
     hotReload.register(agentId, workspacePath);
   }
@@ -303,6 +317,19 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     }
   }
 
+  // Plugin transports
+  const pluginTransports: import("./types.js").Transport[] = [];
+  for (const [id, factory] of pluginManager.getTransportFactories()) {
+    try {
+      const transport = await factory({ agentManager, sessionStoreManager, config });
+      await transport.start();
+      pluginTransports.push(transport);
+      log.info(`Plugin transport "${id}" started`);
+    } catch (err) {
+      log.error(`Failed to start plugin transport "${id}": ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   // API server
   const apiServer = new ApiServer(
     { port: apiPort ?? 2712 },
@@ -310,6 +337,9 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     undefined,
     agentManager,
     usageTracker,
+    undefined,
+    pluginManager.getUIRegistry(),
+    sessionStoreManager,
   );
   await apiServer.start();
 
@@ -322,6 +352,10 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     for (const hb of heartbeatManagers) hb.stop();
     hotReload.stop();
     if (discordManager) await discordManager.stop();
+    for (const t of pluginTransports) {
+      try { await t.stop(); } catch { /* ignore */ }
+    }
+    await pluginManager.shutdown();
     await apiServer.stop();
     sessionStoreManager.destroyAll();
 
@@ -343,6 +377,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     agentWorkspaces,
     cronScheduler,
     usageTracker,
+    pluginManager,
     discordManager,
     apiServer,
     shutdown,

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -65,7 +65,9 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   await ensureDirectories();
 
   // SessionStoreManager backs both main-agent transcripts and subagent runs.
-  const sessionStoreManager = new SessionStoreManager();
+  // Plugin system — initialize early so hooks are available during agent init.
+  const pluginManager = new PluginManager();
+  const sessionStoreManager = new SessionStoreManager({ hooks: pluginManager.getHooks() });
 
   // Initialize core first — the builtin subagent backend hosts subagents
   // in-process via this same core.
@@ -134,6 +136,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       isSingleAgent,
       sandboxExecutor,
       transportContext: transportCtx,
+      hooks: pluginManager.getHooks(),
     });
 
     agentWorkspaces.set(result.agentConfig.id, result.workspacePath);
@@ -144,8 +147,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   // Hot-reload workspace files
   const hotReload = new HotReloadManager(agentManager, { enabled: true, debounceMs: 500 });
 
-  // Plugin system
-  const pluginManager = new PluginManager();
+  // Discover and load plugins (PluginManager created earlier for hooks)
   const pluginDirs = [
     path.join(import.meta.dirname, "../../plugins"),
     path.join(getIsotopesHome(), "plugins"),
@@ -333,13 +335,13 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   // API server
   const apiServer = new ApiServer(
     { port: apiPort ?? 2712 },
-    cronScheduler,
-    undefined,
-    agentManager,
-    usageTracker,
-    undefined,
-    pluginManager.getUIRegistry(),
-    sessionStoreManager,
+    {
+      cronScheduler,
+      agentManager,
+      usageTracker,
+      uiRegistry: pluginManager.getUIRegistry(),
+      sessionStoreManager,
+    },
   );
   await apiServer.start();
 

--- a/src/core/session-store-manager.ts
+++ b/src/core/session-store-manager.ts
@@ -14,6 +14,7 @@ import {
 } from "./paths.js";
 import type { SessionConfig } from "./types.js";
 import { createLogger } from "./logger.js";
+import type { HookRegistry } from "../plugins/hooks.js";
 
 const log = createLogger("session-store-manager");
 
@@ -24,6 +25,8 @@ export interface SessionStoreManagerOptions {
   maxSessions?: number;
   /** Per-store maxTotalSizeMB cap (defaults to DefaultSessionStore default). */
   maxTotalSizeMB?: number;
+  /** Hook registry for lifecycle events. */
+  hooks?: HookRegistry;
 }
 
 /**
@@ -61,6 +64,9 @@ export class SessionStoreManager {
       this.stores.set(key, store);
       this.inits.delete(key);
       log.debug(`Initialized session store for agent ${agentId} at ${dataDir}`);
+      if (this.opts.hooks) {
+        await this.opts.hooks.emit("session_start", { agentId, sessionId: key });
+      }
       return store;
     })();
 
@@ -84,7 +90,10 @@ export class SessionStoreManager {
 
   /** Tear down every initialized store. Safe to call multiple times. */
   destroyAll(): void {
-    for (const store of this.stores.values()) {
+    for (const [key, store] of this.stores) {
+      if (this.opts.hooks) {
+        this.opts.hooks.emit("session_end", { agentId: key, sessionId: key }).catch(() => {});
+      }
       store.destroy();
     }
     this.stores.clear();

--- a/src/core/tools.test.ts
+++ b/src/core/tools.test.ts
@@ -25,7 +25,7 @@ describe("ToolRegistry", () => {
   let registry: ToolRegistry;
 
   beforeEach(() => {
-    registry = new ToolRegistry();
+    registry = new ToolRegistry("test");
   });
 
   describe("register", () => {

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -29,11 +29,14 @@ export interface ToolEntry {
 export class ToolRegistry {
   private tools = new Map<string, ToolEntry>();
   private hooks?: HookRegistry;
-  private agentId?: string;
+  private readonly agentId: string;
 
-  setHooks(hooks: HookRegistry, agentId: string): void {
-    this.hooks = hooks;
+  constructor(agentId: string) {
     this.agentId = agentId;
+  }
+
+  setHooks(hooks: HookRegistry): void {
+    this.hooks = hooks;
   }
   /**
    * Register a tool with its handler.
@@ -73,7 +76,7 @@ export class ToolRegistry {
     if (!entry) {
       throw new Error(`Tool "${name}" not found`);
     }
-    const agentId = this.agentId ?? "unknown";
+    const agentId = this.agentId;
     if (this.hooks) {
       await this.hooks.emit("before_tool_call", { agentId, toolName: name, args });
     }

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentToolSettings, ProviderConfig, Tool } from "./types.js";
+import type { HookRegistry } from "../plugins/hooks.js";
 import type { FsLike } from "../sandbox/fs-bridge.js";
 import { spawnSubagent, getSupportedAgents } from "../tools/subagent.js";
 import { createWebFetchTool, createWebSearchTool } from "../tools/web.js";
@@ -27,6 +28,13 @@ export interface ToolEntry {
  */
 export class ToolRegistry {
   private tools = new Map<string, ToolEntry>();
+  private hooks?: HookRegistry;
+  private agentId?: string;
+
+  setHooks(hooks: HookRegistry, agentId: string): void {
+    this.hooks = hooks;
+    this.agentId = agentId;
+  }
   /**
    * Register a tool with its handler.
    * @throws if tool name already registered
@@ -65,7 +73,15 @@ export class ToolRegistry {
     if (!entry) {
       throw new Error(`Tool "${name}" not found`);
     }
-    return entry.handler(args);
+    const agentId = this.agentId ?? "unknown";
+    if (this.hooks) {
+      await this.hooks.emit("before_tool_call", { agentId, toolName: name, args });
+    }
+    const result = await entry.handler(args);
+    if (this.hooks) {
+      await this.hooks.emit("after_tool_call", { agentId, toolName: name, args, result });
+    }
+    return result;
   }
   /**
    * Unregister a tool.

--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -1,0 +1,64 @@
+// src/plugins/api.ts — Scoped plugin API factory
+
+import path from "node:path";
+import { createLogger } from "../core/logger.js";
+import type { HookRegistry } from "./hooks.js";
+import type { UIRegistry } from "./ui-registry.js";
+import type {
+  IsotopesPluginApi,
+  TransportFactory,
+  UIPluginConfig,
+  PluginManifest,
+} from "./types.js";
+
+export interface CreatePluginApiDeps {
+  hooks: HookRegistry;
+  uiRegistry: UIRegistry;
+  transportFactories: Map<string, TransportFactory>;
+  pluginConfig?: Record<string, unknown>;
+}
+
+export interface CreatePluginApiResult {
+  api: IsotopesPluginApi;
+  cleanup: Array<() => void>;
+}
+
+export function createPluginApi(
+  manifest: PluginManifest,
+  pluginDir: string,
+  deps: CreatePluginApiDeps,
+): CreatePluginApiResult {
+  const cleanup: Array<() => void> = [];
+  const log = createLogger(`plugin:${manifest.id}`);
+
+  const api: IsotopesPluginApi = {
+    registerTransport(id: string, factory: TransportFactory): void {
+      deps.transportFactories.set(id, factory);
+      cleanup.push(() => deps.transportFactories.delete(id));
+      log.info(`Registered transport "${id}"`);
+    },
+
+    registerUI(config: UIPluginConfig): void {
+      const resolved: UIPluginConfig = {
+        ...config,
+        staticDir: path.resolve(pluginDir, config.staticDir),
+      };
+      deps.uiRegistry.register(resolved);
+      log.info(`Registered UI "${config.id}" at ${resolved.mountPath ?? `/ui/${config.id}`}`);
+    },
+
+    on(hook, handler) {
+      const unsub = deps.hooks.on(hook, handler);
+      cleanup.push(unsub);
+      return unsub;
+    },
+
+    getConfig(): Record<string, unknown> | undefined {
+      return deps.pluginConfig;
+    },
+
+    log,
+  };
+
+  return { api, cleanup };
+}

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -1,0 +1,65 @@
+// src/plugins/discovery.ts — Plugin discovery from filesystem
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createLogger } from "../core/logger.js";
+import type { PluginManifest } from "./types.js";
+
+const log = createLogger("plugins:discovery");
+
+export interface DiscoveredPlugin {
+  manifest: PluginManifest;
+  dir: string;
+}
+
+const MANIFEST_FILE = "isotopes.plugin.json";
+
+export async function discoverPlugins(searchDirs: string[]): Promise<DiscoveredPlugin[]> {
+  const results: DiscoveredPlugin[] = [];
+
+  for (const searchDir of searchDirs) {
+    try {
+      await fs.access(searchDir);
+    } catch {
+      continue;
+    }
+
+    let entries: string[];
+    try {
+      entries = await fs.readdir(searchDir);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const pluginDir = path.join(searchDir, entry);
+      const manifestPath = path.join(pluginDir, MANIFEST_FILE);
+
+      try {
+        const stat = await fs.stat(pluginDir);
+        if (!stat.isDirectory()) continue;
+
+        const raw = await fs.readFile(manifestPath, "utf-8");
+        const manifest = JSON.parse(raw) as PluginManifest;
+
+        if (!manifest.id || !manifest.name || !manifest.version || !manifest.entry) {
+          log.warn(`Skipping plugin at ${pluginDir}: manifest missing required fields`);
+          continue;
+        }
+
+        const entryResolved = path.resolve(pluginDir, manifest.entry);
+        if (!entryResolved.startsWith(path.resolve(pluginDir))) {
+          log.warn(`Skipping plugin "${manifest.id}": entry path escapes plugin directory`);
+          continue;
+        }
+
+        results.push({ manifest, dir: pluginDir });
+        log.debug(`Discovered plugin "${manifest.id}" at ${pluginDir}`);
+      } catch {
+        // No manifest or invalid JSON — skip silently
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -1,8 +1,11 @@
 // src/plugins/hooks.ts — Typed hook registry for plugin lifecycle events
 
 import type { HookName, HookPayloads } from "./types.js";
+import { createLogger } from "../core/logger.js";
 
 type HookHandler<H extends HookName> = (payload: HookPayloads[H]) => void | Promise<void>;
+
+const log = createLogger("plugins:hooks");
 
 export class HookRegistry {
   private handlers = new Map<HookName, Array<HookHandler<HookName>>>();
@@ -21,7 +24,11 @@ export class HookRegistry {
     const list = this.handlers.get(hook);
     if (!list) return;
     for (const handler of list) {
-      await handler(payload);
+      try {
+        await handler(payload);
+      } catch (err) {
+        log.error(`Hook "${hook}" handler threw: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
 

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -1,0 +1,31 @@
+// src/plugins/hooks.ts — Typed hook registry for plugin lifecycle events
+
+import type { HookName, HookPayloads } from "./types.js";
+
+type HookHandler<H extends HookName> = (payload: HookPayloads[H]) => void | Promise<void>;
+
+export class HookRegistry {
+  private handlers = new Map<HookName, Array<HookHandler<HookName>>>();
+
+  on<H extends HookName>(hook: H, handler: HookHandler<H>): () => void {
+    const list = this.handlers.get(hook) ?? [];
+    list.push(handler as HookHandler<HookName>);
+    this.handlers.set(hook, list);
+    return () => {
+      const idx = list.indexOf(handler as HookHandler<HookName>);
+      if (idx >= 0) list.splice(idx, 1);
+    };
+  }
+
+  async emit<H extends HookName>(hook: H, payload: HookPayloads[H]): Promise<void> {
+    const list = this.handlers.get(hook);
+    if (!list) return;
+    for (const handler of list) {
+      await handler(payload);
+    }
+  }
+
+  clear(): void {
+    this.handlers.clear();
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,19 @@
+// src/plugins/index.ts — Plugin system barrel exports
+
+export { PluginManager } from "./manager.js";
+export { HookRegistry } from "./hooks.js";
+export { UIRegistry } from "./ui-registry.js";
+export { discoverPlugins } from "./discovery.js";
+export { createPluginApi } from "./api.js";
+export type {
+  PluginManifest,
+  IsotopesPlugin,
+  IsotopesPluginModule,
+  IsotopesPluginApi,
+  HookName,
+  HookPayloads,
+  UIPluginConfig,
+  TransportFactory,
+  TransportFactoryContext,
+  PluginConfigEntry,
+} from "./types.js";

--- a/src/plugins/manager.ts
+++ b/src/plugins/manager.ts
@@ -1,6 +1,7 @@
 // src/plugins/manager.ts — Plugin lifecycle manager
 
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { createLogger } from "../core/logger.js";
 import { HookRegistry } from "./hooks.js";
 import { UIRegistry } from "./ui-registry.js";
@@ -60,7 +61,7 @@ export class PluginManager {
   ): Promise<void> {
     const entryPath = path.resolve(pluginDir, manifest.entry);
 
-    const mod = await import(entryPath);
+    const mod = await import(pathToFileURL(entryPath).href);
     const pluginModule: IsotopesPluginModule = mod.default ?? mod;
 
     const plugin: IsotopesPlugin =

--- a/src/plugins/manager.ts
+++ b/src/plugins/manager.ts
@@ -1,0 +1,114 @@
+// src/plugins/manager.ts — Plugin lifecycle manager
+
+import path from "node:path";
+import { createLogger } from "../core/logger.js";
+import { HookRegistry } from "./hooks.js";
+import { UIRegistry } from "./ui-registry.js";
+import { discoverPlugins } from "./discovery.js";
+import { createPluginApi } from "./api.js";
+import type {
+  IsotopesPlugin,
+  IsotopesPluginModule,
+  PluginManifest,
+  PluginConfigEntry,
+  TransportFactory,
+} from "./types.js";
+
+const log = createLogger("plugins");
+
+interface LoadedPlugin {
+  manifest: PluginManifest;
+  module: IsotopesPlugin;
+  cleanup: Array<() => void>;
+}
+
+export class PluginManager {
+  private plugins = new Map<string, LoadedPlugin>();
+  private hooks = new HookRegistry();
+  private uiRegistry = new UIRegistry();
+  private transportFactories = new Map<string, TransportFactory>();
+
+  async discoverAndLoad(
+    searchDirs: string[],
+    pluginConfigs?: Record<string, PluginConfigEntry>,
+  ): Promise<void> {
+    const discovered = await discoverPlugins(searchDirs);
+
+    for (const { manifest, dir } of discovered) {
+      const config = pluginConfigs?.[manifest.id];
+      if (config?.enabled === false) {
+        log.info(`Plugin "${manifest.id}" is disabled — skipping`);
+        continue;
+      }
+
+      try {
+        await this.loadPlugin(manifest, dir, config?.config);
+      } catch (err) {
+        log.error(
+          `Failed to load plugin "${manifest.id}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    log.info(`Loaded ${this.plugins.size} plugin(s)`);
+  }
+
+  private async loadPlugin(
+    manifest: PluginManifest,
+    pluginDir: string,
+    pluginConfig?: Record<string, unknown>,
+  ): Promise<void> {
+    const entryPath = path.resolve(pluginDir, manifest.entry);
+
+    const mod = await import(entryPath);
+    const pluginModule: IsotopesPluginModule = mod.default ?? mod;
+
+    const plugin: IsotopesPlugin =
+      typeof pluginModule === "function"
+        ? { register: pluginModule }
+        : pluginModule;
+
+    const { api, cleanup } = createPluginApi(manifest, pluginDir, {
+      hooks: this.hooks,
+      uiRegistry: this.uiRegistry,
+      transportFactories: this.transportFactories,
+      pluginConfig,
+    });
+
+    await plugin.register(api);
+
+    this.plugins.set(manifest.id, { manifest, module: plugin, cleanup });
+    log.info(`Loaded plugin "${manifest.id}" v${manifest.version}`);
+  }
+
+  getHooks(): HookRegistry {
+    return this.hooks;
+  }
+
+  getUIRegistry(): UIRegistry {
+    return this.uiRegistry;
+  }
+
+  getTransportFactories(): Map<string, TransportFactory> {
+    return this.transportFactories;
+  }
+
+  getLoadedPlugins(): PluginManifest[] {
+    return [...this.plugins.values()].map((p) => p.manifest);
+  }
+
+  async shutdown(): Promise<void> {
+    for (const [id, plugin] of this.plugins) {
+      try {
+        for (const fn of plugin.cleanup) fn();
+        await plugin.module.unregister?.();
+      } catch (err) {
+        log.error(
+          `Error shutting down plugin "${id}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    this.plugins.clear();
+    this.hooks.clear();
+  }
+}

--- a/src/plugins/plugins.test.ts
+++ b/src/plugins/plugins.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HookRegistry } from "./hooks.js";
+import { UIRegistry } from "./ui-registry.js";
+import { createPluginApi } from "./api.js";
+import type { PluginManifest, TransportFactory } from "./types.js";
+import fs from "node:fs";
+
+// ---------------------------------------------------------------------------
+// HookRegistry
+// ---------------------------------------------------------------------------
+
+describe("HookRegistry", () => {
+  let hooks: HookRegistry;
+
+  beforeEach(() => {
+    hooks = new HookRegistry();
+  });
+
+  it("emits to registered handlers", async () => {
+    const handler = vi.fn();
+    hooks.on("before_tool_call", handler);
+    await hooks.emit("before_tool_call", { agentId: "a1", toolName: "echo", args: {} });
+    expect(handler).toHaveBeenCalledWith({ agentId: "a1", toolName: "echo", args: {} });
+  });
+
+  it("unsubscribes when calling returned function", async () => {
+    const handler = vi.fn();
+    const unsub = hooks.on("agent_end", handler);
+    unsub();
+    await hooks.emit("agent_end", { agentId: "a1" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("runs handlers sequentially", async () => {
+    const order: number[] = [];
+    hooks.on("session_start", async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      order.push(1);
+    });
+    hooks.on("session_start", () => {
+      order.push(2);
+    });
+    await hooks.emit("session_start", { agentId: "a1", sessionId: "s1" });
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("clear() removes all handlers", async () => {
+    const handler = vi.fn();
+    hooks.on("agent_end", handler);
+    hooks.clear();
+    await hooks.emit("agent_end", { agentId: "a1" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("emits to no-op when no handlers registered", async () => {
+    await expect(hooks.emit("agent_end", { agentId: "a1" })).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UIRegistry
+// ---------------------------------------------------------------------------
+
+describe("UIRegistry", () => {
+  it("registers and lists UI configs", () => {
+    const registry = new UIRegistry();
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    registry.register({ id: "dash", label: "Dashboard", staticDir: "/tmp/dash" });
+    expect(registry.list()).toHaveLength(1);
+    expect(registry.get("dash")!.mountPath).toBe("/ui/dash");
+  });
+
+  it("matches request paths", () => {
+    const registry = new UIRegistry();
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    registry.register({ id: "dash", label: "Dashboard", staticDir: "/tmp/dash" });
+    expect(registry.match("/ui/dash")).toBeDefined();
+    expect(registry.match("/ui/dash/index.html")).toBeDefined();
+    expect(registry.match("/api/status")).toBeUndefined();
+  });
+
+  it("throws if staticDir does not exist", () => {
+    const registry = new UIRegistry();
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(() =>
+      registry.register({ id: "x", label: "X", staticDir: "/nonexistent" }),
+    ).toThrow("staticDir does not exist");
+  });
+
+  it("uses custom mountPath", () => {
+    const registry = new UIRegistry();
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    registry.register({ id: "x", label: "X", staticDir: "/tmp/x", mountPath: "/custom" });
+    expect(registry.get("x")!.mountPath).toBe("/custom");
+    expect(registry.match("/custom/foo")).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createPluginApi
+// ---------------------------------------------------------------------------
+
+describe("createPluginApi", () => {
+  const manifest: PluginManifest = {
+    id: "test-plugin",
+    name: "Test Plugin",
+    version: "1.0.0",
+    entry: "./index.ts",
+  };
+
+  it("registers transport and tracks cleanup", () => {
+    const hooks = new HookRegistry();
+    const uiRegistry = new UIRegistry();
+    const transportFactories = new Map<string, TransportFactory>();
+
+    const { api, cleanup } = createPluginApi(manifest, "/tmp/plugin", {
+      hooks,
+      uiRegistry,
+      transportFactories,
+    });
+
+    const factory: TransportFactory = async () => ({ start: async () => {}, stop: async () => {} });
+    api.registerTransport("test", factory);
+    expect(transportFactories.has("test")).toBe(true);
+
+    // Cleanup removes it
+    for (const fn of cleanup) fn();
+    expect(transportFactories.has("test")).toBe(false);
+  });
+
+  it("registers hook and tracks cleanup", async () => {
+    const hooks = new HookRegistry();
+    const uiRegistry = new UIRegistry();
+    const transportFactories = new Map<string, TransportFactory>();
+
+    const { api, cleanup } = createPluginApi(manifest, "/tmp/plugin", {
+      hooks,
+      uiRegistry,
+      transportFactories,
+    });
+
+    const handler = vi.fn();
+    api.on("agent_end", handler);
+    await hooks.emit("agent_end", { agentId: "a1" });
+    expect(handler).toHaveBeenCalled();
+
+    for (const fn of cleanup) fn();
+    handler.mockClear();
+    await hooks.emit("agent_end", { agentId: "a1" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns plugin config", () => {
+    const hooks = new HookRegistry();
+    const uiRegistry = new UIRegistry();
+    const transportFactories = new Map<string, TransportFactory>();
+
+    const { api } = createPluginApi(manifest, "/tmp/plugin", {
+      hooks,
+      uiRegistry,
+      transportFactories,
+      pluginConfig: { theme: "dark" },
+    });
+
+    expect(api.getConfig()).toEqual({ theme: "dark" });
+  });
+
+  it("provides a scoped logger", () => {
+    const hooks = new HookRegistry();
+    const uiRegistry = new UIRegistry();
+    const transportFactories = new Map<string, TransportFactory>();
+
+    const { api } = createPluginApi(manifest, "/tmp/plugin", {
+      hooks,
+      uiRegistry,
+      transportFactories,
+    });
+
+    expect(api.log).toBeDefined();
+    expect(api.log.info).toBeInstanceOf(Function);
+  });
+});

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -65,6 +65,7 @@ export interface UIPluginConfig {
   label: string;
   staticDir: string;
   mountPath?: string;
+  spaFallback?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,0 +1,104 @@
+// src/plugins/types.ts — Plugin system interfaces
+// Defines the manifest, lifecycle, hooks, and API surface for Isotopes plugins.
+
+import type { Logger } from "../core/logger.js";
+import type { Message, Transport, AgentManager } from "../core/types.js";
+import type { SessionStoreManager } from "../core/session-store-manager.js";
+import type { IsotopesConfigFile } from "../core/config.js";
+
+// ---------------------------------------------------------------------------
+// Plugin manifest (isotopes.plugin.json)
+// ---------------------------------------------------------------------------
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  entry: string;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module
+// ---------------------------------------------------------------------------
+
+export interface IsotopesPlugin {
+  register(api: IsotopesPluginApi): void | Promise<void>;
+  unregister?(): void | Promise<void>;
+}
+
+export type IsotopesPluginModule =
+  | IsotopesPlugin
+  | ((api: IsotopesPluginApi) => void | Promise<void>);
+
+// ---------------------------------------------------------------------------
+// Lifecycle hooks
+// ---------------------------------------------------------------------------
+
+export type HookName =
+  | "before_agent_start"
+  | "agent_end"
+  | "before_tool_call"
+  | "after_tool_call"
+  | "message_received"
+  | "message_sending"
+  | "session_start"
+  | "session_end";
+
+export interface HookPayloads {
+  before_agent_start: { agentId: string };
+  agent_end: { agentId: string; stopReason?: string };
+  before_tool_call: { agentId: string; toolName: string; args: unknown };
+  after_tool_call: { agentId: string; toolName: string; args: unknown; result: string };
+  message_received: { agentId: string; sessionId: string; message: Message };
+  message_sending: { agentId: string; sessionId: string; message: Message };
+  session_start: { agentId: string; sessionId: string };
+  session_end: { agentId: string; sessionId: string };
+}
+
+// ---------------------------------------------------------------------------
+// UI plugin config
+// ---------------------------------------------------------------------------
+
+export interface UIPluginConfig {
+  id: string;
+  label: string;
+  staticDir: string;
+  mountPath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Transport factory
+// ---------------------------------------------------------------------------
+
+export type TransportFactory = (ctx: TransportFactoryContext) => Transport | Promise<Transport>;
+
+export interface TransportFactoryContext {
+  agentManager: AgentManager;
+  sessionStoreManager: SessionStoreManager;
+  config: IsotopesConfigFile;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin API — the object passed to plugin.register()
+// ---------------------------------------------------------------------------
+
+export interface IsotopesPluginApi {
+  registerTransport(id: string, factory: TransportFactory): void;
+  registerUI(config: UIPluginConfig): void;
+  on<H extends HookName>(
+    hook: H,
+    handler: (payload: HookPayloads[H]) => void | Promise<void>,
+  ): () => void;
+  getConfig(): Record<string, unknown> | undefined;
+  log: Logger;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin config in isotopes.yaml
+// ---------------------------------------------------------------------------
+
+export interface PluginConfigEntry {
+  enabled?: boolean;
+  config?: Record<string, unknown>;
+}

--- a/src/plugins/ui-registry.ts
+++ b/src/plugins/ui-registry.ts
@@ -1,0 +1,43 @@
+// src/plugins/ui-registry.ts — Registry for UI plugin static file mounts
+
+import path from "node:path";
+import fs from "node:fs";
+import type { UIPluginConfig } from "./types.js";
+
+export class UIRegistry {
+  private entries = new Map<string, UIPluginConfig>();
+
+  register(config: UIPluginConfig): void {
+    const resolved = {
+      ...config,
+      staticDir: path.resolve(config.staticDir),
+      mountPath: config.mountPath ?? `/ui/${config.id}`,
+    };
+
+    if (!fs.existsSync(resolved.staticDir)) {
+      throw new Error(
+        `UI plugin "${config.id}": staticDir does not exist: ${resolved.staticDir}`,
+      );
+    }
+
+    this.entries.set(config.id, resolved);
+  }
+
+  get(id: string): UIPluginConfig | undefined {
+    return this.entries.get(id);
+  }
+
+  list(): UIPluginConfig[] {
+    return [...this.entries.values()];
+  }
+
+  match(pathname: string): UIPluginConfig | undefined {
+    for (const entry of this.entries.values()) {
+      const mount = entry.mountPath!;
+      if (pathname === mount || pathname.startsWith(mount + "/")) {
+        return entry;
+      }
+    }
+    return undefined;
+  }
+}

--- a/src/subagent/builtin/tool-policy.test.ts
+++ b/src/subagent/builtin/tool-policy.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./tool-policy.js";
 
 function makeRegistry(names: string[]): ToolRegistry {
-  const r = new ToolRegistry();
+  const r = new ToolRegistry("test");
   for (const name of names) {
     r.register(
       { name, description: name, parameters: { type: "object", properties: {} } },

--- a/src/subagent/builtin/tool-policy.ts
+++ b/src/subagent/builtin/tool-policy.ts
@@ -41,8 +41,9 @@ export function resolveBuiltinToolPolicy(role: SubagentRole): BuiltinToolPolicy 
 export function filterToolRegistry(
   parent: ToolRegistry,
   policy: BuiltinToolPolicy,
+  agentId = "subagent",
 ): ToolRegistry {
-  const filtered = new ToolRegistry();
+  const filtered = new ToolRegistry(agentId);
   for (const tool of parent.list()) {
     if (policy.deny.has(tool.name)) continue;
     const entry = parent.get(tool.name);

--- a/src/subagent/runners/builtin.test.ts
+++ b/src/subagent/runners/builtin.test.ts
@@ -7,7 +7,7 @@ import type { SubagentEvent } from "../types.js";
 import { BuiltinRunner, type BuiltinAgentCore } from "./builtin.js";
 
 function makeRegistry(names: string[]): ToolRegistry {
-  const r = new ToolRegistry();
+  const r = new ToolRegistry("test");
   for (const name of names) {
     r.register(
       { name, description: name, parameters: { type: "object", properties: {} } },

--- a/tests/e2e-smoke.test.ts
+++ b/tests/e2e-smoke.test.ts
@@ -68,7 +68,7 @@ describe("workspace context", () => {
 
 describe("read_file tool", () => {
   it("reads a file from the workspace", async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     const { tool, handler } = createReadFileTool({ basePath: tmpDir });
     registry.register(tool, handler);
 
@@ -77,7 +77,7 @@ describe("read_file tool", () => {
   });
 
   it("returns error for nonexistent file", async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     const { tool, handler } = createReadFileTool({ basePath: tmpDir });
     registry.register(tool, handler);
 
@@ -97,7 +97,7 @@ describe("edit tool", () => {
     const editFile = path.join(tmpDir, "editable.txt");
     await fs.writeFile(editFile, "foo bar baz\n");
 
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     const { tool, handler } = createEditFileTool({ basePath: tmpDir });
     registry.register(tool, handler);
 
@@ -120,7 +120,7 @@ describe("edit tool", () => {
 
 describe("exec tool", () => {
   it("runs a shell command and returns stdout", async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     const execTools = createExecTools({ cwd: tmpDir });
     for (const { tool, handler } of execTools) {
       registry.register(tool, handler);
@@ -133,7 +133,7 @@ describe("exec tool", () => {
   });
 
   it("reports non-zero exit codes", async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     const execTools = createExecTools({ cwd: tmpDir });
     for (const { tool, handler } of execTools) {
       registry.register(tool, handler);
@@ -151,7 +151,7 @@ describe("exec tool", () => {
 
 describe("web_fetch tool", () => {
   it("fetches a URL and returns content", async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     const { tool, handler } = createWebFetchTool();
     registry.register(tool, handler);
 
@@ -162,7 +162,7 @@ describe("web_fetch tool", () => {
   }, 15_000);
 
   it("returns error for invalid URL", async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     const { tool, handler } = createWebFetchTool();
     registry.register(tool, handler);
 
@@ -212,7 +212,7 @@ describe("tool policy deny", () => {
     const tools = createWorkspaceToolsWithGuards(tmpDir, { cli: true });
     const filtered = applyToolPolicy(tools, { deny: ["read_file"] });
 
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     for (const { tool, handler } of filtered) {
       registry.register(tool, handler);
     }
@@ -226,7 +226,7 @@ describe("tool policy deny", () => {
     const execTools = createExecTools({ cwd: tmpDir });
     const filtered = applyToolPolicy(execTools, { deny: ["exec"] });
 
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
     for (const { tool, handler } of filtered) {
       registry.register(tool, handler);
     }
@@ -264,7 +264,7 @@ describe("tool policy deny", () => {
 
 describe("full tool wiring", () => {
   it("registers all core tools without conflict", async () => {
-    const registry = new ToolRegistry();
+    const registry = new ToolRegistry("test");
 
     // Workspace tools (read, write, edit, list_dir, time)
     const workspaceTools = createWorkspaceToolsWithGuards(tmpDir, {


### PR DESCRIPTION
## Summary

- **Plugin system**: unified `register(api)` entry point with manifest-based discovery from 3 directories (bundled, `~/.isotopes/plugins/`, workspace)
- **Plugin API**: `registerTransport()`, `registerUI()`, `on()` (8 lifecycle hooks), `getConfig()`, `log`
- **Chat API**: SSE-based streaming at `/api/chat/sessions` with REST actions (abort, steer, followup, message history)
- **WebUI support**: static file serving with path traversal guards, SPA fallback, navigation shell at `/ui`
- **Lifecycle hooks**: `before_agent_start`, `agent_end`, `before_tool_call`, `after_tool_call`, `message_received`, `message_sending`, `session_start`, `session_end`

### New files
| File | Purpose |
|------|---------|
| `src/plugins/types.ts` | Plugin interfaces and type definitions |
| `src/plugins/hooks.ts` | Typed event emitter with sequential async execution |
| `src/plugins/discovery.ts` | Directory scanning for `isotopes.plugin.json` manifests |
| `src/plugins/api.ts` | Scoped per-plugin API factory with cleanup tracking |
| `src/plugins/manager.ts` | Plugin lifecycle orchestrator |
| `src/plugins/ui-registry.ts` | UI plugin mount management |
| `src/api/static.ts` | Static file server with security guards |
| `src/api/chat.ts` | Chat API routes (SSE + REST) |

### Modified files
- `src/core/runtime.ts` — wire PluginManager, plugin transports, shutdown
- `src/core/config.ts` — add `plugins` config key
- `src/core/tools.ts` — emit before/after_tool_call hooks
- `src/core/agent-runner.ts` — emit agent_end, message hooks
- `src/api/server.ts` — UIRegistry integration, static serving, nav shell
- `src/api/routes.ts` — add SessionStoreManager to RouteDeps

### Deferred
- Tool registration via plugins → #424 (global ToolRegistry refactor)
- API authentication → #425

## Test plan
- [x] 13 new unit tests for HookRegistry, UIRegistry, createPluginApi
- [x] All existing tests pass
- [x] ESLint clean
- [x] TypeScript typecheck clean
- [ ] Manual: drop a sample plugin into `~/.isotopes/plugins/` and verify discovery
- [ ] Manual: test Chat API SSE streaming via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)