### PR TITLE
fix(daemon): address review comments from #447

### DIFF
--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -80,9 +80,9 @@ describe("getPlatform", () => {
     expect(getPlatform()).toBe("linux");
   });
 
-  it("returns 'unsupported' on win32", () => {
+  it("returns 'windows' on win32", () => {
     mockPlatform("win32");
-    expect(getPlatform()).toBe("unsupported");
+    expect(getPlatform()).toBe("windows");
   });
 });
 
@@ -234,12 +234,92 @@ describe("ServiceManager (Linux)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// ServiceManager — Windows (schtasks)
+// ---------------------------------------------------------------------------
+
+describe("ServiceManager (Windows)", () => {
+  beforeEach(() => {
+    mockPlatform("win32");
+  });
+
+  it("install() writes a .cmd script and creates a scheduled task", async () => {
+    const svc = new ServiceManager();
+    await svc.install(sampleConfig);
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("ai.isotopes.daemon.cmd"),
+      expect.stringContaining("ISOTOPES_DAEMON=1"),
+      "utf-8",
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining("schtasks /Create"),
+    );
+  });
+
+  it("install() .cmd script contains exec and cli paths", async () => {
+    const svc = new ServiceManager();
+    await svc.install(sampleConfig);
+
+    const cmdContent = mockFs.writeFile.mock.calls[0][1] as string;
+    expect(cmdContent).toContain(sampleConfig.execPath);
+    expect(cmdContent).toContain(sampleConfig.cliPath);
+  });
+
+  it("uninstall() deletes the scheduled task and .cmd script", async () => {
+    const svc = new ServiceManager();
+    await svc.uninstall("ai.isotopes.daemon");
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining("schtasks /Delete"),
+    );
+    expect(mockFs.unlink).toHaveBeenCalledWith(
+      expect.stringContaining("ai.isotopes.daemon.cmd"),
+    );
+  });
+
+  it("enable() calls schtasks /Change /ENABLE", async () => {
+    const svc = new ServiceManager();
+    await svc.enable("ai.isotopes.daemon");
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining("schtasks /Change"),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining("/ENABLE"),
+    );
+  });
+
+  it("disable() calls schtasks /Change /DISABLE", async () => {
+    const svc = new ServiceManager();
+    await svc.disable("ai.isotopes.daemon");
+
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining("/DISABLE"),
+    );
+  });
+
+  it("isInstalled() queries schtasks", async () => {
+    mockExec.mockResolvedValue({ stdout: "TaskName: ...", stderr: "" });
+
+    const svc = new ServiceManager();
+    expect(await svc.isInstalled("ai.isotopes.daemon")).toBe(true);
+  });
+
+  it("isInstalled() returns false when task not found", async () => {
+    mockExec.mockRejectedValue(new Error("ERROR: The system cannot find the file specified"));
+
+    const svc = new ServiceManager();
+    expect(await svc.isInstalled("ai.isotopes.daemon")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Unsupported platform
 // ---------------------------------------------------------------------------
 
 describe("ServiceManager (unsupported)", () => {
   beforeEach(() => {
-    mockPlatform("win32");
+    mockPlatform("freebsd" as NodeJS.Platform);
   });
 
   it("install() throws on unsupported platform", async () => {

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -248,7 +248,7 @@ describe("ServiceManager (Windows)", () => {
 
     expect(mockFs.writeFile).toHaveBeenCalledWith(
       expect.stringContaining("ai.isotopes.daemon.cmd"),
-      expect.stringContaining("ISOTOPES_DAEMON=1"),
+      expect.stringMatching(/^set ISOTOPES_DAEMON=1$/m),
       "utf-8",
     );
     expect(mockExec).toHaveBeenCalledWith(
@@ -310,6 +310,24 @@ describe("ServiceManager (Windows)", () => {
 
     const svc = new ServiceManager();
     expect(await svc.isInstalled("ai.isotopes.daemon")).toBe(false);
+  });
+
+  it("install() falls back to Startup folder when schtasks fails", async () => {
+    // First call is writeFile for .cmd script (succeeds),
+    // then execAsync for schtasks /Create (fails),
+    // then writeFile for startup folder fallback
+    mockExec.mockRejectedValue(new Error("Access is denied"));
+
+    const svc = new ServiceManager();
+    await svc.install(sampleConfig);
+
+    // The fallback should write to the Startup folder
+    const fallbackCall = mockFs.writeFile.mock.calls.find(
+      (call: unknown[]) => (call[0] as string).includes("Startup"),
+    );
+    expect(fallbackCall).toBeDefined();
+    expect(fallbackCall![0]).toContain("ai.isotopes.daemon.cmd");
+    expect(fallbackCall![1]).toMatch(/^set ISOTOPES_DAEMON=1$/m);
   });
 });
 

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -16,7 +16,7 @@ const log = createLogger("daemon:service");
 // ---------------------------------------------------------------------------
 
 /** Detected operating system platform for service integration. */
-export type ServicePlatform = "macos" | "linux" | "unsupported";
+export type ServicePlatform = "macos" | "linux" | "windows" | "unsupported";
 
 /** Configuration for installing the daemon as a system service. */
 export interface ServiceConfig {
@@ -46,6 +46,8 @@ export function getPlatform(): ServicePlatform {
       return "macos";
     case "linux":
       return "linux";
+    case "win32":
+      return "windows";
     default:
       return "unsupported";
   }
@@ -131,14 +133,33 @@ WantedBy=default.target
 }
 
 // ---------------------------------------------------------------------------
+// schtasks helpers (Windows)
+// ---------------------------------------------------------------------------
+
+const SCHTASKS_TASK_PREFIX = "\\";
+
+function schtasksTaskName(name: string): string {
+  return `${SCHTASKS_TASK_PREFIX}${name}`;
+}
+
+function buildCmdScript(config: ServiceConfig): string {
+  return `@echo off\r\nset ISOTOPES_DAEMON=1\r\n"${config.execPath}" "${config.cliPath}"\r\n`;
+}
+
+function schtasksCmdScriptPath(name: string): string {
+  return path.join(os.homedir(), ".isotopes", `${name}.cmd`);
+}
+
+// ---------------------------------------------------------------------------
 // ServiceManager
 // ---------------------------------------------------------------------------
 
 /**
  * ServiceManager — installs and manages the daemon as a system service.
  *
- * Supports macOS launchd (plist) and Linux systemd (user unit). Provides
- * install, uninstall, enable, disable, and status-check operations.
+ * Supports macOS launchd (plist), Linux systemd (user unit), and Windows
+ * Task Scheduler (schtasks). Provides install, uninstall, enable, disable,
+ * and status-check operations.
  */
 export class ServiceManager {
   private platform: ServicePlatform;
@@ -163,12 +184,40 @@ export class ServiceManager {
       await fs.mkdir(path.dirname(plistPath), { recursive: true });
       await fs.writeFile(plistPath, buildPlist(config), "utf-8");
       log.info(`Wrote launchd plist to ${plistPath}`);
-    } else {
+    } else if (this.platform === "linux") {
       const unitPath = systemdUnitPath(config.name);
       await fs.mkdir(path.dirname(unitPath), { recursive: true });
       await fs.writeFile(unitPath, buildUnit(config), "utf-8");
       await execAsync("systemctl --user daemon-reload");
       log.info(`Wrote systemd unit to ${unitPath}`);
+    } else {
+      // Windows: write a .cmd launcher script, then register a scheduled task
+      const scriptPath = schtasksCmdScriptPath(config.name);
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(scriptPath, buildCmdScript(config), "utf-8");
+
+      const taskName = schtasksTaskName(config.name);
+      try {
+        await execAsync(
+          `schtasks /Create /F /SC ONLOGON /RL LIMITED /TN "${taskName}" /TR "\\"${scriptPath}\\""`,
+        );
+      } catch {
+        // Fallback: place script in Startup folder if schtasks fails (e.g. restricted env)
+        const startupDir = path.join(
+          process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"),
+          "Microsoft", "Windows", "Start Menu", "Programs", "Startup",
+        );
+        const startupPath = path.join(startupDir, `${config.name}.cmd`);
+        await fs.mkdir(startupDir, { recursive: true });
+        await fs.writeFile(startupPath, buildCmdScript(config), "utf-8");
+        log.warn(`schtasks failed; placed startup script at ${startupPath}`);
+        return;
+      }
+
+      await execAsync(`schtasks /Run /TN "${taskName}"`).catch(() => {
+        log.debug("schtasks /Run failed — task will start at next logon");
+      });
+      log.info(`Registered scheduled task ${taskName}`);
     }
   }
 
@@ -190,11 +239,32 @@ export class ServiceManager {
       const plistPath = launchdPlistPath(name);
       await fs.unlink(plistPath);
       log.info(`Removed launchd plist ${plistPath}`);
-    } else {
+    } else if (this.platform === "linux") {
       const unitPath = systemdUnitPath(name);
       await fs.unlink(unitPath);
       await execAsync("systemctl --user daemon-reload");
       log.info(`Removed systemd unit ${unitPath}`);
+    } else {
+      const taskName = schtasksTaskName(name);
+      await execAsync(`schtasks /Delete /F /TN "${taskName}"`).catch(() => {
+        log.debug("schtasks /Delete failed — task may not exist");
+      });
+
+      // Remove .cmd script
+      try {
+        await fs.unlink(schtasksCmdScriptPath(name));
+      } catch { /* may not exist */ }
+
+      // Remove startup folder fallback if present
+      const startupDir = path.join(
+        process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"),
+        "Microsoft", "Windows", "Start Menu", "Programs", "Startup",
+      );
+      try {
+        await fs.unlink(path.join(startupDir, `${name}.cmd`));
+      } catch { /* may not exist */ }
+
+      log.info(`Removed scheduled task ${taskName}`);
     }
   }
 
@@ -209,6 +279,10 @@ export class ServiceManager {
     } else if (this.platform === "linux") {
       await execAsync(`systemctl --user enable ${name}`);
       log.info(`Enabled systemd service ${name}`);
+    } else if (this.platform === "windows") {
+      const taskName = schtasksTaskName(name);
+      await execAsync(`schtasks /Change /TN "${taskName}" /ENABLE`);
+      log.info(`Enabled scheduled task ${taskName}`);
     } else {
       throw new Error(
         `Service management is not supported on ${os.platform()}`,
@@ -223,6 +297,10 @@ export class ServiceManager {
     } else if (this.platform === "linux") {
       await execAsync(`systemctl --user disable ${name}`);
       log.info(`Disabled systemd service ${name}`);
+    } else if (this.platform === "windows") {
+      const taskName = schtasksTaskName(name);
+      await execAsync(`schtasks /Change /TN "${taskName}" /DISABLE`);
+      log.info(`Disabled scheduled task ${taskName}`);
     } else {
       throw new Error(
         `Service management is not supported on ${os.platform()}`,
@@ -245,6 +323,13 @@ export class ServiceManager {
     } else if (this.platform === "linux") {
       try {
         await fs.access(systemdUnitPath(name));
+        return true;
+      } catch {
+        return false;
+      }
+    } else if (this.platform === "windows") {
+      try {
+        await execAsync(`schtasks /Query /TN "${schtasksTaskName(name)}"`);
         return true;
       } catch {
         return false;

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -1,4 +1,4 @@
-// src/daemon/service.ts — System service integration (launchd / systemd)
+// src/daemon/service.ts — System service integration (launchd / systemd / schtasks)
 // Generates and installs service definitions so the daemon starts at boot.
 
 import fs from "node:fs/promises";
@@ -136,13 +136,31 @@ WantedBy=default.target
 // schtasks helpers (Windows)
 // ---------------------------------------------------------------------------
 
-const SCHTASKS_TASK_PREFIX = "\\";
+const SAFE_NAME_RE = /^[a-zA-Z0-9._-]+$/;
+
+function assertSafeName(name: string): void {
+  if (!SAFE_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid service name "${name}" — only alphanumeric, dot, dash, and underscore are allowed`,
+    );
+  }
+}
+
+function assertSafePath(p: string): void {
+  if (/["&|<>^%]/.test(p)) {
+    throw new Error(
+      `Path contains unsafe characters for shell interpolation: ${p}`,
+    );
+  }
+}
 
 function schtasksTaskName(name: string): string {
-  return `${SCHTASKS_TASK_PREFIX}${name}`;
+  return `\\${name}`;
 }
 
 function buildCmdScript(config: ServiceConfig): string {
+  assertSafePath(config.execPath);
+  assertSafePath(config.cliPath);
   return `@echo off\r\nset ISOTOPES_DAEMON=1\r\n"${config.execPath}" "${config.cliPath}"\r\n`;
 }
 
@@ -173,6 +191,7 @@ export class ServiceManager {
   // -------------------------------------------------------------------------
 
   async install(config: ServiceConfig): Promise<void> {
+    assertSafeName(config.name);
     if (this.platform === "unsupported") {
       throw new Error(
         `Service installation is not supported on ${os.platform()}`,
@@ -222,6 +241,7 @@ export class ServiceManager {
   }
 
   async uninstall(name: string): Promise<void> {
+    assertSafeName(name);
     if (this.platform === "unsupported") {
       throw new Error(
         `Service management is not supported on ${os.platform()}`,


### PR DESCRIPTION
## Summary

Follow-up to #447 (Windows schtasks support) addressing review comments:

- **Input validation**: Add `assertSafeName()` and `assertSafePath()` to prevent command injection via `config.name` or paths interpolated into `execAsync` / `.cmd` scripts
- **File header**: Update comment to mention Windows/schtasks alongside launchd/systemd
- **Inline constant**: Remove `SCHTASKS_TASK_PREFIX` indirection, use `\${name}` directly
- **Tighter test assertion**: `ISOTOPES_DAEMON=1` check now uses regex matching `^set ISOTOPES_DAEMON=1$` instead of `stringContaining`
- **Fallback test**: Add missing test for Startup folder fallback when `schtasks /Create` fails

## Test plan

- [x] All 27 service tests pass (including new fallback test)
- [x] Typecheck clean
- [x] Lint clean
- [ ] Smoke test on real Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)