### PR TITLE
docs: update README with full CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install -g @ghostcomplex/isotopes
 # Generate ~/.isotopes/isotopes.yaml (interactive: pick LLM provider + channel)
 isotopes init
 
-# Set your API key, then run
+# Run
 export ANTHROPIC_API_KEY=sk-ant-...
 isotopes
 
@@ -37,20 +37,44 @@ node dist/cli.js
 
 ```
 isotopes                           Run in foreground (default)
+isotopes init [--force]            Generate ~/.isotopes/isotopes.yaml (interactive)
 isotopes start [--config path]     Start as background daemon
 isotopes stop                      Stop the running daemon
 isotopes status                    Show daemon status
 isotopes restart [--config path]   Restart the daemon
+isotopes reload [agentId]          Reload workspace (hot-reload)
+
+isotopes tui [--agent id] [--message "text"]
+                                   Interactive TUI chat with an agent
+
+isotopes sessions list             List all sessions
+isotopes sessions show <id>        Show session details
+isotopes sessions delete <id>      Delete a session
+isotopes sessions reset <id>       Reset session history
+
+isotopes cron list                 List scheduled jobs
+isotopes cron add <spec> <task>    Add a cron job
+isotopes cron remove <id>          Remove a cron job
+isotopes cron enable/disable <id>  Enable or disable a job
+isotopes cron run <id>             Run a job now
+
+isotopes logs [--lines N] [--level LEVEL] [-f]
+                                   View daemon logs
 
 isotopes service install           Install as system service (launchd/systemd)
 isotopes service uninstall         Remove system service
-isotopes service enable            Enable service (auto-start on boot)
-isotopes service disable           Disable service
+isotopes service enable/disable    Enable or disable auto-start on boot
 
 Options:
   -h, --help       Show help
   -v, --version    Show version
   -c, --config     Path to config file
+  --agent          Agent ID for tui command
+  --message        Send an initial message in TUI mode
+  --json           Output as JSON (sessions, cron commands)
+  --lines          Number of log lines (default: 50)
+  --level          Filter logs by level (debug/info/warn/error)
+  -f, --follow     Follow log output
 ```
 
 ## Configuration
@@ -60,7 +84,7 @@ Options:
 
 provider:
   type: anthropic                    # anthropic | openai | openai-proxy | anthropic-proxy
-  model: claude-sonnet-4-20250514
+  model: claude-opus-4.6
   apiKey: ${ANTHROPIC_API_KEY}
 
 tools:
@@ -69,8 +93,7 @@ tools:
     workspaceOnly: true              # Restrict file tools to workspace
 
 agents:
-  - id: assistant
-    name: Assistant
+  - id: main
     # tools:                         # Per-agent tool overrides
     #   cli: true
     # compaction:
@@ -82,8 +105,18 @@ channels:
   discord:
     accounts:
       main:
-        tokenEnv: DISCORD_TOKEN
-        defaultAgentId: assistant
+        token: ${DISCORD_TOKEN}
+        defaultAgentId: main
+        dm:
+          policy: disabled           # disabled (default) | allowlist
+          # allowlist:
+          #   - "123456789012345678"
+        group:
+          policy: allowlist          # disabled | allowlist (default) | open
+          # guildAllowlist:
+          #   - "guild-id"
+          # channelAllowlist:
+          #   - "channel-id"
 
 # See isotopes.example.yaml for full options including:
 # - Agent bindings (channel + account + peer routing)
@@ -97,4 +130,3 @@ See [isotopes.example.yaml](isotopes.example.yaml) for all options.
 ## License
 
 MIT
-


### PR DESCRIPTION
## Summary
- Add missing CLI commands: `init`, `tui`, `reload`, `sessions`, `cron`, `logs` with all options
- Fix stale defaults in config example: agent ID `assistant` → `main`, model → `claude-opus-4.6`
- Remove dead `name` field from agent config, add `dm`/`group` access control policy

## Test plan
- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)