### PR TITLE
refactor(discord): rename dm/group to dmAccess/groupAccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ channels:
       main:
         token: ${DISCORD_TOKEN}
         defaultAgentId: main
-        dm:
+        dmAccess:
           policy: disabled           # disabled (default) | allowlist
           # allowlist:
           #   - "123456789012345678"
-        group:
+        groupAccess:
           policy: allowlist          # disabled | allowlist (default) | open
           # guildAllowlist:
           #   - "guild-id"

--- a/docs/prd/PRD.md
+++ b/docs/prd/PRD.md
@@ -89,7 +89,7 @@ channels:
     accounts:
       major:
         token: "..."
-        group:
+        groupAccess:
           policy: allowlist
         guilds:
           "1480866703880487034":

--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -103,11 +103,11 @@ channels:
       main:                              # accountId — referenced by bindings, etc.
         tokenEnv: DISCORD_TOKEN          # or `token: <literal>`
         defaultAgentId: main
-        dm:
+        dmAccess:
           policy: disabled               # disabled (default) | allowlist
           # allowlist:                   # Discord user IDs (only when policy=allowlist)
           #   - "123456789012345678"
-        group:
+        groupAccess:
           policy: allowlist              # allowlist (default) | disabled | open
           # channelAllowlist:            # channel IDs (only when policy=allowlist)
           #   - "channel-id"

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -128,7 +128,7 @@ channels:
         defaultAgentId: assistant
         agentBindings:
           "123456": assistant
-        dm:
+        dmAccess:
           policy: open
 `,
       );

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -363,14 +363,14 @@ export interface DiscordAccountConfig {
   /** Channel/guild ID -> agent ID overrides. */
   agentBindings?: Record<string, string>;
   /** DM access control. */
-  dm?: {
+  dmAccess?: {
     /** "disabled" (default) = ignore all DMs, "allowlist" = only from listed user IDs. */
     policy?: "disabled" | "allowlist";
     /** Discord user IDs allowed to DM when policy is "allowlist". */
     allowlist?: string[];
   };
-  /** Group (guild) access control — parallel to `dm`. */
-  group?: {
+  /** Group (guild) access control — parallel to `dmAccess`. */
+  groupAccess?: {
     /** "allowlist" (default) = only listed channels/guilds, "disabled" = ignore all guild messages, "open" = accept all guild channels. */
     policy?: "disabled" | "allowlist" | "open";
     /** Channel IDs allowed when policy is "allowlist". */

--- a/src/init/render.test.ts
+++ b/src/init/render.test.ts
@@ -42,7 +42,7 @@ describe("renderConfig", () => {
       discord: { token: "tok", dmPolicy: "allowlist", dmUserId: "111222333", groupPolicy: "open" },
     });
     expect(yaml).toContain('- "111222333"');
-    expect(yaml).toMatch(/dm:\s+policy: allowlist/);
+    expect(yaml).toMatch(/dmAccess:\s+policy: allowlist/);
   });
 
   it("emits group allowlist with guild and channel IDs", () => {
@@ -56,7 +56,7 @@ describe("renderConfig", () => {
         groupAllowlist: ["111222333", "444555666/777888999"],
       },
     });
-    expect(yaml).toMatch(/group:\s+policy: allowlist/);
+    expect(yaml).toMatch(/groupAccess:\s+policy: allowlist/);
     expect(yaml).toContain('- "111222333"');
     expect(yaml).toContain('- "444555666"');
     expect(yaml).toContain('- "777888999"');
@@ -70,7 +70,7 @@ describe("renderConfig", () => {
       channel: "discord",
       discord: { token: "tok", dmPolicy: "disabled", groupPolicy: "open" },
     });
-    expect(yaml).toMatch(/group:\s+policy: open/);
+    expect(yaml).toMatch(/groupAccess:\s+policy: open/);
     expect(yaml).not.toContain("guildAllowlist:");
   });
 

--- a/src/init/render.ts
+++ b/src/init/render.ts
@@ -40,12 +40,12 @@ function renderChannels(answers: InitAnswers): string {
   const { token, dmPolicy, dmUserId, groupPolicy, groupAllowlist } = answers.discord;
 
   const dmBlock = dmPolicy === "allowlist" && dmUserId
-    ? `        dm:
+    ? `        dmAccess:
           policy: allowlist
           allowlist:
             - "${dmUserId}"
 `
