### PR TITLE
fix(discord): include message ID in inbound metadata

### DIFF
--- a/src/transports/message-metadata.test.ts
+++ b/src/transports/message-metadata.test.ts
@@ -9,6 +9,7 @@ import { extractDiscordMetadata, formatInboundMeta, type MessageMetadata } from 
 
 function createMockDiscordMessage(overrides: Record<string, unknown> = {}) {
   return {
+    id: overrides.id ?? "msg-001",
     author: {
       id: "user-123",
       username: "testuser",
@@ -183,14 +184,16 @@ describe("extractDiscordMetadata", () => {
 describe("formatInboundMeta", () => {
   it("formats basic metadata for group chat", () => {
     const meta: MessageMetadata = {
+      messageId: "msg-001",
       sender: { id: "123", username: "testuser", isBot: false },
       timestamps: { sent: 1700000000000, received: 1700000001000 },
       channel: { id: "456", name: "general", type: "text" },
     };
-    
+
     const result = formatInboundMeta(meta, "group");
-    
+
     expect(result).toContain('<inbound_meta type="untrusted">');
+    expect(result).toContain("<message_id>msg-001</message_id>");
     expect(result).toContain("<chat_type>group</chat_type>");
     expect(result).toContain("<channel_id>456</channel_id>");
     expect(result).toContain("<channel_name>general</channel_name>");
@@ -202,6 +205,7 @@ describe("formatInboundMeta", () => {
 
   it("formats metadata for direct chat", () => {
     const meta: MessageMetadata = {
+      messageId: "msg-002",
       sender: { id: "123", username: "testuser", isBot: false },
       timestamps: { sent: 1700000000000, received: 1700000001000 },
       channel: { id: "789", type: "dm" },
@@ -215,6 +219,7 @@ describe("formatInboundMeta", () => {
 
   it("includes reply_to when present", () => {
     const meta: MessageMetadata = {
+      messageId: "msg-003",
       sender: { id: "123", username: "testuser", isBot: false },
       timestamps: { sent: 1700000000000, received: 1700000001000 },
       channel: { id: "456", type: "text" },
@@ -228,18 +233,20 @@ describe("formatInboundMeta", () => {
 
   it("includes display name when present", () => {
     const meta: MessageMetadata = {
+      messageId: "msg-004",
       sender: { id: "123", username: "testuser", displayName: "Test User", isBot: false },
       timestamps: { sent: 1700000000000, received: 1700000001000 },
       channel: { id: "456", type: "text" },
     };
-    
+
     const result = formatInboundMeta(meta, "group");
-    
+
     expect(result).toContain("<sender_display_name>Test User</sender_display_name>");
   });
 
   it("escapes XML special characters", () => {
     const meta: MessageMetadata = {
+      messageId: "msg-005",
       sender: { id: "123", username: "test<user>", displayName: "Test & User", isBot: false },
       timestamps: { sent: 1700000000000, received: 1700000001000 },
       channel: { id: "456", name: "chat\"room'1", type: "text" },

--- a/src/transports/message-metadata.ts
+++ b/src/transports/message-metadata.ts
@@ -15,6 +15,9 @@ export type ChannelType = "text" | "dm" | "thread" | "voice" | "news" | "unknown
 
 /** Structured metadata extracted from an incoming transport message. */
 export interface MessageMetadata {
+  /** The message's own ID (snowflake) */
+  messageId: string;
+
   /** Sender information */
   sender: {
     id: string;
@@ -67,6 +70,7 @@ function resolveDiscordChannelType(channelType: number): ChannelType {
  */
 export function extractDiscordMetadata(msg: DiscordMessage): MessageMetadata {
   return {
+    messageId: msg.id,
     sender: {
       id: msg.author.id,
       username: msg.author.username,
@@ -95,6 +99,7 @@ export function extractDiscordMetadata(msg: DiscordMessage): MessageMetadata {
 export function formatInboundMeta(meta: MessageMetadata, chatType: "direct" | "group"): string {
   const lines: string[] = [
     `<inbound_meta type="untrusted">`,
+    `  <message_id>${meta.messageId}</message_id>`,
     `  <chat_type>${chatType}</chat_type>`,
     `  <channel_id>${meta.channel.id}</channel_id>`,
   ];


### PR DESCRIPTION
## Summary
- Add `messageId` field to `MessageMetadata` interface and populate it from `msg.id` in `extractDiscordMetadata`
- Emit `<message_id>` in `formatInboundMeta` XML output so the LLM has the real snowflake ID
- Fixes `message_reply` tool failures caused by the LLM hallucinating truncated message IDs (e.g. 13-digit numbers instead of 18-19 digit snowflakes)

## Test plan
- [x] Typecheck passes
- [x] All 167 transport tests pass (including 17 message-metadata tests)
- [ ] Manual: send a message in Discord, verify `message_reply` uses the correct snowflake ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)