### PR TITLE
fix(api): wire discordSessionStores into ApiServer

### DIFF
--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -263,6 +263,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
 
   // Discord transport
   let discordManager: DiscordTransportManager | undefined;
+  let discordSessionStores: Map<string, DefaultSessionStore> | undefined;
 
   if (config.channels?.discord) {
     const accounts = config.channels.discord.accounts ?? {};
@@ -274,6 +275,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       for (const agentFile of config.agents) {
         sessionStores.set(agentFile.id, await sessionStoreManager.getOrCreate(agentFile.id));
       }
+      discordSessionStores = sessionStores;
 
       const firstAccount = Object.values(accounts)[0];
       const defaultAgentId = firstAccount?.defaultAgentId || config.agents[0]?.id;
@@ -339,6 +341,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       usageTracker,
       uiRegistry: pluginManager.getUIRegistry(),
       sessionStoreManager,
+      discordSessionStores,
       hooks: pluginManager.getHooks(),
     },
   );


### PR DESCRIPTION
## Summary
- Runtime extraction in #420 accidentally dropped `discordSessionStores` when constructing `ApiServer` in `src/core/runtime.ts`. The type field stayed on `ApiServerDeps` and the `/api/sessions` handler still reads it, so the endpoint has been returning `[]` regardless of how many Discord sessions are live.
- Same gap silently broke the TUI Status screen, which fetches `/api/sessions` via `src/tui/api.ts:22`, and any UI plugin (e.g. dashboards) relying on that endpoint.
- Fix hoists the per-agent `Map<agentId, SessionStore>` (already being built for `sessionStoreForAgent`) up one scope and forwards it to `ApiServer`, matching the pre-extraction wiring in the old `cli.ts`.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `npx vitest run src/api src/plugins` — 34 tests pass
- [ ] Local smoke: start daemon with at least one Discord account configured, trigger a session, hit `/api/sessions` — should return non-empty array
- [ ] TUI Status screen shows sessions after the fix