### PR TITLE
fix(workspace): stop creating empty sessions/ dir in workspace

### DIFF
--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -8,7 +8,6 @@ import {
   loadWorkspaceContext,
   buildSystemPrompt,
   ensureWorkspaceStructure,
-  getSessionsDir,
 } from "./workspace.js";
 
 describe("Workspace", () => {
@@ -29,9 +28,6 @@ describe("Workspace", () => {
 
       const stats = await fs.stat(workspacePath);
       expect(stats.isDirectory()).toBe(true);
-
-      const sessionsStats = await fs.stat(path.join(workspacePath, "sessions"));
-      expect(sessionsStats.isDirectory()).toBe(true);
 
       const memoryStats = await fs.stat(path.join(workspacePath, "memory"));
       expect(memoryStats.isDirectory()).toBe(true);
@@ -296,13 +292,6 @@ description: Help with git operations
       expect(result).toContain("git-helper");
       expect(result).toContain("Help with git operations");
       expect(result).toContain("<available_skills>");
-    });
-  });
-
-  describe("getSessionsDir", () => {
-    it("returns sessions subdirectory path", () => {
-      const result = getSessionsDir("/path/to/workspace");
-      expect(result).toBe("/path/to/workspace/sessions");
     });
   });
 });

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -111,18 +111,10 @@ export function buildSystemPrompt(
 }
 
 /**
- * Get the sessions directory for a workspace.
- */
-export function getSessionsDir(workspacePath: string): string {
-  return path.join(workspacePath, "sessions");
-}
-
-/**
  * Ensure workspace directory structure exists.
  */
 export async function ensureWorkspaceStructure(workspacePath: string): Promise<void> {
   await fs.mkdir(workspacePath, { recursive: true });
-  await fs.mkdir(path.join(workspacePath, "sessions"), { recursive: true });
   await fs.mkdir(path.join(workspacePath, "memory"), { recursive: true });
 }
 

--- a/src/workspace/templates.ts
+++ b/src/workspace/templates.ts
@@ -163,7 +163,6 @@ MEMORY.md      — accumulated knowledge
 AGENTS.md      — this file (your operating instructions)
 memory/        — daily notes (YYYY-MM-DD.md)
 skills/        — your learned skills (each has a SKILL.md)
-sessions/      — conversation logs
 \`\`\`
 
 All workspace paths are relative to your workspace root. Use filenames like "SOUL.md" or "skills/my-skill/SKILL.md" with \`read_file\`/\`write_file\`/\`edit\` — no absolute paths needed.


### PR DESCRIPTION
## Summary
- Sessions moved to `~/.isotopes/agents/<id>/sessions/` a while back, but `ensureWorkspaceStructure` still mkdir'd a `sessions/` subdir inside every workspace on startup, leaving an empty directory next to `SOUL.md` etc.
- Removed the stray mkdir, dropped the now-unused `getSessionsDir` helper (only its own test referenced it), and cleaned the stale `sessions/` line from the AGENTS.md template.

## Test plan
- [x] `pnpm typecheck`
- [x] `npx vitest run src/core/workspace.test.ts`
- [ ] Start a fresh workspace and confirm no `sessions/` directory is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)