-    : `        dm:
+    : `        dmAccess:
           policy: disabled
 `;
 
@@ -60,7 +60,7 @@ function renderChannels(answers: InitAnswers): string {
     }
     const guildLines = [...guildIds].map((id) => `            - "${id}"`).join("\n");
     const channelLines = channelIds.map((id) => `            - "${id}"`).join("\n");
-    groupBlock = `        group:
+    groupBlock = `        groupAccess:
           policy: allowlist
           guildAllowlist:
 ${guildLines}
@@ -71,7 +71,7 @@ ${channelLines}
 `;
     }
   } else {
-    groupBlock = `        group:
+    groupBlock = `        groupAccess:
           policy: ${groupPolicy}
 `;
   }

--- a/src/transports/discord-manager.test.ts
+++ b/src/transports/discord-manager.test.ts
@@ -121,13 +121,13 @@ describe("DiscordTransportManager", () => {
         major: {
           token: "tok-major",
           defaultAgentId: "major",
-          dm: { policy: "allowlist", allowlist: ["user-1"] },
-          group: { policy: "allowlist", channelAllowlist: ["ch-1"] },
+          dmAccess: { policy: "allowlist", allowlist: ["user-1"] },
+          groupAccess: { policy: "allowlist", channelAllowlist: ["ch-1"] },
         },
         tachikoma: {
           token: "tok-tachi",
           defaultAgentId: "tachikoma",
-          dm: { policy: "disabled" },
+          dmAccess: { policy: "disabled" },
         },
       },
       shared: { agentManager, sessionStore },

--- a/src/transports/discord-manager.ts
+++ b/src/transports/discord-manager.ts
@@ -36,7 +36,7 @@ export interface DiscordTransportManagerConfig {
  * DiscordTransportManager — creates and manages multiple DiscordTransport instances.
  *
  * Each account in the config gets its own transport with an independent Client,
- * token, and identity. All per-account behavior (dm, allowBots, threadBindings,
+ * token, and identity. All per-account behavior (dmAccess, allowBots, threadBindings,
  * subagentStreaming, context, adminUsers, etc.) is read from the account config.
  */
 export class DiscordTransportManager {
@@ -62,8 +62,8 @@ export class DiscordTransportManager {
         sessionStoreForAgent: shared.sessionStoreForAgent,
         defaultAgentId: account.defaultAgentId,
         agentBindings: account.agentBindings,
-        dm: account.dm,
-        group: account.group,
+        dmAccess: account.dmAccess,
+        groupAccess: account.groupAccess,
         channels: shared.channels,
         accountId,
         threadBindings: account.threadBindings,

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -73,7 +73,7 @@ describe("DiscordTransport", () => {
     agentManager = createMockAgentManager();
     sessionStore = createMockSessionStore();
     transport = new DiscordTransport({
-      group: { policy: "open" },
+      groupAccess: { policy: "open" },
       token: "test-token",
       agentManager,
       sessionStore,
@@ -269,7 +269,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -307,7 +307,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -345,7 +345,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportWithMention = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -393,7 +393,7 @@ describe("DiscordTransport", () => {
   describe("thread bindings", () => {
     it("registers threadCreate handler when threadBindings.enabled is true", async () => {
       const transportWithThreads = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -414,7 +414,7 @@ describe("DiscordTransport", () => {
 
     it("does NOT register threadCreate handler when threadBindings.enabled is false", async () => {
       const transportNoThreads = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -449,7 +449,7 @@ describe("DiscordTransport", () => {
     it("creates a binding when a thread is created", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -482,7 +482,7 @@ describe("DiscordTransport", () => {
     it("uses 'default' agentId when defaultAgentId is not configured", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -507,7 +507,7 @@ describe("DiscordTransport", () => {
     it("ignores threads without a parent channel", async () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -539,7 +539,7 @@ describe("DiscordTransport", () => {
         defaultAgentId: "test-agent",
         threadBindings: { enabled: true },
         threadBindingManager: bindingManager,
-        group: { policy: "allowlist", channelAllowlist: ["channel-allowed"] },
+        groupAccess: { policy: "allowlist", channelAllowlist: ["channel-allowed"] },
       });
 
       await transportWithThreads.start();
@@ -562,7 +562,7 @@ describe("DiscordTransport", () => {
     it("exposes thread binding manager via getThreadBindingManager()", () => {
       const bindingManager = new ThreadBindingManager();
       const transportWithThreads = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -575,7 +575,7 @@ describe("DiscordTransport", () => {
 
     it("creates a default ThreadBindingManager when none is provided", () => {
       const transportWithThreads = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -616,7 +616,7 @@ describe("DiscordTransport", () => {
 
     it("routes /status to command handler and sends response", async () => {
       const transportWithAdmin = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -645,7 +645,7 @@ describe("DiscordTransport", () => {
       (agentManager.reloadWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const transportWithAdmin = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -673,7 +673,7 @@ describe("DiscordTransport", () => {
       ]);
 
       const transportWithAdmin = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -697,7 +697,7 @@ describe("DiscordTransport", () => {
 
     it("rejects non-admin users with authorization error", async () => {
       const transportWithAdmin = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -721,7 +721,7 @@ describe("DiscordTransport", () => {
 
     it("passes non-command messages through to agent", async () => {
       const transportWithAdmin = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -745,7 +745,7 @@ describe("DiscordTransport", () => {
 
     it("ignores unknown slash commands and passes them to agent", async () => {
       const transportWithAdmin = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -808,7 +808,7 @@ describe("DiscordTransport", () => {
       };
 
       const transportCtx = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -832,7 +832,7 @@ describe("DiscordTransport", () => {
 
     it("injects channel history into user message when bot is triggered", async () => {
       const transportMention = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -877,7 +877,7 @@ describe("DiscordTransport", () => {
 
     it("deduplicates messages with the same ID", async () => {
       const transportCtx = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -912,7 +912,7 @@ describe("DiscordTransport", () => {
       ]);
 
       const transportCtx = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -959,7 +959,7 @@ describe("DiscordTransport", () => {
 
       // Need to set up bindings via config
       const testTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
@@ -1004,12 +1004,12 @@ describe("DiscordTransport", () => {
       sessionStore.getMessages = vi.fn().mockResolvedValue([]);
 
       const testTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager,
         sessionStore,
         defaultAgentId: "default",
-        dm: { policy: "allowlist", allowlist: ["user-bob"] },
+        dmAccess: { policy: "allowlist", allowlist: ["user-bob"] },
       });
 
       const msg: MockIncomingMessage = {
@@ -1066,7 +1066,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1087,7 +1087,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1109,7 +1109,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1131,7 +1131,7 @@ describe("DiscordTransport", () => {
       const localAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1201,7 +1201,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(hangingAgent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1251,7 +1251,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1312,7 +1312,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(completingAgent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1394,7 +1394,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1425,7 +1425,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1460,7 +1460,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1485,7 +1485,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1516,7 +1516,7 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
@@ -1547,12 +1547,12 @@ describe("DiscordTransport", () => {
       localAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
-        group: { policy: "open" },
+        groupAccess: { policy: "open" },
         token: "test-token",
         agentManager: localAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
-        dm: { policy: "allowlist", allowlist: ["user-1"] },
+        dmAccess: { policy: "allowlist", allowlist: ["user-1"] },
       });
       await localTransport.start();
 

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -558,11 +558,11 @@ export class DiscordTransport implements Transport {
   }
 
   private isDmAllowed(userId: string): boolean {
-    const dm = this.config.dmAccess;
-    if (dm?.policy) {
-      switch (dm.policy) {
+    const dmAccess = this.config.dmAccess;
+    if (dmAccess?.policy) {
+      switch (dmAccess.policy) {
         case "disabled": return false;
-        case "allowlist": return dm.allowlist?.includes(userId) ?? false;
+        case "allowlist": return dmAccess.allowlist?.includes(userId) ?? false;
       }
     }
     return false;

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -155,12 +155,12 @@ export interface DiscordTransportConfig {
   /** Map of Discord bot user ID → agent ID for multi-agent routing */
   agentBindings?: Record<string, string>;
   /** DM access control policy. */
-  dm?: {
+  dmAccess?: {
     policy?: "disabled" | "allowlist";
     allowlist?: string[];
   };
-  /** Group (guild) access control — parallel to `dm`. Default policy is `"allowlist"`. */
-  group?: {
+  /** Group (guild) access control — parallel to `dmAccess`. Default policy is `"allowlist"`. */
+  groupAccess?: {
     policy?: "disabled" | "allowlist" | "open";
     channelAllowlist?: string[];
     guildAllowlist?: string[];
@@ -558,7 +558,7 @@ export class DiscordTransport implements Transport {
   }
 
   private isDmAllowed(userId: string): boolean {
-    const dm = this.config.dm;
+    const dm = this.config.dmAccess;
     if (dm?.policy) {
       switch (dm.policy) {
         case "disabled": return false;
@@ -574,7 +574,7 @@ export class DiscordTransport implements Transport {
     channelAllowlist?: string[];
     guildAllowlist?: string[];
   } {
-    const g = this.config.group;
+    const g = this.config.groupAccess;
     if (g?.policy || g?.channelAllowlist?.length || g?.guildAllowlist?.length) {
       return {
         policy: g.policy ?? "allowlist",

--- a/tests/integration/discord.test.ts
+++ b/tests/integration/discord.test.ts
@@ -112,7 +112,7 @@ async function runTest() {
     agentManager,
     sessionStore,
     defaultAgentId: "test-agent",
-    group: { policy: "allowlist", channelAllowlist: [TEST_CHANNEL_ID!] },
+    groupAccess: { policy: "allowlist", channelAllowlist: [TEST_CHANNEL_ID!] },
   });
 
   await transport.start();


### PR DESCRIPTION
## Summary
- Rename `dm` → `dmAccess` and `group` → `groupAccess` in Discord account config to clarify these fields control access policy
- Updated types, transport, manager, all tests, example config, and README

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 49 discord-related tests pass
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)