### PR TITLE
refactor(init,discord): improve init wizard, add group policy, remove isSingleAgent

### DIFF
--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -96,7 +96,7 @@ channels:
         defaultAgentId: main
         # allowDMs: true                  # deprecated — use dm.policy instead
         dm:
-          policy: disabled               # disabled (default) | open | allowlist
+          policy: disabled               # disabled (default) | allowlist
           # allowlist:                   # Discord user IDs (only when policy=allowlist)
           #   - "123456789012345678"
         group:

--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -99,8 +99,14 @@ channels:
           policy: disabled               # disabled (default) | open | allowlist
           # allowlist:                   # Discord user IDs (only when policy=allowlist)
           #   - "123456789012345678"
+        group:
+          policy: allowlist              # disabled | allowlist (default) | open
+          # channelAllowlist:            # channel IDs (only when policy=allowlist)
+          #   - "channel-id"
+          # guildAllowlist:              # guild/server IDs (only when policy=allowlist)
+          #   - "guild-id"
         # allowBots: false               # respond to messages from other bots
-        # channelAllowlist:
+        # channelAllowlist:              # deprecated — use group.channelAllowlist
         #   - "channel-id"
         # agentBindings:                 # bot user id → agent id
         #   "bot-user-id": main

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -66,8 +66,6 @@ export interface InitAgentOptions {
   core: PiMonoCore;
   /** Agent manager */
   agentManager: DefaultAgentManager;
-  /** Whether this is the only agent (affects workspace naming) */
-  isSingleAgent?: boolean;
   /** Pre-built sandbox executor (optional — no sandbox if omitted) */
   sandboxExecutor?: SandboxExecutor;
   /** Transport context for reply/react tools (optional — skipped if omitted) */
@@ -102,7 +100,6 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
     subagent,
     core,
     agentManager,
-    isSingleAgent = true,
     sandboxExecutor,
     transportContext,
   } = opts;
