### PR TITLE
fix(sandbox): skip subagent tools for sandboxed agents

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -129,10 +129,11 @@ RUN npm install -g @anthropic-ai/claude-code
 USER agent
 ```
 
-Then:
+Then exec into the running container (containers are named
+`isotopes-sandbox-<agent-id>` — see `src/sandbox/executor.ts`):
 
 ```bash
-docker exec -it $(docker ps -qf name=isotopes-sandbox-<agent>) claude
+docker exec -it isotopes-sandbox-<agent-id> claude
 ```
 
 Credentials must be mounted into the container (e.g. via `docker.binds`) —

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -112,6 +112,32 @@ and `SandboxFs` satisfy. Tools take `fsImpl: FsLike` and call its methods —
 they have no awareness of host vs. sandbox. `cli.ts` is the single place
 that picks the implementation per agent.
 
+## What's NOT sandboxed: subagents
+
+Subagent runners (`ClaudeRunner` spawning the Claude Code CLI, `BuiltinRunner`
+running in-process) execute on the host and would bypass the sandbox boundary
+entirely. To avoid this escape, **`spawn_subagent` is not registered for
+sandboxed agents** — the tool simply does not exist in their tool list.
+
+If you need a coding CLI inside the sandbox, build a custom image that
+includes it and `docker exec` into the running container:
+
+```dockerfile
+FROM isotopes-sandbox:latest
+USER root
+RUN npm install -g @anthropic-ai/claude-code
+USER agent
+```
+
+Then:
+
+```bash
+docker exec -it $(docker ps -qf name=isotopes-sandbox-<agent>) claude
+```
+
+Credentials must be mounted into the container (e.g. via `docker.binds`) —
+they are not forwarded from the host automatically.
+
 ## Background processes
 
 `exec` with `background: true` works in sandbox mode: the host spawns a

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -120,13 +120,28 @@ entirely. To avoid this escape, **`spawn_subagent` is not registered for
 sandboxed agents** — the tool simply does not exist in their tool list.
 
 If you need a coding CLI inside the sandbox, build a custom image that
-includes it and `docker exec` into the running container:
+includes it and point `sandbox.docker.image` at the new tag. Recommended
+naming convention: `isotopes-sandbox-<cli>` (e.g. `isotopes-sandbox-claude`),
+so it composes with the base image namespace and aligns with any
+prebuilt images we may ship later (see issue #451):
 
 ```dockerfile
+# Dockerfile.claude
 FROM isotopes-sandbox:latest
 USER root
 RUN npm install -g @anthropic-ai/claude-code
 USER agent
