### PR TITLE
fix: use fileURLToPath and os.homedir for Windows compatibility

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@
 
 import { parseArgs } from "node:util";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import fs from "node:fs/promises";
 import { VERSION } from "./version.js";
 import { loadConfig } from "./core/config.js";
@@ -47,7 +48,7 @@ function makeServiceConfig(): ServiceConfig {
     description: SERVICE_DESCRIPTION,
     execPath: process.argv[0],
     cliPath: path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "cli.js",
     ),
     configPath: getConfigPath(),

--- a/src/daemon/process.ts
+++ b/src/daemon/process.ts
@@ -3,7 +3,9 @@
 
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createLogger } from "../core/logger.js";
 
 const log = createLogger("daemon:process");
@@ -133,7 +135,7 @@ export class DaemonProcess {
     // the CLI file as its first argument so that `tsx` works transparently
     // during development.
     const cliEntry = path.resolve(
-      path.dirname(new URL(import.meta.url).pathname),
+      path.dirname(fileURLToPath(import.meta.url)),
       "..",
       "cli.js",
     );
@@ -145,7 +147,7 @@ export class DaemonProcess {
       // Without this, file tools with workspaceOnly=false resolve relative
       // paths against the caller's cwd, which may be another agent's workspace,
       // causing identity contamination (#92).
-      cwd: process.env.HOME || "/",
+      cwd: os.homedir(),
       env: {
         ...process.env,
         ISOTOPES_DAEMON: "1",


### PR DESCRIPTION
## Summary
- Replace `new URL(import.meta.url).pathname` with `fileURLToPath(import.meta.url)` in `src/cli.ts` and `src/daemon/process.ts` — the former returns `/C:/foo` on Windows, breaking path resolution
- Replace `process.env.HOME || "/"` with `os.homedir()` in daemon process spawning — `HOME` is unset on Windows and `"/"` resolves to drive root

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Verify daemon starts correctly on Windows (`isotopes start`)
- [ ] Verify `isotopes service install` resolves CLI path correctly on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)