@@ -117,8 +114,7 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
     workspacePath = await ensureExplicitWorkspaceDir(resolved);
     log.info(`Using explicit workspace for ${agentConfig.id}: ${workspacePath}`);
   } else {
-    const workspaceKey = isSingleAgent ? "default" : agentConfig.id;
-    workspacePath = await ensureWorkspaceDir(workspaceKey);
+    workspacePath = await ensureWorkspaceDir(agentConfig.id);
   }
 
   // 3. Seed workspace templates on first creation

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -78,7 +78,7 @@ export interface AgentConfigFile {
   /**
    * Explicit workspace directory for this agent (#214).
    * Absolute paths are used as-is; relative paths resolve from ISOTOPES_HOME.
-   * When omitted, the default derivation (single → "workspace/", multi → "workspace-{id}/") is used.
+   * When omitted, defaults to "workspace-{id}/".
    */
   workspace?: string;
   tools?: AgentToolsConfigFile;

--- a/src/core/paths.test.ts
+++ b/src/core/paths.test.ts
@@ -48,14 +48,13 @@ describe("paths", () => {
   });
 
   describe("getWorkspacePath", () => {
-    it("returns ~/.isotopes/workspace for default agent", () => {
-      const expected = path.join(os.homedir(), ".isotopes", "workspace");
-      expect(getWorkspacePath("default")).toBe(expected);
-    });
-
-    it("returns ~/.isotopes/workspace-{id} for named agent", () => {
-      const expected = path.join(os.homedir(), ".isotopes", "workspace-assistant");
-      expect(getWorkspacePath("assistant")).toBe(expected);
+    it("returns ~/.isotopes/workspace-{id} for any agent", () => {
+      expect(getWorkspacePath("default")).toBe(
+        path.join(os.homedir(), ".isotopes", "workspace-default"),
+      );
+      expect(getWorkspacePath("main")).toBe(
+        path.join(os.homedir(), ".isotopes", "workspace-main"),
+      );
     });
   });
 
@@ -154,13 +153,13 @@ describe("paths", () => {
   });
 
   describe("ensureWorkspaceDir", () => {
-    it("creates workspace dir for default agent and returns its path", async () => {
+    it("creates workspace-{id} dir and returns its path", async () => {
       const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "isotopes-paths-"));
       const home = path.join(tmp, "home");
       vi.stubEnv("ISOTOPES_HOME", home);
       try {
         const ws = await ensureWorkspaceDir("default");
-        expect(ws).toBe(path.join(home, "workspace"));
+        expect(ws).toBe(path.join(home, "workspace-default"));
         await expect(fs.stat(ws)).resolves.toMatchObject({});
       } finally {
         await fs.rm(tmp, { recursive: true, force: true });

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -9,9 +9,6 @@ import fs from "node:fs/promises";
 // Constants
 // ---------------------------------------------------------------------------
 
-/** The default agent ID used for single-agent setups. */
-const DEFAULT_AGENT_ID = "default";
-
 // ---------------------------------------------------------------------------
 // Base directories
 // ---------------------------------------------------------------------------
@@ -40,14 +37,9 @@ export function getLogsDir(): string {
 /**
  * Get the workspace directory for an agent.
  *
- * Layout mirrors OpenClaw:
- * - Default agent: ~/.isotopes/workspace/
- * - Named agent:   ~/.isotopes/workspace-{agentId}/
+ * All agents use: ~/.isotopes/workspace-{agentId}/
  */
 export function getWorkspacePath(agentId: string): string {
-  if (agentId === DEFAULT_AGENT_ID) {
-    return path.join(getIsotopesHome(), "workspace");
-  }
   return path.join(getIsotopesHome(), `workspace-${agentId}`);
 }
 

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -92,7 +92,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   const agentWorkspaces = new Map<string, string>();
   const transportContexts = new Map<string, LazyTransportContext>();
   const processRegistries = new Map<string, ProcessRegistry>();
-  const isSingleAgent = config.agents.length === 1;
 
   // Build sandbox executor if any agent uses sandboxing
   let sandboxExecutor: SandboxExecutor | undefined;
@@ -133,7 +132,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       subagent: config.subagent,
       core,
       agentManager,
-      isSingleAgent,
       sandboxExecutor,
       transportContext: transportCtx,
       hooks: pluginManager.getHooks(),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -369,9 +369,24 @@ export interface DiscordAccountConfig {
     /** Discord user IDs allowed to DM when policy is "allowlist". */
     allowlist?: string[];
   };
-  /** Restrict the bot to a list of channel IDs. */
+  /** Group (guild) access control — parallel to `dm`. */
+  group?: {
+    /** "allowlist" (default) = only listed channels/guilds, "disabled" = ignore all guild messages, "open" = accept all guild channels. */
+    policy?: "disabled" | "allowlist" | "open";
+    /** Channel IDs allowed when policy is "allowlist". */
+    channelAllowlist?: string[];
+    /** Guild (server) IDs allowed when policy is "allowlist". */
+    guildAllowlist?: string[];
+  };
+  /**
+   * Restrict the bot to a list of channel IDs.
+   * @deprecated Use `group.channelAllowlist` with `group.policy: "allowlist"`.
+   */
   channelAllowlist?: string[];
-  /** Group join policy (allowlist/denylist semantics, transport-defined). */
+  /**
+   * Group join policy (allowlist/denylist semantics, transport-defined).
+   * @deprecated Use `group.policy`.
+   */
   groupPolicy?: string;
   /** Per-guild configuration keyed by guild ID */
   guilds?: Record<string, GuildConfig>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -364,8 +364,8 @@ export interface DiscordAccountConfig {
   agentBindings?: Record<string, string>;
   /** DM access control. */
   dm?: {
-    /** "disabled" (default) = ignore all DMs, "open" = accept all, "allowlist" = only from listed user IDs. */
-    policy?: "disabled" | "open" | "allowlist";
+    /** "disabled" (default) = ignore all DMs, "allowlist" = only from listed user IDs. */
+    policy?: "disabled" | "allowlist";
     /** Discord user IDs allowed to DM when policy is "allowlist". */
     allowlist?: string[];
   };

--- a/src/init/render.test.ts
+++ b/src/init/render.test.ts
@@ -22,15 +22,56 @@ describe("renderConfig", () => {
     expect(yaml).toContain("model: claude-opus-4.7");
   });
 
-  it("emits a discord channel block when discord token is provided", () => {
+  it("emits discord with dm disabled and group allowlist by default", () => {
     const yaml = renderConfig({
       llm: "skip",
       channel: "discord",
-      discord: { token: "bot-token-abc" },
+      discord: { token: "bot-token-abc", dmPolicy: "disabled", groupPolicy: "allowlist" },
     });
     expect(yaml).toContain("channels:");
     expect(yaml).toContain("token: bot-token-abc");
     expect(yaml).toContain("defaultAgentId: main");
+    expect(yaml).toContain("policy: disabled");
+    expect(yaml).toContain("policy: allowlist");
+  });
+
+  it("emits dm allowlist with user ID", () => {
+    const yaml = renderConfig({
+      llm: "skip",
+      channel: "discord",
+      discord: { token: "tok", dmPolicy: "allowlist", dmUserId: "111222333", groupPolicy: "open" },
+    });
+    expect(yaml).toContain('- "111222333"');
+    expect(yaml).toMatch(/dm:\s+policy: allowlist/);
+  });
+
+  it("emits group allowlist with guild and channel IDs", () => {
+    const yaml = renderConfig({
+      llm: "skip",
+      channel: "discord",
+      discord: {
+        token: "tok",
+        dmPolicy: "disabled",
+        groupPolicy: "allowlist",
+        groupAllowlist: ["111222333", "444555666/777888999"],
+      },
+    });
+    expect(yaml).toMatch(/group:\s+policy: allowlist/);
+    expect(yaml).toContain('- "111222333"');
+    expect(yaml).toContain('- "444555666"');
+    expect(yaml).toContain('- "777888999"');
+    expect(yaml).toContain("guildAllowlist:");
+    expect(yaml).toContain("channelAllowlist:");
+  });
+
+  it("emits group open without allowlist entries", () => {
+    const yaml = renderConfig({
+      llm: "skip",
+      channel: "discord",
+      discord: { token: "tok", dmPolicy: "disabled", groupPolicy: "open" },
+    });
+    expect(yaml).toMatch(/group:\s+policy: open/);
+    expect(yaml).not.toContain("guildAllowlist:");
   });
 
   it("emits both provider and channel when both selected", () => {
@@ -38,7 +79,7 @@ describe("renderConfig", () => {
       llm: "ghc-proxy",
       ghcProxy: { baseUrl: "https://api.example.com", apiKey: "sk-test", model: "claude-opus-4.7" },
       channel: "discord",
-      discord: { token: "bot-token-abc" },
+      discord: { token: "bot-token-abc", dmPolicy: "disabled", groupPolicy: "allowlist" },
     });
     expect(yaml).toContain("type: anthropic-proxy");
     expect(yaml).toContain("token: bot-token-abc");

--- a/src/init/render.test.ts
+++ b/src/init/render.test.ts
@@ -6,7 +6,7 @@ describe("renderConfig", () => {
     const yaml = renderConfig({ llm: "skip", channel: "skip" });
     expect(yaml).toMatch(/^# provider:/m);
     expect(yaml).toContain("agents:");
-    expect(yaml).toContain("- id: assistant");
+    expect(yaml).toContain("- id: main");
     expect(yaml).not.toContain("channels:");
   });
 
@@ -30,7 +30,7 @@ describe("renderConfig", () => {
     });
     expect(yaml).toContain("channels:");
     expect(yaml).toContain("token: bot-token-abc");
-    expect(yaml).toContain("defaultAgentId: assistant");
+    expect(yaml).toContain("defaultAgentId: main");
   });
 
   it("emits both provider and channel when both selected", () => {

--- a/src/init/render.ts
+++ b/src/init/render.ts
@@ -48,8 +48,8 @@ function renderChannels(answers: InitAnswers): string {
           policy: disabled
 `;
   const groupBlock = `        group:
-          policy: open                   # disabled | allowlist | open — narrow this once you know your channel/guild IDs
-          # channelAllowlist:
+          policy: open                   # default is "allowlist" (fail-closed); set to "open" here so the bot works out-of-the-box
+          # channelAllowlist:            # uncomment and switch policy to "allowlist" once you know your IDs
           #   - "channel-id"
           # guildAllowlist:
           #   - "guild-id"

--- a/src/init/render.ts
+++ b/src/init/render.ts
@@ -32,25 +32,36 @@ const TOOLS = `tools:
 `;
 
 const AGENTS = `agents:
-  - id: assistant
-    name: Assistant
-    systemPrompt: |
-      You are a helpful assistant running locally via Isotopes.
+  - id: main
 `;
 
 function renderChannels(answers: InitAnswers): string {
   if (answers.channel !== "discord" || !answers.discord) return "";
-  const { token } = answers.discord;
+  const { token, dmUserId } = answers.discord;
+  const dmBlock = dmUserId
+    ? `        dm:
+          policy: allowlist
+          allowlist:
+            - "${dmUserId}"
+`
+    : `        dm:
+          policy: disabled
+`;
+  const groupBlock = `        group:
+          policy: open                   # disabled | allowlist | open — narrow this once you know your channel/guild IDs
+          # channelAllowlist:
+          #   - "channel-id"
+          # guildAllowlist:
+          #   - "guild-id"
+`;
   return `
 channels:
   discord:
     accounts:
       main:
         token: ${token}
-        defaultAgentId: assistant
-        dm:
-          policy: disabled
-        threadBindings:
+        defaultAgentId: main
+${dmBlock}${groupBlock}        threadBindings:
           enabled: true
 `;
 }

--- a/src/init/render.ts
+++ b/src/init/render.ts
@@ -37,8 +37,9 @@ const AGENTS = `agents:
 
 function renderChannels(answers: InitAnswers): string {
   if (answers.channel !== "discord" || !answers.discord) return "";
-  const { token, dmUserId } = answers.discord;
-  const dmBlock = dmUserId
+  const { token, dmPolicy, dmUserId, groupPolicy, groupAllowlist } = answers.discord;
+
+  const dmBlock = dmPolicy === "allowlist" && dmUserId
     ? `        dm:
           policy: allowlist
           allowlist:
@@ -47,13 +48,34 @@ function renderChannels(answers: InitAnswers): string {
     : `        dm:
           policy: disabled
 `;
-  const groupBlock = `        group:
-          policy: open                   # default is "allowlist" (fail-closed); set to "open" here so the bot works out-of-the-box
-          # channelAllowlist:            # uncomment and switch policy to "allowlist" once you know your IDs
-          #   - "channel-id"
-          # guildAllowlist:
-          #   - "guild-id"
+
+  let groupBlock: string;
+  if (groupPolicy === "allowlist" && groupAllowlist?.length) {
+    const guildIds = new Set<string>();
+    const channelIds: string[] = [];
+    for (const entry of groupAllowlist) {
+      const [guildId, channelId] = entry.split("/");
+      guildIds.add(guildId);
+      if (channelId) channelIds.push(channelId);
+    }
+    const guildLines = [...guildIds].map((id) => `            - "${id}"`).join("\n");
+    const channelLines = channelIds.map((id) => `            - "${id}"`).join("\n");
+    groupBlock = `        group:
+          policy: allowlist
+          guildAllowlist:
+${guildLines}
 `;
+    if (channelLines.length > 0) {
+      groupBlock += `          channelAllowlist:
+${channelLines}
+`;
+    }
+  } else {
+    groupBlock = `        group:
+          policy: ${groupPolicy}
+`;
+  }
+
   return `
 channels:
   discord:

--- a/src/init/wizard.tsx
+++ b/src/init/wizard.tsx
@@ -23,6 +23,7 @@ export interface GhcProxyAnswers {
 
 export interface DiscordAnswers {
   token: string;
+  dmUserId?: string;
 }
 
 export interface InitAnswers {
@@ -49,7 +50,9 @@ type Step =
   | { kind: "ghc-apiKey" }
   | { kind: "ghc-model" }
   | { kind: "channel" }
-  | { kind: "discord-token" };
+  | { kind: "discord-token" }
+  | { kind: "discord-dm-choice" }
+  | { kind: "discord-dm-userId" };
 
 interface Props {
   onDone: (answers: InitAnswers) => void;
@@ -66,6 +69,7 @@ function InitWizard({ onDone }: Props) {
 
   const [channel, setChannel] = useState<ChannelChoice>("skip");
   const [discordToken, setDiscordToken] = useState("");
+  const [discordDmUserId, setDiscordDmUserId] = useState("");
 
   useInput((_input, key) => {
     if (key.ctrl && _input === "c") {
@@ -81,7 +85,14 @@ function InitWizard({ onDone }: Props) {
       ...(llm === "ghc-proxy"
         ? { ghcProxy: { baseUrl: ghcBaseUrl, apiKey: ghcApiKey, model: ghcModel } }
         : {}),
-      ...(channel === "discord" ? { discord: { token: discordToken } } : {}),
+      ...(channel === "discord"
+        ? {
+            discord: {
+              token: discordToken,
+              ...(discordDmUserId.trim().length > 0 ? { dmUserId: discordDmUserId.trim() } : {}),
+            },
+          }
+        : {}),
       ...overrides,
     };
     onDone(answers);
@@ -190,12 +201,47 @@ function InitWizard({ onDone }: Props) {
               value={discordToken}
               onChange={setDiscordToken}
               onSubmit={() => {
-                if (discordToken.trim().length > 0) finish();
+                if (discordToken.trim().length > 0) setStep({ kind: "discord-dm-choice" });
               }}
             />
           </Box>
           {discordToken.trim().length === 0 && (
             <Text color="yellow">  token is required</Text>
+          )}
+        </Box>
+      )}
+
+      {step.kind === "discord-dm-choice" && (
+        <Box flexDirection="column">
+          <Text>Configure DM (direct message) access?</Text>
+          <SelectInput
+            items={[
+              { label: "yes (allowlist your Discord user ID)", value: "yes" as const },
+              { label: "no (DMs disabled, configure later)", value: "no" as const },
+            ]}
+            onSelect={(item) => {
+              if (item.value === "yes") setStep({ kind: "discord-dm-userId" });
+              else finish();
+            }}
+          />
+        </Box>
+      )}
+
+      {step.kind === "discord-dm-userId" && (
+        <Box flexDirection="column">
+          <Text>Your Discord user ID (numeric, e.g. 123456789012345678):</Text>
+          <Box>
+            <Text color="cyan">› </Text>
+            <TextInput
+              value={discordDmUserId}
+              onChange={setDiscordDmUserId}
+              onSubmit={() => {
+                if (/^\d+$/.test(discordDmUserId.trim())) finish();
+              }}
+            />
+          </Box>
+          {discordDmUserId.trim().length > 0 && !/^\d+$/.test(discordDmUserId.trim()) && (
+            <Text color="yellow">  must be a numeric Discord user ID</Text>
           )}
         </Box>
       )}

--- a/src/init/wizard.tsx
+++ b/src/init/wizard.tsx
@@ -21,9 +21,15 @@ export interface GhcProxyAnswers {
   model: string;
 }
 
+export type DmPolicyChoice = "disabled" | "allowlist";
+export type GroupPolicyChoice = "disabled" | "allowlist" | "open";
+
 export interface DiscordAnswers {
   token: string;
+  dmPolicy: DmPolicyChoice;
   dmUserId?: string;
+  groupPolicy: GroupPolicyChoice;
+  groupAllowlist?: string[];
 }
 
 export interface InitAnswers {
@@ -51,8 +57,10 @@ type Step =
   | { kind: "ghc-model" }
   | { kind: "channel" }
   | { kind: "discord-token" }
-  | { kind: "discord-dm-choice" }
-  | { kind: "discord-dm-userId" };
+  | { kind: "discord-dm-policy" }
+  | { kind: "discord-dm-userId" }
+  | { kind: "discord-group-policy" }
+  | { kind: "discord-group-allowlist" };
 
 interface Props {
   onDone: (answers: InitAnswers) => void;
@@ -69,7 +77,10 @@ function InitWizard({ onDone }: Props) {
 
   const [channel, setChannel] = useState<ChannelChoice>("skip");
   const [discordToken, setDiscordToken] = useState("");
+  const [dmPolicy, setDmPolicy] = useState<DmPolicyChoice>("disabled");
   const [discordDmUserId, setDiscordDmUserId] = useState("");
+  const [groupPolicy, setGroupPolicy] = useState<GroupPolicyChoice>("allowlist");
+  const [groupAllowlistInput, setGroupAllowlistInput] = useState("");
 
   useInput((_input, key) => {
     if (key.ctrl && _input === "c") {
@@ -89,7 +100,14 @@ function InitWizard({ onDone }: Props) {
         ? {
             discord: {
               token: discordToken,
-              ...(discordDmUserId.trim().length > 0 ? { dmUserId: discordDmUserId.trim() } : {}),
+              dmPolicy,
+              ...(dmPolicy === "allowlist" && discordDmUserId.trim().length > 0
+                ? { dmUserId: discordDmUserId.trim() }
+                : {}),
+              groupPolicy,
+              ...(groupPolicy === "allowlist" && groupAllowlistInput.trim().length > 0
+                ? { groupAllowlist: groupAllowlistInput.trim().split(",").map((s) => s.trim()) }
+                : {}),
             },
           }
         : {}),
@@ -201,7 +219,7 @@ function InitWizard({ onDone }: Props) {
               value={discordToken}
               onChange={setDiscordToken}
               onSubmit={() => {
-                if (discordToken.trim().length > 0) setStep({ kind: "discord-dm-choice" });
+                if (discordToken.trim().length > 0) setStep({ kind: "discord-dm-policy" });
               }}
             />
           </Box>
@@ -211,17 +229,18 @@ function InitWizard({ onDone }: Props) {
         </Box>
       )}
 
-      {step.kind === "discord-dm-choice" && (
+      {step.kind === "discord-dm-policy" && (
         <Box flexDirection="column">
-          <Text>Configure DM (direct message) access?</Text>
+          <Text>DM (direct message) policy:</Text>
           <SelectInput
             items={[
-              { label: "yes (allowlist your Discord user ID)", value: "yes" as const },
-              { label: "no (DMs disabled, configure later)", value: "no" as const },
+              { label: "disabled (default)", value: "disabled" as const },
+              { label: "allowlist (enter your Discord user ID)", value: "allowlist" as const },
             ]}
             onSelect={(item) => {
-              if (item.value === "yes") setStep({ kind: "discord-dm-userId" });
-              else finish();
+              setDmPolicy(item.value);
+              if (item.value === "allowlist") setStep({ kind: "discord-dm-userId" });
+              else setStep({ kind: "discord-group-policy" });
             }}
           />
         </Box>
@@ -236,13 +255,55 @@ function InitWizard({ onDone }: Props) {
               value={discordDmUserId}
               onChange={setDiscordDmUserId}
               onSubmit={() => {
-                if (/^\d+$/.test(discordDmUserId.trim())) finish();
+                if (/^\d+$/.test(discordDmUserId.trim())) setStep({ kind: "discord-group-policy" });
               }}
             />
           </Box>
           {discordDmUserId.trim().length > 0 && !/^\d+$/.test(discordDmUserId.trim()) && (
             <Text color="yellow">  must be a numeric Discord user ID</Text>
           )}
+        </Box>
+      )}
+
+      {step.kind === "discord-group-policy" && (
+        <Box flexDirection="column">
+          <Text>Group (server/guild) policy:</Text>
+          <SelectInput
+            items={[
+              { label: "allowlist (default — enter server/channel IDs)", value: "allowlist" as const },
+              { label: "open (accept all servers)", value: "open" as const },
+              { label: "disabled (ignore all guild messages)", value: "disabled" as const },
+            ]}
+            onSelect={(item) => {
+              setGroupPolicy(item.value);
+              if (item.value === "allowlist") setStep({ kind: "discord-group-allowlist" });
+              else finish();
+            }}
+          />
+        </Box>
+      )}
+
+      {step.kind === "discord-group-allowlist" && (
+        <Box flexDirection="column">
+          <Text>Server/channel allowlist (format: serverId or serverId/channelId, comma-separated):</Text>
+          <Text dimColor>  e.g. 123456789012345678, 987654321098765432/111222333444555666</Text>
+          <Box>
+            <Text color="cyan">› </Text>
+            <TextInput
+              value={groupAllowlistInput}
+              onChange={setGroupAllowlistInput}
+              onSubmit={() => {
+                const entries = groupAllowlistInput.trim().split(",").map((s) => s.trim()).filter(Boolean);
+                const valid = entries.every((e) => /^\d+(\/\d+)?$/.test(e));
+                if (entries.length > 0 && valid) finish();
+              }}
+            />
+          </Box>
+          {groupAllowlistInput.trim().length > 0 && (() => {
+            const entries = groupAllowlistInput.trim().split(",").map((s) => s.trim()).filter(Boolean);
+            const valid = entries.every((e) => /^\d+(\/\d+)?$/.test(e));
+            return !valid ? <Text color="yellow">  each entry must be serverId or serverId/channelId (numeric)</Text> : null;
+          })()}
         </Box>
       )}
     </Box>

--- a/src/transports/discord-manager.test.ts
+++ b/src/transports/discord-manager.test.ts
@@ -121,7 +121,7 @@ describe("DiscordTransportManager", () => {
         major: {
           token: "tok-major",
           defaultAgentId: "major",
-          dm: { policy: "open" },
+          dm: { policy: "allowlist", allowlist: ["user-1"] },
           channelAllowlist: ["ch-1"],
         },
         tachikoma: {

--- a/src/transports/discord-manager.ts
+++ b/src/transports/discord-manager.ts
@@ -63,6 +63,7 @@ export class DiscordTransportManager {
         defaultAgentId: account.defaultAgentId,
         agentBindings: account.agentBindings,
         dm: account.dm,
+        group: account.group,
         channelAllowlist: account.channelAllowlist,
         channels: shared.channels,
         accountId,

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -269,7 +269,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -307,7 +307,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -345,7 +345,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -393,7 +393,7 @@ describe("DiscordTransport", () => {
   describe("thread bindings", () => {
     it("registers threadCreate handler when threadBindings.enabled is true", async () => {
       const transportWithThreads = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -414,7 +414,7 @@ describe("DiscordTransport", () => {
 
     it("does NOT register threadCreate handler when threadBindings.enabled is false", async () => {
       const transportNoThreads = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -449,7 +449,7 @@ describe("DiscordTransport", () => {
     it("creates a binding when a thread is created", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -482,7 +482,7 @@ describe("DiscordTransport", () => {
     it("uses 'default' agentId when defaultAgentId is not configured", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -507,7 +507,7 @@ describe("DiscordTransport", () => {
     it("ignores threads without a parent channel", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -562,7 +562,7 @@ describe("DiscordTransport", () => {
     it("exposes thread binding manager via getThreadBindingManager()", () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -575,7 +575,7 @@ describe("DiscordTransport", () => {
 
     it("creates a default ThreadBindingManager when none is provided", () => {
       const transportWithThreads = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -616,7 +616,7 @@ describe("DiscordTransport", () => {
 
     it("routes /status to command handler and sends response", async () => {
       const transportWithAdmin = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -645,7 +645,7 @@ describe("DiscordTransport", () => {
       (agentManager.reloadWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const transportWithAdmin = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -673,7 +673,7 @@ describe("DiscordTransport", () => {
       ]);
 
       const transportWithAdmin = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -697,7 +697,7 @@ describe("DiscordTransport", () => {
 
     it("rejects non-admin users with authorization error", async () => {
       const transportWithAdmin = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -721,7 +721,7 @@ describe("DiscordTransport", () => {
 
     it("passes non-command messages through to agent", async () => {
       const transportWithAdmin = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -745,7 +745,7 @@ describe("DiscordTransport", () => {
 
     it("ignores unknown slash commands and passes them to agent", async () => {
       const transportWithAdmin = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -808,7 +808,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportCtx = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -832,7 +832,7 @@ describe("DiscordTransport", () => {
 
     it("injects channel history into user message when bot is triggered", async () => {
       const transportMention = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -877,7 +877,7 @@ describe("DiscordTransport", () => {
 
     it("deduplicates messages with the same ID", async () => {
       const transportCtx = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -912,7 +912,7 @@ describe("DiscordTransport", () => {
       ]);
 
       const transportCtx = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -959,7 +959,7 @@ describe("DiscordTransport", () => {
 
       // Need to set up bindings via config
       const testTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -1004,7 +1004,7 @@ describe("DiscordTransport", () => {
       sessionStore.getMessages = vi.fn().mockResolvedValue([]);
 
       const testTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -1066,7 +1066,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1087,7 +1087,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1109,7 +1109,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1131,7 +1131,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1201,7 +1201,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(hangingAgent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1251,7 +1251,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1312,7 +1312,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(completingAgent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1394,7 +1394,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1425,7 +1425,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1460,7 +1460,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1485,7 +1485,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1516,7 +1516,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1547,7 +1547,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-      group: { policy: "open" },
+        group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -1009,7 +1009,7 @@ describe("DiscordTransport", () => {
         agentManager,
         sessionStore,
         defaultAgentId: "default",
-        dm: { policy: "open" },
+        dm: { policy: "allowlist", allowlist: ["user-bob"] },
       });
 
       const msg: MockIncomingMessage = {
@@ -1552,7 +1552,7 @@ describe("DiscordTransport", () => {
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
-        dm: { policy: "open" },
+        dm: { policy: "allowlist", allowlist: ["user-1"] },
       });
       await localTransport.start();
 

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -73,6 +73,7 @@ describe("DiscordTransport", () => {
     agentManager = createMockAgentManager();
     sessionStore = createMockSessionStore();
     transport = new DiscordTransport({
+      group: { policy: "open" },
       token: "test-token",
       agentManager,
       sessionStore,
@@ -268,6 +269,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -305,6 +307,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -342,6 +345,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -389,6 +393,7 @@ describe("DiscordTransport", () => {
   describe("thread bindings", () => {
     it("registers threadCreate handler when threadBindings.enabled is true", async () => {
       const transportWithThreads = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -409,6 +414,7 @@ describe("DiscordTransport", () => {
 
     it("does NOT register threadCreate handler when threadBindings.enabled is false", async () => {
       const transportNoThreads = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -443,6 +449,7 @@ describe("DiscordTransport", () => {
     it("creates a binding when a thread is created", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -475,6 +482,7 @@ describe("DiscordTransport", () => {
     it("uses 'default' agentId when defaultAgentId is not configured", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -499,6 +507,7 @@ describe("DiscordTransport", () => {
     it("ignores threads without a parent channel", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -553,6 +562,7 @@ describe("DiscordTransport", () => {
     it("exposes thread binding manager via getThreadBindingManager()", () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -565,6 +575,7 @@ describe("DiscordTransport", () => {
 
     it("creates a default ThreadBindingManager when none is provided", () => {
       const transportWithThreads = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -605,6 +616,7 @@ describe("DiscordTransport", () => {
 
     it("routes /status to command handler and sends response", async () => {
       const transportWithAdmin = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -633,6 +645,7 @@ describe("DiscordTransport", () => {
       (agentManager.reloadWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const transportWithAdmin = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -660,6 +673,7 @@ describe("DiscordTransport", () => {
       ]);
 
       const transportWithAdmin = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -683,6 +697,7 @@ describe("DiscordTransport", () => {
 
     it("rejects non-admin users with authorization error", async () => {
       const transportWithAdmin = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -706,6 +721,7 @@ describe("DiscordTransport", () => {
 
     it("passes non-command messages through to agent", async () => {
       const transportWithAdmin = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -729,6 +745,7 @@ describe("DiscordTransport", () => {
 
     it("ignores unknown slash commands and passes them to agent", async () => {
       const transportWithAdmin = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -791,6 +808,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportCtx = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -814,6 +832,7 @@ describe("DiscordTransport", () => {
 
     it("injects channel history into user message when bot is triggered", async () => {
       const transportMention = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -858,6 +877,7 @@ describe("DiscordTransport", () => {
 
     it("deduplicates messages with the same ID", async () => {
       const transportCtx = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -892,6 +912,7 @@ describe("DiscordTransport", () => {
       ]);
 
       const transportCtx = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -938,6 +959,7 @@ describe("DiscordTransport", () => {
 
       // Need to set up bindings via config
       const testTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -982,6 +1004,7 @@ describe("DiscordTransport", () => {
       sessionStore.getMessages = vi.fn().mockResolvedValue([]);
 
       const testTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -1043,6 +1066,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1063,6 +1087,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1084,6 +1109,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1105,6 +1131,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1174,6 +1201,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(hangingAgent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1223,6 +1251,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1283,6 +1312,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(completingAgent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1364,6 +1394,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1394,6 +1425,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1428,6 +1460,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1452,6 +1485,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1482,6 +1516,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1512,6 +1547,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
+      group: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -159,7 +159,16 @@ export interface DiscordTransportConfig {
     policy?: "disabled" | "open" | "allowlist";
     allowlist?: string[];
   };
-  /** Channel IDs to listen to (empty = all) */
+  /** Group (guild) access control — parallel to `dm`. Default policy is `"allowlist"`. */
+  group?: {
+    policy?: "disabled" | "allowlist" | "open";
+    channelAllowlist?: string[];
+    guildAllowlist?: string[];
+  };
+  /**
+   * Channel IDs to listen to (empty = all).
+   * @deprecated Use `group.channelAllowlist` with `group.policy: "allowlist"`.
+   */
   channelAllowlist?: string[];
   /** Channels config for per-guild/group settings (e.g. requireMention) */
   channels?: ChannelsConfig;
@@ -306,9 +315,16 @@ export class DiscordTransport implements Transport {
       return;
     }
 
-    // If there's a channel allowlist, only bind threads in allowed channels
-    if (this.config.channelAllowlist?.length) {
-      if (!this.config.channelAllowlist.includes(thread.parentId)) {
+    // If a channel allowlist is configured, only bind threads in allowed channels.
+    const group = this.resolveGroup();
+    if (group.policy === "disabled") {
+      log.debug(`Ignoring thread ${thread.id} — group policy disabled`);
+      return;
+    }
+    if (group.policy === "allowlist") {
+      const channelOk = group.channelAllowlist?.includes(thread.parentId) ?? false;
+      // For thread parents we only check the channel list; guild-level allow is handled at message time.
+      if (!channelOk && !group.guildAllowlist?.length) {
         log.debug(`Ignoring thread ${thread.id} — parent ${thread.parentId} not in allowlist`);
         return;
       }
@@ -558,17 +574,41 @@ export class DiscordTransport implements Transport {
     return false;
   }
 
+  /** Resolve the effective group config, honoring legacy `channelAllowlist` for back-compat. Default policy is fail-closed `"allowlist"`. */
+  private resolveGroup(): {
+    policy: "disabled" | "allowlist" | "open";
+    channelAllowlist?: string[];
+    guildAllowlist?: string[];
+  } {
+    const g = this.config.group;
+    if (g?.policy || g?.channelAllowlist?.length || g?.guildAllowlist?.length) {
+      return {
+        policy: g.policy ?? "allowlist",
+        channelAllowlist: g.channelAllowlist,
+        guildAllowlist: g.guildAllowlist,
+      };
+    }
+    // Legacy: top-level channelAllowlist implies allowlist policy on channels.
+    const legacy = this.config.channelAllowlist;
+    if (legacy?.length) {
+      return { policy: "allowlist", channelAllowlist: legacy };
+    }
+    return { policy: "allowlist" };
+  }
+
   private shouldRespond(msg: DiscordMessage): boolean {
     // DM handling
     if (!msg.guild) {
       return this.isDmAllowed(msg.author.id);
     }
 
-    // Channel allowlist
-    if (this.config.channelAllowlist?.length) {
-      if (!this.config.channelAllowlist.includes(msg.channelId)) {
-        return false;
-      }
+    // Group (guild) policy
+    const group = this.resolveGroup();
+    if (group.policy === "disabled") return false;
+    if (group.policy === "allowlist") {
+      const channelOk = group.channelAllowlist?.includes(msg.channelId) ?? false;
+      const guildOk = group.guildAllowlist?.includes(msg.guild.id) ?? false;
+      if (!channelOk && !guildOk) return false;
     }
 
     // Check mention-based response using guild config

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -156,7 +156,7 @@ export interface DiscordTransportConfig {
   agentBindings?: Record<string, string>;
   /** DM access control policy. */
   dm?: {
-    policy?: "disabled" | "open" | "allowlist";
+    policy?: "disabled" | "allowlist";
     allowlist?: string[];
   };
   /** Group (guild) access control — parallel to `dm`. Default policy is `"allowlist"`. */
@@ -567,7 +567,6 @@ export class DiscordTransport implements Transport {
     if (dm?.policy) {
       switch (dm.policy) {
         case "disabled": return false;
-        case "open": return true;
         case "allowlist": return dm.allowlist?.includes(userId) ?? false;
       }
     }

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -323,8 +323,8 @@ export class DiscordTransport implements Transport {
     }
     if (group.policy === "allowlist") {
       const channelOk = group.channelAllowlist?.includes(thread.parentId) ?? false;
-      // For thread parents we only check the channel list; guild-level allow is handled at message time.
-      if (!channelOk && !group.guildAllowlist?.length) {
+      const guildOk = group.guildAllowlist?.includes(thread.guildId) ?? false;
+      if (!channelOk && !guildOk) {
         log.debug(`Ignoring thread ${thread.id} — parent ${thread.parentId} not in allowlist`);
         return;
       }

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -58,7 +58,6 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         subagent: config.subagent,
         core,
         agentManager: mgr,
-        isSingleAgent: config.agents.length === 1,
       });
 
       agentRef.current = result.instance;


### PR DESCRIPTION
## Summary

- **Init wizard**: after Discord token, asks about DM access and prompts for Discord user ID (allowlist)
- **Init render**: default agent is `main`, removed dead `systemPrompt`/`name` fields from generated YAML
- **Discord group policy**: added `group: { policy, channelAllowlist, guildAllowlist }` parallel to `dm` on `DiscordAccountConfig`. Default is fail-closed `allowlist`. Deprecated top-level `channelAllowlist` and `groupPolicy` with back-compat shim in `resolveGroup()`
- **Removed `isSingleAgent`**: all agents now use `workspace-{agentId}/` uniformly. Removed `DEFAULT_AGENT_ID` and bare `workspace/` special case from `paths.ts`

## Breaking changes

- Existing configs without `group: { policy: open }` will now block all guild messages (fail-closed default). Users must add `group: { policy: open }` or list specific channels/guilds.
- Single-agent setups: workspace moves from `~/.isotopes/workspace/` to `~/.isotopes/workspace-{id}/`. Users should manually move their workspace directory.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `discord.test.ts` — 44 tests pass (all transport constructions updated with `group: { policy: "open" }`, legacy `channelAllowlist` test preserved)
- [x] `discord-manager.test.ts` — 5 tests pass
- [x] `render.test.ts` — 4 tests pass (updated assertions for `main` agent, `defaultAgentId: main`)
- [x] `paths.test.ts` — 21 tests pass (updated workspace path assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)