+```
+
+```bash
+docker build -t isotopes-sandbox-claude:latest -f Dockerfile.claude .
+```
+
+```yaml
+# isotopes.yaml
+sandbox:
+  docker:
+    image: isotopes-sandbox-claude:latest
 ```
 
 Then exec into the running container (containers are named

--- a/src/core/agent-init.test.ts
+++ b/src/core/agent-init.test.ts
@@ -7,8 +7,9 @@ import { createMockAgentInstance } from "./test-helpers.js";
 import type { SandboxExecutor } from "../sandbox/executor.js";
 
 function makeMockSandboxExecutor(): SandboxExecutor {
+  // Only fields touched by initializeAgent matter; sandbox gating uses
+  // shouldSandbox(agentConfig.sandbox) — not any executor method.
   return {
-    shouldExecuteInSandbox: vi.fn(() => true),
     execute: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
     buildExecArgv: vi.fn(async (_id: string, cmd: string[]) => ["docker", "exec", "ctr", ...cmd]),
     cleanup: vi.fn(async () => {}),
@@ -126,6 +127,8 @@ describe("initializeAgent", () => {
   });
 
   it("does not register spawn_subagent when sandbox is active (issue #440)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     const result = await initializeAgent({
       agentFile: makeMinimalAgentFile({ sandbox: { mode: "all" } }),
       sandbox: { mode: "all", docker: { image: "isotopes-sandbox:latest" } },
@@ -137,5 +140,11 @@ describe("initializeAgent", () => {
 
     const toolNames = result.toolRegistry.list().map((t) => t.name);
     expect(toolNames).not.toContain("spawn_subagent");
+    // Warn fired — proves the sandboxed branch ran (test isn't passing for the wrong reason).
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Subagent tools disabled for test-agent"),
+    );
+
+    warnSpy.mockRestore();
   });
 });

--- a/src/core/agent-init.test.ts
+++ b/src/core/agent-init.test.ts
@@ -4,6 +4,16 @@ import type { AgentConfigFile } from "./config.js";
 import { PiMonoCore } from "./pi-mono.js";
 import { DefaultAgentManager } from "./agent-manager.js";
 import { createMockAgentInstance } from "./test-helpers.js";
+import type { SandboxExecutor } from "../sandbox/executor.js";
+
+function makeMockSandboxExecutor(): SandboxExecutor {
+  return {
+    shouldExecuteInSandbox: vi.fn(() => true),
+    execute: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
+    buildExecArgv: vi.fn(async (_id: string, cmd: string[]) => ["docker", "exec", "ctr", ...cmd]),
+    cleanup: vi.fn(async () => {}),
+  } as unknown as SandboxExecutor;
+}
 
 function makeMinimalAgentFile(overrides?: Partial<AgentConfigFile>): AgentConfigFile {
   return {
@@ -101,5 +111,31 @@ describe("initializeAgent", () => {
         baseSystemPrompt: expect.any(String),
       }),
     );
+  });
+
+  it("registers spawn_subagent when subagent enabled and no sandbox", async () => {
+    const result = await initializeAgent({
+      agentFile: makeMinimalAgentFile(),
+      subagent: { enabled: true },
+      core,
+      agentManager,
+    });
+
+    const toolNames = result.toolRegistry.list().map((t) => t.name);
+    expect(toolNames).toContain("spawn_subagent");
+  });
+
+  it("does not register spawn_subagent when sandbox is active (issue #440)", async () => {
+    const result = await initializeAgent({
+      agentFile: makeMinimalAgentFile({ sandbox: { mode: "all" } }),
+      sandbox: { mode: "all", docker: { image: "isotopes-sandbox:latest" } },
+      subagent: { enabled: true },
+      sandboxExecutor: makeMockSandboxExecutor(),
+      core,
+      agentManager,
+    });
+
+    const toolNames = result.toolRegistry.list().map((t) => t.name);
+    expect(toolNames).not.toContain("spawn_subagent");
   });
 });

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -151,9 +151,7 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
   const subagentEnabled = subagent?.enabled === true && !isSandboxed;
   if (subagent?.enabled === true && isSandboxed) {
     log.warn(
-      `Subagent tools disabled for ${agentConfig.id}: sandbox is active and ` +
-        `child runners cannot be confined. Use \`docker exec\` with a custom ` +
-        `image to run a coding CLI inside the sandbox.`,
+      `Subagent tools disabled for ${agentConfig.id}: sandbox is active and child runners cannot be confined. Use \`docker exec\` with a custom image to run a coding CLI inside the sandbox.`,
     );
   }
 

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -139,13 +139,23 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
   const resolvedToolGuards = resolveToolGuards(agentConfig.toolSettings);
   const toolRegistry = new ToolRegistry(agentConfig.id);
   const processRegistry = new ProcessRegistry();
-  const subagentEnabled = subagent?.enabled === true;
   const agentAllowedWorkspaces = agentFile.allowedWorkspaces ?? [];
 
   // 8. Resolve fs implementation (host vs sandbox)
-  const fsImpl: FsLike = sandboxExecutor && agentConfig.sandbox && shouldSandbox(agentConfig.sandbox, false)
-    ? new SandboxFs(sandboxExecutor, agentConfig.id)
-    : nodeFs;
+  const isSandboxed = !!(sandboxExecutor && agentConfig.sandbox && shouldSandbox(agentConfig.sandbox, false));
+  const fsImpl: FsLike = isSandboxed ? new SandboxFs(sandboxExecutor!, agentConfig.id) : nodeFs;
+
+  // Subagent tools spawn child runners (Claude CLI, builtin) that execute on
+  // the host, bypassing the Docker sandbox. Disable them entirely for
+  // sandboxed agents — see issue #440.
+  const subagentEnabled = subagent?.enabled === true && !isSandboxed;
+  if (subagent?.enabled === true && isSandboxed) {
+    log.warn(
+      `Subagent tools disabled for ${agentConfig.id}: sandbox is active and ` +
+        `child runners cannot be confined. Use \`docker exec\` with a custom ` +
+        `image to run a coding CLI inside the sandbox.`,
+    );
+  }
 
   // 9. Create and register workspace tools
   const workspaceTools = createWorkspaceToolsWithGuards(


### PR DESCRIPTION
## Summary
- Sandboxed agents no longer get `spawn_subagent` registered — closes the escape hatch where subagent runners (Claude CLI, builtin) executed on the host and bypassed the Docker sandbox (issue #440).
- Added tests covering both the sandbox-on and sandbox-off cases.
- Documented the recommended workaround in `docs/sandbox.md`: build a custom image with a coding CLI pre-installed and use `docker exec` to drive it.

Since the tool is never registered, the LLM never sees it in its tool schema and cannot attempt to call it — no runtime error path needed.

Closes #440

## Test plan
- [x] `pnpm lint`, `pnpm typecheck` pass
- [x] `src/core/agent-init.test.ts` — 8 tests pass (2 new)
- [x] Focused run across `src/subagent`, `src/sandbox`, `src/core/tools.test.ts`, `src/core/agent-init.test.ts` — 281 tests pass
- [ ] Manual: configure an agent with `sandbox.mode: all` and `subagent.enabled: true`; confirm `spawn_subagent` absent from its tool list and a warn log appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)