### PR TITLE
refactor(tools): rename reply-react to react

### DIFF
--- a/src/core/agent-init.test.ts
+++ b/src/core/agent-init.test.ts
@@ -85,7 +85,7 @@ describe("initializeAgent", () => {
     expect(toolNames).not.toContain("exec");
   });
 
-  it("skips reply/react tools when no transportContext provided", async () => {
+  it("skips react tools when no transportContext provided", async () => {
     const result = await initializeAgent({
       agentFile: makeMinimalAgentFile(),
       core,

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -31,7 +31,7 @@ import {
   resolveToolGuards,
   applyToolPolicy,
 } from "./tools.js";
-import { createReplyReactTools, LazyTransportContext } from "../tools/reply-react.js";
+import { createReactTools, LazyTransportContext } from "../tools/react.js";
 import { createExecTools, ProcessRegistry } from "../tools/exec.js";
 import { SandboxExecutor, SandboxFs, shouldSandbox, type FsLike } from "../sandbox/index.js";
 import * as nodeFs from "node:fs/promises";
@@ -175,7 +175,7 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
 
   // 10. Register reply/react tools (transport is bound lazily after transport starts)
   if (transportContext) {
-    for (const { tool, handler } of createReplyReactTools(transportContext)) {
+    for (const { tool, handler } of createReactTools(transportContext)) {
       toolRegistry.register(tool, handler);
     }
   }

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -68,7 +68,7 @@ export interface InitAgentOptions {
   agentManager: DefaultAgentManager;
   /** Pre-built sandbox executor (optional — no sandbox if omitted) */
   sandboxExecutor?: SandboxExecutor;
-  /** Transport context for reply/react tools (optional — skipped if omitted) */
+  /** Transport context for react tools (optional — skipped if omitted) */
   transportContext?: LazyTransportContext;
   /** Hook registry for lifecycle events (optional) */
   hooks?: HookRegistry;
@@ -173,7 +173,7 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
     toolRegistry.register(tool, handler);
   }
 
-  // 10. Register reply/react tools (transport is bound lazily after transport starts)
+  // 10. Register react tools (transport is bound lazily after transport starts)
   if (transportContext) {
     for (const { tool, handler } of createReactTools(transportContext)) {
       toolRegistry.register(tool, handler);

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -311,7 +311,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       if (firstTransport) {
         for (const [agentId, ctx] of transportContexts) {
           ctx.setTransport(firstTransport);
-          log.debug(`Bound Discord transport for reply/react tools (agent: ${agentId})`);
+          log.debug(`Bound Discord transport for react tools (agent: ${agentId})`);
         }
       }
     }

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -17,7 +17,7 @@ import { SessionStoreManager } from "./session-store-manager.js";
 import { DiscordTransportManager } from "../transports/discord-manager.js";
 import { ThreadBindingManager } from "./thread-bindings.js";
 import { createLogger } from "./logger.js";
-import { LazyTransportContext } from "../tools/reply-react.js";
+import { LazyTransportContext } from "../tools/react.js";
 import { ProcessRegistry } from "../tools/exec.js";
 import { ContainerManager, SandboxExecutor } from "../sandbox/index.js";
 import { initializeAgent } from "./agent-init.js";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -71,6 +71,6 @@ export type { ExecToolOptions, ProcessInfo } from "./exec.js";
 
 export {
   createMessageReactTool,
-  createReplyReactTools,
-} from "./reply-react.js";
-export type { ReplyReactToolContext } from "./reply-react.js";
+  createReactTools,
+} from "./react.js";
+export type { ReactToolContext } from "./react.js";

--- a/src/tools/react.test.ts
+++ b/src/tools/react.test.ts
@@ -112,7 +112,7 @@ describe("LazyTransportContext", () => {
 });
 
 describe("createReactTools", () => {
-  it("returns the react tool only (message_reply removed)", () => {
+  it("returns the react tool", () => {
     const transport = createMockTransport();
     const tools = createReactTools(wrapTransport(transport));
     expect(tools.map((t) => t.tool.name)).toEqual(["message_react"]);

--- a/src/tools/react.test.ts
+++ b/src/tools/react.test.ts
@@ -1,12 +1,12 @@
-// src/tools/reply-react.test.ts — Unit tests for message_react tool
+// src/tools/react.test.ts — Unit tests for message_react tool
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   createMessageReactTool,
-  createReplyReactTools,
+  createReactTools,
   LazyTransportContext,
-  type ReplyReactToolContext,
-} from "./reply-react.js";
+  type ReactToolContext,
+} from "./react.js";
 import type { Transport } from "../core/types.js";
 
 function createMockTransport(overrides: Partial<Transport> = {}): Transport {
@@ -18,12 +18,12 @@ function createMockTransport(overrides: Partial<Transport> = {}): Transport {
   };
 }
 
-function wrapTransport(transport: Transport): ReplyReactToolContext {
+function wrapTransport(transport: Transport): ReactToolContext {
   return { getTransport: () => transport };
 }
 
 describe("message_react tool", () => {
-  let ctx: ReplyReactToolContext;
+  let ctx: ReactToolContext;
   let transport: Transport;
 
   beforeEach(() => {
@@ -111,10 +111,10 @@ describe("LazyTransportContext", () => {
   });
 });
 
-describe("createReplyReactTools", () => {
+describe("createReactTools", () => {
   it("returns the react tool only (message_reply removed)", () => {
     const transport = createMockTransport();
-    const tools = createReplyReactTools(wrapTransport(transport));
+    const tools = createReactTools(wrapTransport(transport));
     expect(tools.map((t) => t.tool.name)).toEqual(["message_react"]);
   });
 });

--- a/src/tools/react.ts
+++ b/src/tools/react.ts
@@ -1,23 +1,17 @@
-// src/tools/reply-react.ts — message_react tool (reactions only)
-//
-// The previous `message_reply` tool was removed: it called Discord's
-// `target.reply()` directly, which double-sent alongside the auto-streamed
-// channel.send() in the transport. Reply-marker behavior now lives in the
-// transport via the [[reply_to_current]] / [[reply_to: <id>]] inline
-// directives — see src/transports/reply-directive.ts.
+// src/tools/react.ts — message_react tool
 
 import { createLogger } from "../core/logger.js";
 import type { Tool, Transport } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";
 
-const log = createLogger("tools:reply-react");
+const log = createLogger("tools:react");
 
 // ---------------------------------------------------------------------------
 // Context
 // ---------------------------------------------------------------------------
 
 /** Runtime context required by react tools. */
-export interface ReplyReactToolContext {
+export interface ReactToolContext {
   getTransport: () => Transport | undefined;
 }
 
@@ -26,7 +20,7 @@ export interface ReplyReactToolContext {
  * be set after tool registration.  This allows cli.ts to register react tools
  * eagerly and bind the real transport once the channel transport starts.
  */
-export class LazyTransportContext implements ReplyReactToolContext {
+export class LazyTransportContext implements ReactToolContext {
   private _transport: Transport | undefined;
 
   setTransport(transport: Transport): void {
@@ -48,7 +42,7 @@ export class LazyTransportContext implements ReplyReactToolContext {
  * Adds an emoji reaction to a specific message by its ID via the current transport.
  */
 export function createMessageReactTool(
-  ctx: ReplyReactToolContext,
+  ctx: ReactToolContext,
 ): { tool: Tool; handler: ToolHandler } {
   return {
     tool: {
@@ -126,8 +120,8 @@ export function createMessageReactTool(
  * Create the react tool(s) with shared context.
  * Returns an array of tool+handler pairs ready for registration.
  */
-export function createReplyReactTools(
-  ctx: ReplyReactToolContext,
+export function createReactTools(
+  ctx: ReactToolContext,
 ): { tool: Tool; handler: ToolHandler }[] {
   return [createMessageReactTool(ctx)];
 }


### PR DESCRIPTION
## Summary

PR #452 removed the `message_reply` tool; the file now hosts only `message_react`. This PR drops the historical \`reply-react\` naming.

- \`src/tools/reply-react.ts\` → \`src/tools/react.ts\`
- \`src/tools/reply-react.test.ts\` → \`src/tools/react.test.ts\`
- \`ReplyReactToolContext\` → \`ReactToolContext\`
- \`createReplyReactTools\` → \`createReactTools\`
- logger tag \`tools:reply-react\` → \`tools:react\`

\`LazyTransportContext\` keeps its name — it's a generic transport holder, not react-specific.

Pure rename, no behavior change.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`src/tools/react.test.ts\` + \`src/core\` tests pass (526 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)