### PR TITLE
fix(init): drop hardcoded ghc-proxy baseUrl default

### DIFF
--- a/src/init/wizard.tsx
+++ b/src/init/wizard.tsx
@@ -43,7 +43,6 @@ export interface InitAnswers {
 // Defaults
 // ---------------------------------------------------------------------------
 
-const DEFAULT_GHC_BASE_URL = "https://api.ghccoder.com";
 const DEFAULT_GHC_MODEL = "claude-opus-4.6";
 
 // ---------------------------------------------------------------------------
@@ -71,7 +70,7 @@ function InitWizard({ onDone }: Props) {
   const [step, setStep] = useState<Step>({ kind: "llm" });
 
   const [llm, setLlm] = useState<LlmChoice>("skip");
-  const [ghcBaseUrl, setGhcBaseUrl] = useState(DEFAULT_GHC_BASE_URL);
+  const [ghcBaseUrl, setGhcBaseUrl] = useState("");
   const [ghcApiKey, setGhcApiKey] = useState("");
   const [ghcModel, setGhcModel] = useState(DEFAULT_GHC_MODEL);
 


### PR DESCRIPTION
## Summary
- The init wizard prefilled the ghc-proxy baseUrl field with \`https://api.ghccoder.com\`. Start with an empty input so users enter their own URL explicitly.

## Test plan
- [x] \`pnpm typecheck\`
- [ ] Manual: run \`isotopes init\`, pick ghc-proxy, verify the baseUrl prompt starts empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)