### PR TITLE
feat(session): persist tool_call/tool_result blocks to JSONL

### DIFF
--- a/src/core/agent-runner.test.ts
+++ b/src/core/agent-runner.test.ts
@@ -198,4 +198,127 @@ describe("runAgentLoop", () => {
     // Should not crash, just skip the callback
     expect(agent.steer).not.toHaveBeenCalled();
   });
+
+  it("persists tool_call blocks on the assistant message and tool_result as its own message", async () => {
+    const agent = createMockAgentInstance([
+      { type: "text_delta", text: "Let me check." },
+      { type: "tool_call", id: "call-1", name: "shell", args: { cmd: "ls" } },
+      { type: "tool_result", id: "call-1", output: "a.txt\nb.txt" },
+      { type: "turn_end" },
+      { type: "text_delta", text: "Done." },
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    const sessionStore = createMockSessionStore();
+
+    await runAgentLoop({
+      agent,
+      input: "list files",
+      sessionId: "s1",
+      sessionStore,
+      log: createMockLogger(),
+    });
+
+    const calls = (sessionStore.addMessage as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(3);
+
+    // Turn 1: assistant with text + tool_call
+    expect(calls[0][0]).toBe("s1");
+    expect(calls[0][1].role).toBe("assistant");
+    expect(calls[0][1].content).toEqual([
+      { type: "text", text: "Let me check." },
+      { type: "tool_call", id: "call-1", name: "shell", input: { cmd: "ls" } },
+    ]);
+
+    // Turn 1: tool_result-role message paired to call-1, with toolName
+    expect(calls[1][1].role).toBe("tool_result");
+    expect(calls[1][1].content).toEqual([
+      {
+        type: "tool_result",
+        output: "a.txt\nb.txt",
+        toolCallId: "call-1",
+        toolName: "shell",
+      },
+    ]);
+    expect(calls[1][1].metadata).toMatchObject({ toolCallId: "call-1", toolName: "shell" });
+
+    // Turn 2: text-only assistant
+    expect(calls[2][1].role).toBe("assistant");
+    expect(calls[2][1].content).toEqual([{ type: "text", text: "Done." }]);
+  });
+
+  it("truncates oversized tool_result output when persisting", async () => {
+    const big = "x".repeat(30_000);
+    const agent = createMockAgentInstance([
+      { type: "tool_call", id: "c", name: "read_file", args: {} },
+      { type: "tool_result", id: "c", output: big },
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    const sessionStore = createMockSessionStore();
+
+    await runAgentLoop({
+      agent,
+      input: "read",
+      sessionId: "s1",
+      sessionStore,
+      log: createMockLogger(),
+    });
+
+    const toolResultCall = (sessionStore.addMessage as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[1].role === "tool_result",
+    );
+    expect(toolResultCall).toBeDefined();
+    const output = toolResultCall![1].content[0].output as string;
+    expect(output.length).toBeLessThan(big.length);
+    expect(output).toContain("[truncated");
+  });
+
+  it("propagates isError on tool_result blocks", async () => {
+    const agent = createMockAgentInstance([
+      { type: "tool_call", id: "c", name: "shell", args: {} },
+      { type: "tool_result", id: "c", output: "boom", isError: true },
+      { type: "turn_end" },
+      { type: "agent_end", messages: [] },
+    ]);
+    const sessionStore = createMockSessionStore();
+
+    await runAgentLoop({
+      agent,
+      input: "x",
+      sessionId: "s1",
+      sessionStore,
+      log: createMockLogger(),
+    });
+
+    const toolResultCall = (sessionStore.addMessage as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[1].role === "tool_result",
+    );
+    expect(toolResultCall![1].content[0].isError).toBe(true);
+  });
+
+  it("flushes accumulated tool_calls at agent_end when turn_end is missing", async () => {
+    const agent = createMockAgentInstance([
+      { type: "text_delta", text: "partial" },
+      { type: "tool_call", id: "c", name: "t", args: {} },
+      { type: "agent_end", messages: [] },
+    ]);
+    const sessionStore = createMockSessionStore();
+
+    await runAgentLoop({
+      agent,
+      input: "x",
+      sessionId: "s1",
+      sessionStore,
+      log: createMockLogger(),
+    });
+
+    const calls = (sessionStore.addMessage as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][1].role).toBe("assistant");
+    expect(calls[0][1].content).toEqual([
+      { type: "text", text: "partial" },
+      { type: "tool_call", id: "c", name: "t", input: {} },
+    ]);
+  });
 });

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -1,10 +1,26 @@
 // src/core/agent-runner.ts — Shared agent event loop
 // Iterates over agent.prompt() and collects the response, handling errors uniformly.
 
-import { textContent, type AgentInstance, type Message, type SessionStore } from "./types.js";
+import {
+  textContent,
+  type AgentInstance,
+  type Message,
+  type MessageContentBlock,
+  type SessionStore,
+  type ToolCallContentBlock,
+} from "./types.js";
 import type { Logger } from "./logger.js";
 import type { UsageTracker } from "./usage-tracker.js";
 import type { HookRegistry } from "../plugins/hooks.js";
+
+/** Max chars to keep in a persisted tool_result output. Longer outputs are truncated. */
+export const MAX_TOOL_RESULT_CHARS = 25_000;
+
+function truncateToolResult(output: string): string {
+  if (output.length <= MAX_TOOL_RESULT_CHARS) return output;
+  const head = output.slice(0, MAX_TOOL_RESULT_CHARS);
+  return `${head}\n...[truncated ${output.length - MAX_TOOL_RESULT_CHARS} chars]`;
+}
 
 /** Result of running an agent prompt to completion */
 export interface AgentRunResult {
@@ -64,20 +80,72 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
   let responseText = "";
   let errorMessage: string | null = null;
 
+  // Per-turn persistence state. Each LLM turn may emit text deltas and any
+  // number of tool_call / tool_result events. At turn_end we flush: one
+  // assistant message (text + tool_call blocks) followed by one tool_result-
+  // role message per tool result, preserving wire-format ordering.
+  let turnText = "";
+  let turnToolCalls: ToolCallContentBlock[] = [];
+  let turnToolResults: Message[] = [];
+  const toolNameById = new Map<string, string>();
+
+  const flushTurn = async (): Promise<void> => {
+    if (turnText || turnToolCalls.length > 0) {
+      const content: MessageContentBlock[] = [];
+      if (turnText) content.push({ type: "text", text: turnText });
+      content.push(...turnToolCalls);
+      await sessionStore.addMessage(sessionId, {
+        role: "assistant",
+        content,
+        timestamp: Date.now(),
+      });
+    }
+    for (const msg of turnToolResults) {
+      await sessionStore.addMessage(sessionId, msg);
+    }
+    turnText = "";
+    turnToolCalls = [];
+    turnToolResults = [];
+  };
+
   for await (const event of agent.prompt(input)) {
     if (event.type === "text_delta") {
       responseText += event.text;
+      turnText += event.text;
       if (onTextDelta) {
         await onTextDelta(responseText);
       }
     } else if (event.type === "tool_call") {
       log.debug(`Tool call: ${event.name}`, { id: event.id });
+      toolNameById.set(event.id, event.name);
+      turnToolCalls.push({
+        type: "tool_call",
+        id: event.id,
+        name: event.name,
+        input: event.args,
+      });
     } else if (event.type === "tool_result") {
       log.debug(`Tool result: ${event.id}`);
+      const toolName = toolNameById.get(event.id);
+      turnToolResults.push({
+        role: "tool_result",
+        content: [{
+          type: "tool_result",
+          output: truncateToolResult(event.output),
+          ...(event.isError !== undefined ? { isError: event.isError } : {}),
+          toolCallId: event.id,
+          ...(toolName ? { toolName } : {}),
+        }],
+        timestamp: Date.now(),
+        metadata: { toolCallId: event.id, ...(toolName ? { toolName } : {}) },
+      });
     } else if (event.type === "turn_end") {
       if (usageTracker && event.usage) {
         usageTracker.record(sessionId, event.usage);
       }
+
+      // Persist this turn's assistant message + tool_result messages.
+      await flushTurn();
 
       // Check for pending messages after tool calls complete
       if (onToolComplete) {
@@ -88,20 +156,15 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
         }
       }
     } else if (event.type === "agent_end") {
+      // Defensive flush — if the run ended without a final turn_end, persist
+      // whatever text/tool blocks we accumulated so nothing is silently dropped.
+      await flushTurn();
+
       if (hooks && agentId && responseText) {
         await hooks.emit("message_sending", {
           agentId,
           sessionId,
           message: { role: "assistant", content: textContent(responseText) },
-        });
-      }
-
-      // Store final assistant message
-      if (responseText) {
-        await sessionStore.addMessage(sessionId, {
-          role: "assistant",
-          content: textContent(responseText),
-          timestamp: Date.now(),
         });
       }
 

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -14,7 +14,7 @@ import type { UsageTracker } from "./usage-tracker.js";
 import type { HookRegistry } from "../plugins/hooks.js";
 
 /** Max chars to keep in a persisted tool_result output. Longer outputs are truncated. */
-export const MAX_TOOL_RESULT_CHARS = 25_000;
+export const MAX_TOOL_RESULT_CHARS = 16_000;
 
 function truncateToolResult(output: string): string {
   if (output.length <= MAX_TOOL_RESULT_CHARS) return output;

--- a/src/core/context.test.ts
+++ b/src/core/context.test.ts
@@ -134,6 +134,26 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result).toEqual(msgs);
   });
 
+  it("recognizes the tool_call block shape (our persisted format) for orphan synthesis", () => {
+    const msgs: Message[] = [
+      user("do it"),
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "calling" },
+          { type: "tool_call", id: "t1", name: "read_file", input: { path: "/x" } },
+        ],
+      },
+      // no tool_result for t1 — session truncated mid-turn
+      user("next"),
+    ];
+    const result = sanitizeToolUseResultPairing(msgs);
+    expect(result.length).toBe(4);
+    expect(result[2].role).toBe("tool_result");
+    expect(result[2].metadata?.toolCallId).toBe("t1");
+    expect(result[2].metadata?.synthetic).toBe(true);
+  });
+
   it("handles multiple tool_use blocks in one assistant message", () => {
     const msgs = [
       user("do both"),

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -39,16 +39,16 @@ export function limitHistoryTurns(messages: Message[], limit: number): Message[]
 
 /** Duck-type check for tool_use blocks inside assistant message content. */
 interface ToolUseBlock {
-  type: "tool_use";
+  type: "tool_use" | "tool_call";
   id: string;
   name?: string;
 }
 
 function isToolUseBlock(block: unknown): block is ToolUseBlock {
+  if (typeof block !== "object" || block === null) return false;
+  const t = (block as Record<string, unknown>).type;
   return (
-    typeof block === "object" &&
-    block !== null &&
-    (block as Record<string, unknown>).type === "tool_use" &&
+    (t === "tool_use" || t === "tool_call") &&
     typeof (block as Record<string, unknown>).id === "string"
   );
 }

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -727,6 +727,25 @@ describe("Message conversion", () => {
 
     vi.restoreAllMocks();
   });
+
+  it("serializes assistant tool_call blocks to pi-agent-core toolCall shape", () => {
+    const core = new PiMonoCore();
+    const instance = core.createAgent(makeConfig());
+    instance.steer({
+      role: "assistant",
+      content: [
+        { type: "text", text: "calling" },
+        { type: "tool_call", id: "c-1", name: "shell", input: { cmd: "ls" } },
+      ],
+    });
+
+    const arg = mockAgent.steer.mock.calls[0][0];
+    expect(arg.role).toBe("assistant");
+    expect(arg.content).toEqual([
+      { type: "text", text: "calling" },
+      { type: "toolCall", id: "c-1", name: "shell", input: { cmd: "ls" } },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -130,9 +130,19 @@ function toAgentMessage(msg: Message): AgentMessage {
     } as unknown as AgentMessage;
   }
 
+  // Translate our assistant tool_call blocks into pi-agent-core's toolCall shape.
+  const content = role === "assistant"
+    ? msg.content.map((block) => {
+        if (block.type === "tool_call") {
+          return { type: "toolCall", id: block.id, name: block.name, input: block.input };
+        }
+        return block;
+      })
+    : msg.content;
+
   return {
     role,
-    content: msg.content,
+    content,
     timestamp: msg.timestamp ?? Date.now(),
   } as AgentMessage;
 }
@@ -193,10 +203,28 @@ function normalizeContentBlocks(content: unknown): MessageContentBlock[] {
         isError?: unknown;
         toolCallId?: unknown;
         toolName?: unknown;
+        id?: unknown;
+        name?: unknown;
+        input?: unknown;
+        arguments?: unknown;
       };
 
       if (typed.type === "text" && typeof typed.text === "string") {
         blocks.push({ type: "text", text: typed.text });
+        continue;
+      }
+
+      if (
+        (typed.type === "toolCall" || typed.type === "tool_call" || typed.type === "tool_use") &&
+        typeof typed.id === "string" &&
+        typeof typed.name === "string"
+      ) {
+        blocks.push({
+          type: "tool_call",
+          id: typed.id,
+          name: typed.name,
+          input: typed.input ?? typed.arguments ?? {},
+        });
         continue;
       }
 

--- a/src/core/types.test.ts
+++ b/src/core/types.test.ts
@@ -68,4 +68,13 @@ describe("messageContentToPlainText", () => {
 
     expect(messageContentToPlainText(blocks)).toBe("only text");
   });
+
+  it("renders tool_call blocks as [tool: name]", () => {
+    const blocks: MessageContentBlock[] = [
+      { type: "text", text: "Let me check." },
+      { type: "tool_call", id: "c1", name: "shell", input: { cmd: "ls" } },
+    ];
+
+    expect(messageContentToPlainText(blocks)).toBe("Let me check.\n[tool: shell]");
+  });
 });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -14,6 +14,14 @@ export interface TextContentBlock {
   text: string;
 }
 
+/** A tool call (the model's request to invoke a tool) inside an assistant message. */
+export interface ToolCallContentBlock {
+  type: 'tool_call';
+  id: string;
+  name: string;
+  input: unknown;
+}
+
 /** A tool result content block within a message. */
 export interface ToolResultContentBlock {
   type: 'tool_result';
@@ -24,7 +32,7 @@ export interface ToolResultContentBlock {
 }
 
 /** Union of content block types that can appear in a {@link Message}. */
-export type MessageContentBlock = TextContentBlock | ToolResultContentBlock;
+export type MessageContentBlock = TextContentBlock | ToolCallContentBlock | ToolResultContentBlock;
 
 /** Wrap a plain text string into a single-element {@link MessageContentBlock} array. */
 export function textContent(text: string): MessageContentBlock[] {
@@ -37,6 +45,9 @@ export function messageContentToPlainText(content: MessageContentBlock[]): strin
     .map((block) => {
       if (block.type === 'text') {
         return block.text;
+      }
+      if (block.type === 'tool_call') {
+        return `[tool: ${block.name}]`;
       }
       return block.output;
     })


### PR DESCRIPTION
Closes #453

## Summary
- Add `ToolCallContentBlock` to the core content union so tool invocations are first-class in session history.
- Replace the old "persist only final responseText at agent_end" path in `agent-runner` with per-turn flushing: one assistant message (text + tool_call blocks) plus one tool_result-role message per result, preserving wire ordering. Tool result outputs are truncated at 25k chars.
- `pi-mono` now converts between our `tool_call` blocks and pi-agent-core's `toolCall` shape in both directions, so persisted sessions replay cleanly.
- `sanitizeToolUseResultPairing` recognizes the new `tool_call` block shape (alongside legacy `tool_use`) when synthesizing results for orphaned calls after truncation.

## Test plan
- [x] `npx vitest run src/core/agent-runner.test.ts src/core/context.test.ts src/core/types.test.ts src/core/pi-mono.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm lint`