### PR TITLE
refactor(config): remove deprecated discord account fields

### DIFF
--- a/docs/prd/PRD.md
+++ b/docs/prd/PRD.md
@@ -89,7 +89,8 @@ channels:
     accounts:
       major:
         token: "..."
-        groupPolicy: allowlist
+        group:
+          policy: allowlist
         guilds:
           "1480866703880487034":
             requireMention: false  # Respond without @mention

--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -20,10 +20,16 @@ provider:
 #   2) object form with shared defaults:
 #        agents:
 #          defaults:
-#            provider: { ... }
-#            tools: { ... }
-#            compaction: { ... }
-#            sandbox: { ... }
+#            provider:
+#              type: anthropic
+#              model: claude-opus-4.6
+#              apiKey: ${ANTHROPIC_API_KEY}
+#            tools:
+#              cli: false
+#            compaction:
+#              mode: safeguard
+#            sandbox:
+#              mode: off
 #          list:
 #            - id: main
 #            - id: helper
@@ -34,6 +40,9 @@ agents:
     # allowedWorkspaces:                    # extra dirs subagents may cwd into
     #   - /path/to/repo
     # codingMode: auto                      # subagent | direct | auto
+    #                                       #   subagent = force code edits through spawn_subagent
+    #                                       #   direct   = agent edits files directly
+    #                                       #   auto     = agent chooses (default)
     # heartbeatInterval: 0                  # ms; 0 = disabled (legacy field)
     # heartbeatPrompt: "what's next?"       # custom heartbeat prompt
     # heartbeat:                            # periodic wake-up (#191)
@@ -84,7 +93,7 @@ compaction:
 #   cleanupInterval: 3600            # 1h sweep
 
 # =============================================================================
-# CHANNELS — Discord / Feishu transports + per-guild settings
+# CHANNELS — Discord transport + per-guild settings
 # All Discord configuration lives under channels.discord.accounts.<accountId>.
 # Multi-bot is supported by listing multiple accounts.
 # =============================================================================
@@ -94,20 +103,17 @@ channels:
       main:                              # accountId — referenced by bindings, etc.
         tokenEnv: DISCORD_TOKEN          # or `token: <literal>`
         defaultAgentId: main
-        # allowDMs: true                  # deprecated — use dm.policy instead
         dm:
           policy: disabled               # disabled (default) | allowlist
           # allowlist:                   # Discord user IDs (only when policy=allowlist)
           #   - "123456789012345678"
         group:
-          policy: allowlist              # disabled | allowlist (default) | open
+          policy: allowlist              # allowlist (default) | disabled | open
           # channelAllowlist:            # channel IDs (only when policy=allowlist)
           #   - "channel-id"
           # guildAllowlist:              # guild/server IDs (only when policy=allowlist)
           #   - "guild-id"
         # allowBots: false               # respond to messages from other bots
-        # channelAllowlist:              # deprecated — use group.channelAllowlist
-        #   - "channel-id"
         # agentBindings:                 # bot user id → agent id
         #   "bot-user-id": main
         # adminUsers:                    # discord user ids allowed to run /slash commands
@@ -148,11 +154,6 @@ channels:
       #   tokenEnv: DISCORD_TOKEN_HELPER
       #   defaultAgentId: helper
 
-  # feishu:
-  #   groups:
-  #     "oc_xxx":
-  #       requireMention: false
-
 # =============================================================================
 # BINDINGS — agent ↔ channel routing
 # More specific match wins (channel + accountId + peer > channel + accountId > channel)
@@ -178,22 +179,19 @@ subagent:
   #   authToken: ${ANTHROPIC_AUTH_TOKEN}     # → ANTHROPIC_AUTH_TOKEN for spawned process
   #   baseUrl: ${ANTHROPIC_BASE_URL}         # → ANTHROPIC_BASE_URL for spawned process
   #   pathToClaudeCodeExecutable: /custom/path/to/claude
-  # subagent:                         # M7/M8 subagent execution
-  #   defaultAgent: main
-  #   allowedAgents: [main]
-  #   timeout: 900                    # seconds; backend default 15min
-  #   maxTurns: 50
-  #   permissionMode: allowlist       # skip | allowlist | default
-  #   allowedTools:                   # used when permissionMode=allowlist
-  #     - Read
-  #     - Write
-  #     - Edit
-  #     - Glob
-  #     - Grep
-  #     - LS
-  #   enableShell: false              # appends Bash to allowedTools
-  #   useThread: true                 # spawn Discord thread for subagent output
-  #   showToolCalls: true
+  # timeout: 900                      # seconds; backend default 15min
+  # maxTurns: 50
+  # permissionMode: allowlist         # skip | allowlist | default
+  # allowedTools:                     # used when permissionMode=allowlist
+  #   - Read
+  #   - Write
+  #   - Edit
+  #   - Glob
+  #   - Grep
+  #   - LS
+  # enableShell: false                # appends Bash to allowedTools
+  # useThread: true                   # spawn Discord thread for subagent output
+  # showToolCalls: true
 
 # =============================================================================
 # CRON — channel-level scheduled jobs (per-agent cron lives under agents.<id>.cron)
@@ -223,13 +221,10 @@ subagent:
 #     memoryLimit: 512m
 
 # =============================================================================
-# FEISHU — Feishu / Lark transport
-# NOTE: FeishuTransport is exported from the library but NOT yet wired into the
-# CLI/daemon. Configuring it here has no effect until CLI integration lands.
-# Schema below reflects FeishuTransportConfig in src/transports/feishu.ts.
+# PLUGINS — optional plugin configurations (keyed by plugin id)
 # =============================================================================
