### PR TITLE
fix: Windows-compatible process spawning and signals

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -606,29 +606,50 @@ async function handleLogsCommand(): Promise<void> {
   };
 
   if (follow) {
-    // Follow mode: watch file for changes and stream new content
-    const { watch, createReadStream } = await import("node:fs");
+    // Follow mode: poll file for new content (fs.watchFile is more reliable
+    // than fs.watch for append-only log files, especially on network FS).
+    const nodeFs = await import("node:fs");
     let position = (await fsPromises.stat(logFile)).size;
+    let reading = false;
+    let trailingFragment = "";
 
     const readNew = () => {
-      const stream = createReadStream(logFile, { start: position, encoding: "utf-8" });
+      if (reading) return;
+      // Handle log rotation: if file shrank, reset to beginning
+      let currentSize: number;
+      try {
+        currentSize = nodeFs.statSync(logFile).size;
+      } catch {
+        return;
+      }
+      if (currentSize < position) position = 0;
+      if (currentSize === position) return;
+
+      reading = true;
+      const readStart = position;
+      position = currentSize;
+
+      const stream = nodeFs.createReadStream(logFile, { start: readStart, end: currentSize - 1, encoding: "utf-8" });
       let buf = "";
       stream.on("data", (chunk: string | Buffer) => { buf += String(chunk); });
       stream.on("end", () => {
-        position += Buffer.byteLength(buf);
-        const newLines = buf.split("\n");
-        for (const line of newLines) {
+        reading = false;
+        const text = trailingFragment + buf;
+        const parts = text.split("\n");
+        trailingFragment = parts.pop() ?? "";
+        for (const line of parts) {
           if (line && matchesLevel(line)) {
             console.log(line);
           }
         }
       });
+      stream.on("error", () => { reading = false; });
     };
 
-    const watcher = watch(logFile, () => readNew());
+    nodeFs.watchFile(logFile, { interval: 500 }, () => readNew());
 
     process.on("SIGINT", () => {
-      watcher.close();
+      nodeFs.unwatchFile(logFile);
       process.exit(0);
     });
   } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -606,22 +606,29 @@ async function handleLogsCommand(): Promise<void> {
   };
 
   if (follow) {
-    // Follow mode: use tail -f
-    const { spawn } = await import("node:child_process");
-    const tail = spawn("tail", ["-f", logFile], { stdio: ["ignore", "pipe", "inherit"] });
+    // Follow mode: watch file for changes and stream new content
+    const { watch, createReadStream } = await import("node:fs");
+    let position = (await fsPromises.stat(logFile)).size;
 
-    tail.stdout.on("data", (chunk: Buffer) => {
-      const lines = chunk.toString().split("\n");
-      for (const line of lines) {
-        if (line && matchesLevel(line)) {
-          console.log(line);
+    const readNew = () => {
+      const stream = createReadStream(logFile, { start: position, encoding: "utf-8" });
+      let buf = "";
+      stream.on("data", (chunk: string | Buffer) => { buf += String(chunk); });
+      stream.on("end", () => {
+        position += Buffer.byteLength(buf);
+        const newLines = buf.split("\n");
+        for (const line of newLines) {
+          if (line && matchesLevel(line)) {
+            console.log(line);
+          }
         }
-      }
-    });
+      });
+    };
 
-    // Handle Ctrl+C gracefully
+    const watcher = watch(logFile, () => readNew());
+
     process.on("SIGINT", () => {
-      tail.kill();
+      watcher.close();
       process.exit(0);
     });
   } else {

--- a/src/daemon/process.test.ts
+++ b/src/daemon/process.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
-import { spawn } from "node:child_process";
+import { spawn, execSync } from "node:child_process";
 import { DaemonProcess } from "./process.js";
 import type { DaemonOptions } from "./process.js";
 
@@ -22,6 +22,7 @@ vi.mock("node:fs/promises", () => ({
 
 vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
+  execSync: vi.fn(),
 }));
 
 const mockFs = fs as unknown as {
@@ -33,6 +34,7 @@ const mockFs = fs as unknown as {
 };
 
 const mockSpawn = spawn as unknown as ReturnType<typeof vi.fn>;
+const mockExecSync = execSync as unknown as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -179,26 +181,46 @@ describe("DaemonProcess.stop", () => {
       throw new Error("ENOENT");
     });
 
-    // Process is alive at first, then dies after SIGTERM
-    let alive = true;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    killSpy = vi.spyOn(process, "kill").mockImplementation(((_pid: any, signal: any) => {
-      if (signal === 0 || signal === undefined) {
-        if (!alive) throw new Error("ESRCH");
+    if (process.platform === "win32") {
+      // On Windows, killProcess uses execSync("taskkill ...") then checks
+      // process.kill(pid, 0) which should throw after the kill.
+      let alive = true;
+      killSpy = vi.spyOn(process, "kill").mockImplementation(((_pid: unknown, signal: unknown) => {
+        if (signal === 0 || signal === undefined) {
+          if (!alive) throw new Error("ESRCH");
+          return true;
+        }
         return true;
-      }
-      if (signal === "SIGTERM") {
-        alive = false;
-        return true;
-      }
-      return true;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any);
+      mockExecSync.mockImplementation(() => { alive = false; });
+
+      const d = makeDaemon();
+      await d.stop();
+
+      expect(mockExecSync).toHaveBeenCalledWith("taskkill /F /T /PID 12345", { stdio: "ignore" });
+    } else {
+      // On Unix, killProcess uses process.kill(pid, "SIGTERM")
+      let alive = true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any);
+      killSpy = vi.spyOn(process, "kill").mockImplementation(((_pid: any, signal: any) => {
+        if (signal === 0 || signal === undefined) {
+          if (!alive) throw new Error("ESRCH");
+          return true;
+        }
+        if (signal === "SIGTERM") {
+          alive = false;
+          return true;
+        }
+        return true;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any);
 
-    const d = makeDaemon();
-    await d.stop();
+      const d = makeDaemon();
+      await d.stop();
 
-    expect(killSpy).toHaveBeenCalledWith(12345, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(12345, "SIGTERM");
+    }
     // pidfile removed
     expect(mockFs.unlink).toHaveBeenCalledWith(defaultOpts.pidFile);
   });

--- a/src/daemon/process.test.ts
+++ b/src/daemon/process.test.ts
@@ -198,7 +198,7 @@ describe("DaemonProcess.stop", () => {
       const d = makeDaemon();
       await d.stop();
 
-      expect(mockExecSync).toHaveBeenCalledWith("taskkill /F /T /PID 12345", { stdio: "ignore" });
+      expect(mockExecSync).toHaveBeenCalledWith("taskkill /T /PID 12345", { stdio: "ignore" });
     } else {
       // On Unix, killProcess uses process.kill(pid, "SIGTERM")
       let alive = true;

--- a/src/daemon/process.ts
+++ b/src/daemon/process.ts
@@ -1,7 +1,7 @@
 // src/daemon/process.ts — Daemon process lifecycle management
 // Handles starting, stopping, and querying the Isotopes daemon process.
 
-import { spawn } from "node:child_process";
+import { spawn, execSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -60,7 +60,19 @@ async function removePid(pidFile: string): Promise<void> {
   }
 }
 
-/** Check whether a process with the given PID is alive. */
+/** Terminate a process by PID. On Windows uses taskkill for tree kill. */
+function killProcess(pid: number, force = false): void {
+  if (process.platform === "win32") {
+    try {
+      execSync(`taskkill /F /T /PID ${pid}`, { stdio: "ignore" });
+    } catch {
+      // process may have already exited
+    }
+  } else {
+    process.kill(pid, force ? "SIGKILL" : "SIGTERM");
+  }
+}
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -187,7 +199,7 @@ export class DaemonProcess {
     }
 
     // Graceful stop
-    process.kill(pid, "SIGTERM");
+    killProcess(pid);
 
     // Wait for exit (poll every 100 ms, max 5 s)
     const deadline = Date.now() + 5_000;
@@ -203,7 +215,7 @@ export class DaemonProcess {
 
     // Force kill
     try {
-      process.kill(pid, "SIGKILL");
+      killProcess(pid, true);
     } catch {
       // already gone
     }

--- a/src/daemon/process.ts
+++ b/src/daemon/process.ts
@@ -60,13 +60,16 @@ async function removePid(pidFile: string): Promise<void> {
   }
 }
 
-/** Terminate a process by PID. On Windows uses taskkill for tree kill. */
+/** Terminate a process by PID. On Windows uses taskkill (tree kill); without
+ *  force it omits /F to allow graceful shutdown, with force it adds /F. */
 function killProcess(pid: number, force = false): void {
   if (process.platform === "win32") {
     try {
-      execSync(`taskkill /F /T /PID ${pid}`, { stdio: "ignore" });
+      const flags = force ? "/F /T" : "/T";
+      execSync(`taskkill ${flags} /PID ${pid}`, { stdio: "ignore" });
     } catch {
-      // process may have already exited
+      // Exit code 128 = process not found (already exited) — acceptable.
+      // Permission errors will surface via the isProcessAlive poll timeout.
     }
   } else {
     process.kill(pid, force ? "SIGKILL" : "SIGTERM");

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -74,10 +74,11 @@ export class ProcessRegistry {
           stdio: ["ignore", "pipe", "pipe"],
           detached: false,
         })
-      : spawn("sh", ["-c", command], {
+      : spawn(command, [], {
           cwd,
           stdio: ["ignore", "pipe", "pipe"],
           detached: false,
+          shell: true,
         });
 
     const info: ProcessInfo = {


### PR DESCRIPTION
## Summary
- Replace `spawn("sh", ...)` with `shell: true` in exec tool so Node picks the platform shell (`cmd.exe` on Windows, `sh` on Unix)
- Add `killProcess` helper using `taskkill` on Windows instead of SIGTERM/SIGKILL which behave differently on win32
- Replace `spawn("tail", ["-f", ...])` with `fs.watch` + `createReadStream` for cross-platform log following
- Update daemon process tests for platform-aware kill behavior

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — daemon process tests pass (13/13), exec sandbox test failure is pre-existing
- [ ] Verify `isotopes logs --follow` works on Windows
- [ ] Verify daemon start/stop works on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)