### PR TITLE
docs,code: drop external-project references (openclaw/hermes)

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -24,7 +24,7 @@ non-root `agent` user with uid 1000.
 
 ## Configure
 
-Sandbox config is layered openclaw-style: an **agents-level** block (under
+Sandbox config is layered: an **agents-level** block (under
 `agents.defaults.sandbox` or top-level `sandbox`) supplies docker / mount
 defaults; each agent may overlay a partial **per-agent** override (typically
 just `mode: "off"` to opt one agent out).

--- a/docs/subagent-architecture.md
+++ b/docs/subagent-architecture.md
@@ -262,11 +262,11 @@ cli.ts  init
 
 新增 builtin backend **不需要改 cli.ts**，也不需要改 recorder。`metadata.subagent.backend` 字段在创建 session 时由 `spawnSubagent` 写入（值为 `"claude"` / `"builtin"`），落盘后可按 backend 过滤。
 
-### 4.4 目标布局：对齐 openclaw（计划项）
+### 4.4 目标布局（计划项）
 
-**现状的两个根**（§4.2 表里那两条 dataDir）和"主 agent / subagent 各自一套 store 实例"是历史遗留。计划在独立 PR 里把整个存储层对齐 openclaw：主 + sub 共用一个根目录、一个 manager、一种 agentId 体系。**不做向后兼容**——切换后旧路径下的 transcript 文件物理上还在，但代码不再读，等同于失忆。
+**现状的两个根**（§4.2 表里那两条 dataDir）和"主 agent / subagent 各自一套 store 实例"是历史遗留。计划在独立 PR 里把整个存储层收敛：主 + sub 共用一个根目录、一个 manager、一种 agentId 体系。**不做向后兼容**——切换后旧路径下的 transcript 文件物理上还在，但代码不再读，等同于失忆。
 
-#### 核心原则（直接抄 openclaw）
+#### 核心原则
 
 1. **agentId 永远是真实的**——主 agent 用它配置里的真实 ID，命名 subagent（比如 `code-reviewer`）用自己的真名，**没有"虚拟 agentId"概念**（不再有 `subagent:<parent>:<task>` 这种合成 ID）。
 2. **匿名/动态 subagent fallback 到父 agent 的 ID**——没指定 `targetAgentId` 时，session 直接落在父 agent 目录下。
@@ -407,21 +407,6 @@ cli.ts  init
                                                 │ 复用粒度   │ 主连续 / sub 默认一次性
 ```
 
-#### 与 openclaw 对照
-
-```
-  openclaw                                我们 (对齐后)
-  ──────────                              ─────────────
-  <stateDir>/agents/<id>/sessions/        ~/.isotopes/agents/<id>/sessions/
-  normalizeAgentId() 把 :,/ 替成 -        同
-  per-agentId store 实例                   同 (SessionStoreManager 提供)
-  agentId 永远真实，无合成 ID              同
-  匿名 sub 落父 agent 目录                 同
-  sessionKey: agent:<id>:subagent:<uuid>  同
-  主 agent + 命名 sub + 匿名 sub 同根     同
-  无 workspace-local                      同 (砍掉旧分支)
-```
-
 #### 改动清单
 
 - `paths.ts`：加 `normalizeAgentId()`（小写 + `[^a-z0-9_-]+ → -`）和 `getAgentSessionsDir(agentId)`。
@@ -484,4 +469,3 @@ dispatcher 负责所有"通用机制"（并发、超时、cancel、validate、st
 - `src/tools/subagent.ts` — `spawnSubagent` 入口（recorder 已接好）
 - `src/subagent/persistence.ts` — recorder + 事件→Message 适配
 - `docs/subagent-persistence.md` — 上一阶段（#400）的持久化设计
-- openclaw `pi-embedded-runner`、hermes `delegate_tool` — builtin 风格参考

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -439,7 +439,7 @@ export function resolveSubagentConfig(
 /**
  * Resolve sandbox config from config file types.
  *
- * Layered resolution (openclaw-style): an agents-level config (from
+ * Layered resolution: an agents-level config (from
  * `agents.defaults.sandbox` or top-level `sandbox`) provides image / docker /
  * workspaceAccess. Per-agent `sandbox` is a partial override — typically just
  * `{ mode: "off" }` to opt a single agent out. Per-agent `sandbox.docker` is

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -95,7 +95,7 @@ export function buildSystemPrompt(
 
   const parts = [basePrompt];
 
-  // Inject workspace path (like OpenClaw's ## Workspace section)
+  // Inject workspace path
   parts.push(`# Workspace\n\nYour working directory is: ${workspace.workspacePath}`);
 
   if (workspace.systemPromptAdditions) {

--- a/src/subagent/persistence.test.ts
+++ b/src/subagent/persistence.test.ts
@@ -10,7 +10,7 @@ import type { SubagentEvent } from "./types.js";
 import type { SessionStore, Message, Session } from "../core/types.js";
 
 describe("buildSubagentSessionKey", () => {
-  it("produces the openclaw-style sessionKey", () => {
+  it("produces the expected sessionKey", () => {
     const key = buildSubagentSessionKey("code-reviewer");
     expect(key.startsWith("agent:code-reviewer:subagent:")).toBe(true);
     // suffix should be a UUID-shaped string (8-4-4-4-12)


### PR DESCRIPTION
## Summary
- Strip incidental comparison phrasing that pointed at unrelated external projects (openclaw/hermes) from code comments, a test description, and two non-PRD docs.
- Substance unchanged; only the framing references are removed.

## Scope
- \`src/core/workspace.ts\`, \`src/core/config.ts\` — comment rewording
- \`src/subagent/persistence.test.ts\` — test description rewording
- \`docs/sandbox.md\` — drop "openclaw-style" adjective
- \`docs/subagent-architecture.md\` — drop §4.4 comparison framing and the closing comparison ASCII block

Intentionally left alone:
- \`docs/prd/**\` and \`docs/archive/PRD-M*.md\` (PRDs, per user direction)
- \`docs/research/**\` (comparative research notes, same spirit as PRDs)
- \`OPENCLAW_TOOL_PROFILE_ASCII.md\` (kept per user direction)

## Test plan
- [x] \`pnpm typecheck\` (via pre-commit hook)
- [x] \`eslint --fix\` on staged files (via pre-commit hook)
- [x] Scoped vitest: \`src/subagent/persistence.test.ts\` (18 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)