-# feishu:
-#   appId: ${FEISHU_APP_ID}
-#   appSecret: ${FEISHU_APP_SECRET}
-#   defaultAgentId: main
-#   # agentBindings: {}
+# plugins:
+#   my-plugin:
+#     enabled: true
+#     config:
+#       apiKey: ${MY_PLUGIN_KEY}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -378,16 +378,6 @@ export interface DiscordAccountConfig {
     /** Guild (server) IDs allowed when policy is "allowlist". */
     guildAllowlist?: string[];
   };
-  /**
-   * Restrict the bot to a list of channel IDs.
-   * @deprecated Use `group.channelAllowlist` with `group.policy: "allowlist"`.
-   */
-  channelAllowlist?: string[];
-  /**
-   * Group join policy (allowlist/denylist semantics, transport-defined).
-   * @deprecated Use `group.policy`.
-   */
-  groupPolicy?: string;
   /** Per-guild configuration keyed by guild ID */
   guilds?: Record<string, GuildConfig>;
   /** Thread binding configuration for auto-binding threads to agent sessions */

--- a/src/transports/discord-manager.test.ts
+++ b/src/transports/discord-manager.test.ts
@@ -122,7 +122,7 @@ describe("DiscordTransportManager", () => {
           token: "tok-major",
           defaultAgentId: "major",
           dm: { policy: "allowlist", allowlist: ["user-1"] },
-          channelAllowlist: ["ch-1"],
+          group: { policy: "allowlist", channelAllowlist: ["ch-1"] },
         },
         tachikoma: {
           token: "tok-tachi",

--- a/src/transports/discord-manager.ts
+++ b/src/transports/discord-manager.ts
@@ -64,7 +64,6 @@ export class DiscordTransportManager {
         agentBindings: account.agentBindings,
         dm: account.dm,
         group: account.group,
-        channelAllowlist: account.channelAllowlist,
         channels: shared.channels,
         accountId,
         threadBindings: account.threadBindings,

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -530,7 +530,7 @@ describe("DiscordTransport", () => {
       expect(bindingManager.size).toBe(0);
     });
 
-    it("respects channelAllowlist — only binds threads in allowed channels", async () => {
+    it("respects group.channelAllowlist — only binds threads in allowed channels", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
         token: "test-token",
@@ -539,7 +539,7 @@ describe("DiscordTransport", () => {
         defaultAgentId: "test-agent",
         threadBindings: { enabled: true },
         threadBindingManager: bindingManager,
-        channelAllowlist: ["channel-allowed"],
+        group: { policy: "allowlist", channelAllowlist: ["channel-allowed"] },
       });
 
       await transportWithThreads.start();

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -165,11 +165,6 @@ export interface DiscordTransportConfig {
     channelAllowlist?: string[];
     guildAllowlist?: string[];
   };
-  /**
-   * Channel IDs to listen to (empty = all).
-   * @deprecated Use `group.channelAllowlist` with `group.policy: "allowlist"`.
-   */
-  channelAllowlist?: string[];
   /** Channels config for per-guild/group settings (e.g. requireMention) */
   channels?: ChannelsConfig;
   /** The account ID this bot is running as (for guild config lookup) */
@@ -573,7 +568,7 @@ export class DiscordTransport implements Transport {
     return false;
   }
 
-  /** Resolve the effective group config, honoring legacy `channelAllowlist` for back-compat. Default policy is fail-closed `"allowlist"`. */
+  /** Resolve the effective group config. Default policy is fail-closed `"allowlist"`. */
   private resolveGroup(): {
     policy: "disabled" | "allowlist" | "open";
     channelAllowlist?: string[];
@@ -586,11 +581,6 @@ export class DiscordTransport implements Transport {
         channelAllowlist: g.channelAllowlist,
         guildAllowlist: g.guildAllowlist,
       };
-    }
-    // Legacy: top-level channelAllowlist implies allowlist policy on channels.
-    const legacy = this.config.channelAllowlist;
-    if (legacy?.length) {
-      return { policy: "allowlist", channelAllowlist: legacy };
     }
     return { policy: "allowlist" };
   }

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -50,7 +50,7 @@ npx tsx tests/integration/discord.test.ts
 **Bot doesn't respond:**
 - Check bot is in the channel
 - Check Message Content Intent is enabled
-- Check channelAllowlist includes test channel
+- Check `group.channelAllowlist` includes test channel
 
 **API errors:**
 - Verify API key is valid

--- a/tests/integration/discord.test.ts
+++ b/tests/integration/discord.test.ts
@@ -112,7 +112,7 @@ async function runTest() {
     agentManager,
     sessionStore,
     defaultAgentId: "test-agent",
-    channelAllowlist: [TEST_CHANNEL_ID!],
+    group: { policy: "allowlist", channelAllowlist: [TEST_CHANNEL_ID!] },
   });
 
   await transport.start();


### PR DESCRIPTION
## Summary
- Drop `DiscordAccountConfig.channelAllowlist` / `.groupPolicy` and `DiscordTransportConfig.channelAllowlist` (all `@deprecated` in favor of `group.policy` / `group.channelAllowlist`)
- Remove the legacy fallback branch in `resolveGroup()` and the pass-through in `discord-manager.ts`
- Refresh `isotopes.example.yaml`: drop `allowDMs` / deprecated `channelAllowlist` / feishu blocks; add `plugins:` example; expand `agents` object-form and `codingMode` docs

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 42 test files, all passing
- [ ] Manually verify a real `isotopes.yaml` with `group.policy: allowlist` + `group.channelAllowlist` still routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)