### PR TITLE
chore(init): default model to claude-opus-4.6

### DIFF
--- a/src/init/render.ts
+++ b/src/init/render.ts
@@ -10,7 +10,7 @@ const HEADER = `# ~/.isotopes/isotopes.yaml
 
 const PROVIDER_SKIP = `# provider:
 #   type: anthropic
-#   model: claude-sonnet-4-5-20250929
+#   model: claude-opus-4.6
 #   apiKey: \${ANTHROPIC_API_KEY}
 `;
 

--- a/src/init/wizard.tsx
+++ b/src/init/wizard.tsx
@@ -44,7 +44,7 @@ export interface InitAnswers {
 // ---------------------------------------------------------------------------
 
 const DEFAULT_GHC_BASE_URL = "https://api.ghccoder.com";
-const DEFAULT_GHC_MODEL = "claude-opus-4.7";
+const DEFAULT_GHC_MODEL = "claude-opus-4.6";
 
 // ---------------------------------------------------------------------------
 // Wizard


### PR DESCRIPTION
## Summary

- Default GHC proxy model changed from `claude-opus-4.7` to `claude-opus-4.6`
- Also updated the skip-provider template comment to show `claude-opus-4.6`

## Test plan

- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)