### PR TITLE
refactor: delete AgentCore/AgentInstance/AgentManager/AgentEvent abstraction layer (#475)

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -142,27 +142,30 @@ addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
       if (ac.signal.aborted) break;
 
       switch (event.type) {
-        case "text_delta":
-          responseText += event.text;
-          writeEvent("text_delta", { text: event.text });
+        case "message_update": {
+          const ame = event.assistantMessageEvent;
+          if (ame.type === "text_delta") {
+            responseText += ame.delta;
+            writeEvent("text_delta", { text: ame.delta });
+          }
           break;
-        case "tool_call":
-          writeEvent("tool_call", { id: event.id, name: event.name, args: event.args });
+        }
+        case "tool_execution_start":
+          writeEvent("tool_call", { id: event.toolCallId, name: event.toolName, args: event.args });
           break;
-        case "tool_result":
-          writeEvent("tool_result", { id: event.id, output: event.output, isError: event.isError });
+        case "tool_execution_end": {
+          const output = typeof event.result === "string" ? event.result : JSON.stringify(event.result);
+          writeEvent("tool_result", { id: event.toolCallId, output, isError: event.isError });
           break;
+        }
         case "turn_start":
           writeEvent("turn_start", {});
           break;
         case "turn_end":
-          writeEvent("turn_end", { usage: event.usage });
+          writeEvent("turn_end", {});
           break;
         case "agent_end":
-          writeEvent("agent_end", { stopReason: event.stopReason });
-          break;
-        case "error":
-          writeEvent("error", { message: event.error.message });
+          writeEvent("agent_end", {});
           break;
       }
     }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -9,7 +9,8 @@ import path from "node:path";
 import { VERSION } from "../version.js";
 import type { CronScheduler, CronJobInput } from "../automation/cron-job.js";
 import type { ConfigReloader } from "../workspace/config-reloader.js";
-import type { AgentManager, SessionStore } from "../core/types.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
+import type { SessionStore } from "../core/types.js";
 import { messageText } from "../core/messages.js";
 import type { UsageTracker } from "../core/usage-tracker.js";
 import type { SessionStoreManager } from "../core/session-store-manager.js";
@@ -25,7 +26,7 @@ import { sendJson, sendError, handleRouteError, type ApiRequest } from "./middle
 export interface RouteDeps {
   cronScheduler: CronScheduler;
   configReloader?: ConfigReloader;
-  agentManager?: AgentManager;
+  agentManager?: DefaultAgentManager;
   discordSessionStores?: Map<string, SessionStore>;
   usageTracker?: UsageTracker;
   sessionStoreManager?: SessionStoreManager;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -6,7 +6,8 @@ import path from "node:path";
 import { createLogger } from "../core/logger.js";
 import type { CronScheduler } from "../automation/cron-job.js";
 import type { ConfigReloader } from "../workspace/config-reloader.js";
-import type { AgentManager, SessionStore } from "../core/types.js";
+import type { DefaultAgentManager } from '../core/agent-manager.js';
+import type { SessionStore } from '../core/types.js';
 import type { UsageTracker } from "../core/usage-tracker.js";
 import type { SessionStoreManager } from "../core/session-store-manager.js";
 import {
@@ -56,7 +57,7 @@ export interface ApiServerConfig {
 export interface ApiServerDeps {
   cronScheduler: CronScheduler;
   configReloader?: ConfigReloader;
-  agentManager?: AgentManager;
+  agentManager?: DefaultAgentManager;
   usageTracker?: UsageTracker;
   discordSessionStores?: Map<string, SessionStore>;
   uiRegistry?: UIRegistry;

--- a/src/commands/slash-commands.test.ts
+++ b/src/commands/slash-commands.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SlashCommandHandler, type CommandContext } from "./slash-commands.js";
-import { createMockAgentManager, createMockSessionStore } from "../core/test-helpers.js";
+import { createMockSessionStore } from "../core/test-helpers.js";
 
 function createContext(overrides?: Partial<CommandContext>): CommandContext {
   return {

--- a/src/commands/slash-commands.test.ts
+++ b/src/commands/slash-commands.test.ts
@@ -2,7 +2,8 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SlashCommandHandler, type CommandContext } from "./slash-commands.js";
-import { createMockSessionStore } from "../core/test-helpers.js";
+import { createMockAgentManager, createMockSessionStore } from "../core/test-helpers.js";
+import type { PiMonoInstance } from "../core/pi-mono.js";
 
 function createContext(overrides?: Partial<CommandContext>): CommandContext {
   return {
@@ -249,7 +250,7 @@ describe("SlashCommandHandler", () => {
         steer: vi.fn(),
         followUp: vi.fn(),
         clearMessages: vi.fn(),
-      };
+      } as unknown as PiMonoInstance;
 
       const ctx = createContext({
         sessionStore,
@@ -320,7 +321,7 @@ describe("SlashCommandHandler", () => {
         steer: vi.fn(),
         followUp: vi.fn(),
         forceCompact: vi.fn().mockResolvedValue(true),
-      };
+      } as unknown as PiMonoInstance;
 
       const ctx = createContext({
         sessionStore,
@@ -341,7 +342,7 @@ describe("SlashCommandHandler", () => {
         steer: vi.fn(),
         followUp: vi.fn(),
         forceCompact: vi.fn().mockResolvedValue(false),
-      };
+      } as unknown as PiMonoInstance;
 
       const ctx = createContext({
         sessionId: "session-small",
@@ -366,7 +367,7 @@ describe("SlashCommandHandler", () => {
         steer: vi.fn(),
         followUp: vi.fn(),
         // No forceCompact method
-      };
+      } as unknown as PiMonoInstance;
 
       const ctx = createContext({
         sessionId: "session-no-compact",
@@ -385,7 +386,7 @@ describe("SlashCommandHandler", () => {
         steer: vi.fn(),
         followUp: vi.fn(),
         forceCompact: vi.fn().mockRejectedValue(new Error("Model API error")),
-      };
+      } as unknown as PiMonoInstance;
 
       const ctx = createContext({
         sessionId: "session-error",

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -1,7 +1,9 @@
 // src/commands/slash-commands.ts — Slash command handler for admin operations
 // Parses and dispatches /status, /reload, /model commands from chat messages.
 
-import type { AgentManager, SessionStore, AgentInstance } from "../core/types.js";
+import type { SessionStore, PiMonoInstance } from "../core/types.js";
+import type { PiMonoInstance } from "../core/pi-mono.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
 import { createLogger } from "../core/logger.js";
 import { failureTracker } from "../subagent/failure-tracker.js";
 
@@ -28,7 +30,7 @@ export interface CommandContext {
   /** Current session key (if available) */
   sessionKey?: string;
   /** Agent instance (if available) */
-  agentInstance?: AgentInstance;
+  agentInstance?: PiMonoInstance;
 }
 
 /** Result of executing a slash command */

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -1,7 +1,7 @@
 // src/commands/slash-commands.ts — Slash command handler for admin operations
 // Parses and dispatches /status, /reload, /model commands from chat messages.
 
-import type { SessionStore, PiMonoInstance } from "../core/types.js";
+import type { SessionStore } from "../core/types.js";
 import type { PiMonoInstance } from "../core/pi-mono.js";
 import type { DefaultAgentManager } from "../core/agent-manager.js";
 import { createLogger } from "../core/logger.js";
@@ -17,7 +17,7 @@ export interface ParsedCommand {
 
 /** Context passed to command handlers */
 export interface CommandContext {
-  agentManager: AgentManager;
+  agentManager: DefaultAgentManager;
   sessionStore: SessionStore;
   /** The agent ID this message was routed to */
   agentId: string;

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -35,10 +35,9 @@ import { createReactTools, LazyTransportContext } from "../tools/react.js";
 import { createExecTools, ProcessRegistry } from "../tools/exec.js";
 import { SandboxExecutor, SandboxFs, shouldSandbox, type FsLike } from "../sandbox/index.js";
 import * as nodeFs from "node:fs/promises";
-import type { PiMonoCore } from "./pi-mono.js";
+import { PiMonoCore, PiMonoInstance } from "./pi-mono.js";
 import type { DefaultAgentManager } from "./agent-manager.js";
-import type { AgentConfig, PiMonoInstance } from "./types.js";
-import { PiMonoInstance } from "./pi-mono.js";
+import type { AgentConfig } from "./types.js";
 import { createLogger } from "./logger.js";
 import type { HookRegistry } from "../plugins/hooks.js";
 

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -37,7 +37,7 @@ import { SandboxExecutor, SandboxFs, shouldSandbox, type FsLike } from "../sandb
 import * as nodeFs from "node:fs/promises";
 import type { PiMonoCore } from "./pi-mono.js";
 import type { DefaultAgentManager } from "./agent-manager.js";
-import type { AgentConfig, AgentInstance } from "./types.js";
+import type { AgentConfig, PiMonoInstance } from "./types.js";
 import { createLogger } from "./logger.js";
 import type { HookRegistry } from "../plugins/hooks.js";
 
@@ -62,7 +62,7 @@ export interface InitAgentOptions {
   sandbox?: SandboxConfigFile;
   /** Subagent config */
   subagent?: SubagentConfigFile;
-  /** AgentCore implementation */
+  /** PiMonoCore implementation */
   core: PiMonoCore;
   /** Agent manager */
   agentManager: DefaultAgentManager;
@@ -76,7 +76,7 @@ export interface InitAgentOptions {
 
 export interface InitAgentResult {
   agentConfig: AgentConfig;
-  instance: AgentInstance;
+  instance: PiMonoInstance;
   workspacePath: string;
   toolRegistry: ToolRegistry;
   processRegistry: ProcessRegistry;

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -38,6 +38,7 @@ import * as nodeFs from "node:fs/promises";
 import type { PiMonoCore } from "./pi-mono.js";
 import type { DefaultAgentManager } from "./agent-manager.js";
 import type { AgentConfig, PiMonoInstance } from "./types.js";
+import { PiMonoInstance } from "./pi-mono.js";
 import { createLogger } from "./logger.js";
 import type { HookRegistry } from "../plugins/hooks.js";
 

--- a/src/core/agent-manager.test.ts
+++ b/src/core/agent-manager.test.ts
@@ -2,25 +2,28 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DefaultAgentManager } from "./agent-manager.js";
-import type { AgentConfig, AgentCore, AgentInstance } from "./types.js";
+import type { AgentConfig } from "./types.js";
+import { PiMonoCore } from "./pi-mono.js";
 
 // ---------------------------------------------------------------------------
 // Mock setup
 // ---------------------------------------------------------------------------
 
-function createMockInstance(): AgentInstance {
+import type { PiMonoInstance } from "./pi-mono.js";
+
+function createMockInstance(): PiMonoInstance {
   return {
     prompt: vi.fn(),
     abort: vi.fn(),
     steer: vi.fn(),
     followUp: vi.fn(),
-  };
+  } as unknown as PiMonoInstance;
 }
 
-function createMockCore(): AgentCore {
+function createMockCore(): PiMonoCore {
   return {
     createAgent: vi.fn(() => createMockInstance()),
-  };
+  } as unknown as PiMonoCore;
 }
 
 function makeConfig(overrides?: Partial<AgentConfig>): AgentConfig {
@@ -36,7 +39,7 @@ function makeConfig(overrides?: Partial<AgentConfig>): AgentConfig {
 // ---------------------------------------------------------------------------
 
 describe("DefaultAgentManager", () => {
-  let core: AgentCore;
+  let core: PiMonoCore;
   let manager: DefaultAgentManager;
 
   beforeEach(() => {

--- a/src/core/agent-manager.ts
+++ b/src/core/agent-manager.ts
@@ -1,13 +1,8 @@
-import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 // src/core/agent-manager.ts — Agent lifecycle management
-// Creates, stores, and manages PiMonoInstance objects.
 
-import type {
-  AgentConfig,
-  
-} from "./types.js";
+import type { AgentConfig } from "./types.js";
 import { PiMonoCore, PiMonoInstance } from "./pi-mono.js";
-import { PiMonoCore } from "./pi-mono.js";
+import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 import {
   buildSystemPrompt,
   ensureWorkspaceStructure,
@@ -46,7 +41,7 @@ interface AgentEntry {
  * SOUL.md, MEMORY.md, and other context files that are merged into
  * the system prompt.
  */
-export class DefaultAgentManager implements AgentManager {
+export class DefaultAgentManager {
   private agents = new Map<string, AgentEntry>();
 
   constructor(private core: PiMonoCore) {}

--- a/src/core/agent-manager.ts
+++ b/src/core/agent-manager.ts
@@ -4,10 +4,9 @@ import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 
 import type {
   AgentConfig,
-  PiMonoCore,
   
-  AgentManager,
 } from "./types.js";
+import { PiMonoCore, PiMonoInstance } from "./pi-mono.js";
 import { PiMonoCore } from "./pi-mono.js";
 import {
   buildSystemPrompt,

--- a/src/core/agent-manager.ts
+++ b/src/core/agent-manager.ts
@@ -1,13 +1,14 @@
 import { resolveBundledSkillsDir } from "../skills/bundled-dir.js";
 // src/core/agent-manager.ts — Agent lifecycle management
-// Creates, stores, and manages AgentInstance objects.
+// Creates, stores, and manages PiMonoInstance objects.
 
 import type {
   AgentConfig,
-  AgentCore,
-  AgentInstance,
+  PiMonoCore,
+  
   AgentManager,
 } from "./types.js";
+import { PiMonoCore } from "./pi-mono.js";
 import {
   buildSystemPrompt,
   ensureWorkspaceStructure,
@@ -28,7 +29,7 @@ export interface AgentCreateOptions {
 /** Internal entry combining config, instance, and workspace */
 interface AgentEntry {
   config: AgentConfig;
-  instance: AgentInstance;
+  instance: PiMonoInstance;
   workspace: WorkspaceContext | null;
   /** Base system prompt before workspace assembly (for hot-reload) */
   baseSystemPrompt: string;
@@ -41,7 +42,7 @@ interface AgentEntry {
 /**
  * DefaultAgentManager — in-memory {@link AgentManager} implementation.
  *
- * Manages agent configs and instances backed by an {@link AgentCore}.
+ * Manages agent configs and instances backed by an {@link PiMonoCore}.
  * Each agent can optionally have its own workspace directory containing
  * SOUL.md, MEMORY.md, and other context files that are merged into
  * the system prompt.
@@ -49,7 +50,7 @@ interface AgentEntry {
 export class DefaultAgentManager implements AgentManager {
   private agents = new Map<string, AgentEntry>();
 
-  constructor(private core: AgentCore) {}
+  constructor(private core: PiMonoCore) {}
 
   /**
    * Create a new agent.
@@ -58,7 +59,7 @@ export class DefaultAgentManager implements AgentManager {
    * (workspace context + tool guards included). The options provide workspace
    * metadata needed for hot-reload.
    */
-  async create(config: AgentConfig, options?: AgentCreateOptions): Promise<AgentInstance> {
+  async create(config: AgentConfig, options?: AgentCreateOptions): Promise<PiMonoInstance> {
     if (this.agents.has(config.id)) {
       throw new Error(`Agent "${config.id}" already exists`);
     }
@@ -75,7 +76,7 @@ export class DefaultAgentManager implements AgentManager {
     return instance;
   }
 
-  get(id: string): AgentInstance | undefined {
+  get(id: string): PiMonoInstance | undefined {
     return this.agents.get(id)?.instance;
   }
 
@@ -88,7 +89,7 @@ export class DefaultAgentManager implements AgentManager {
     return Array.from(this.agents.values()).map((e) => e.config);
   }
 
-  async update(id: string, updates: Partial<AgentConfig>): Promise<AgentInstance> {
+  async update(id: string, updates: Partial<AgentConfig>): Promise<PiMonoInstance> {
     const entry = this.agents.get(id);
     if (!entry) {
       throw new Error(`Agent "${id}" not found`);

--- a/src/core/agent-runner.test.ts
+++ b/src/core/agent-runner.test.ts
@@ -137,7 +137,7 @@ describe("runAgentLoop", () => {
 
   it("calls onToolComplete after turn_end and injects via steer", async () => {
     const agent = createMockAgentInstance([
-      { type: "turn_end" },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -163,7 +163,7 @@ describe("runAgentLoop", () => {
 
   it("does not call steer if onToolComplete returns null", async () => {
     const agent = createMockAgentInstance([
-      { type: "turn_end" },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -184,7 +184,7 @@ describe("runAgentLoop", () => {
 
   it("does not call onToolComplete if not provided", async () => {
     const agent = createMockAgentInstance([
-      { type: "turn_end" },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -205,10 +205,10 @@ describe("runAgentLoop", () => {
     const agent = createMockAgentInstance([
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Let me check." } as never },
       { type: "tool_execution_start", toolCallId: "call-1", toolName: "shell", args: { cmd: "ls" } },
-      { type: "tool_execution_end", toolCallId: "call-1", result: "a.txt\nb.txt" },
-      { type: "turn_end" },
+      { type: "tool_execution_end", toolCallId: "call-1", toolName: "test", result: "a.txt\nb.txt", isError: false },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Done." } as never },
-      { type: "turn_end" },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -247,8 +247,8 @@ describe("runAgentLoop", () => {
     const big = "x".repeat(30_000);
     const agent = createMockAgentInstance([
       { type: "tool_execution_start", toolCallId: "c", toolName: "read_file", args: {} },
-      { type: "tool_execution_end", toolCallId: "c", result: big },
-      { type: "turn_end" },
+      { type: "tool_execution_end", toolCallId: "c", toolName: "read_file", result: big, isError: false },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -273,8 +273,8 @@ describe("runAgentLoop", () => {
   it("propagates isError on tool_result blocks", async () => {
     const agent = createMockAgentInstance([
       { type: "tool_execution_start", toolCallId: "c", toolName: "shell", args: {} },
-      { type: "tool_execution_end", toolCallId: "c", result: "boom", isError: true },
-      { type: "turn_end" },
+      { type: "tool_execution_end", toolCallId: "c", toolName: "test", result: "boom", isError: true },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();

--- a/src/core/agent-runner.test.ts
+++ b/src/core/agent-runner.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { runAgentLoop } from "./agent-runner.js";
-import { createMockAgentInstance, createMockSessionStore } from "./test-helpers.js";
+import { createMockPiMonoInstance, createMockSessionStore } from "./test-helpers.js";
 import { msgField } from "./messages.js";
 import type { Logger } from "./logger.js";
 
@@ -21,9 +21,9 @@ function createMockLogger(): Logger {
 
 describe("runAgentLoop", () => {
   it("accumulates text_delta events into responseText", async () => {
-    const agent = createMockAgentInstance([
-      { type: "text_delta", text: "Hello " },
-      { type: "text_delta", text: "world!" },
+    const agent = createMockPiMonoInstance([
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Hello " } as never },
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "world!" } as never },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -41,8 +41,8 @@ describe("runAgentLoop", () => {
   });
 
   it("stores assistant message on agent_end", async () => {
-    const agent = createMockAgentInstance([
-      { type: "text_delta", text: "Reply" },
+    const agent = createMockPiMonoInstance([
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Reply" } as never },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -65,7 +65,7 @@ describe("runAgentLoop", () => {
   });
 
   it("does not store assistant message when responseText is empty", async () => {
-    const agent = createMockAgentInstance([
+    const agent = createMockPiMonoInstance([
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -82,8 +82,8 @@ describe("runAgentLoop", () => {
   });
 
   it("captures error message on agent_end with error stopReason", async () => {
-    const agent = createMockAgentInstance([
-      { type: "agent_end", messages: [], stopReason: "error", errorMessage: "API key invalid" },
+    const agent = createMockPiMonoInstance([
+      { type: "agent_end", messages: [{ role: "assistant", content: [], stopReason: "error", errorMessage: "API key invalid", timestamp: Date.now() } as never] },
     ]);
     const log = createMockLogger();
 
@@ -100,8 +100,8 @@ describe("runAgentLoop", () => {
   });
 
   it("defaults errorMessage to 'Unknown agent error'", async () => {
-    const agent = createMockAgentInstance([
-      { type: "agent_end", messages: [], stopReason: "error" },
+    const agent = createMockPiMonoInstance([
+      { type: "agent_end", messages: [{ role: "assistant", content: [], stopReason: "error", timestamp: Date.now() } as never] },
     ]);
 
     const result = await runAgentLoop({
@@ -116,9 +116,9 @@ describe("runAgentLoop", () => {
   });
 
   it("calls onTextDelta with accumulated text", async () => {
-    const agent = createMockAgentInstance([
-      { type: "text_delta", text: "a" },
-      { type: "text_delta", text: "b" },
+    const agent = createMockPiMonoInstance([
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "a" } as never },
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "b" } as never },
       { type: "agent_end", messages: [] },
     ]);
 
@@ -136,7 +136,7 @@ describe("runAgentLoop", () => {
   });
 
   it("calls onToolComplete after turn_end and injects via steer", async () => {
-    const agent = createMockAgentInstance([
+    const agent = createMockPiMonoInstance([
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -162,7 +162,7 @@ describe("runAgentLoop", () => {
   });
 
   it("does not call steer if onToolComplete returns null", async () => {
-    const agent = createMockAgentInstance([
+    const agent = createMockPiMonoInstance([
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -183,7 +183,7 @@ describe("runAgentLoop", () => {
   });
 
   it("does not call onToolComplete if not provided", async () => {
-    const agent = createMockAgentInstance([
+    const agent = createMockPiMonoInstance([
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -202,12 +202,12 @@ describe("runAgentLoop", () => {
   });
 
   it("persists tool_call blocks on the assistant message and tool_result as its own message", async () => {
-    const agent = createMockAgentInstance([
-      { type: "text_delta", text: "Let me check." },
-      { type: "tool_call", id: "call-1", name: "shell", args: { cmd: "ls" } },
-      { type: "tool_result", id: "call-1", output: "a.txt\nb.txt" },
+    const agent = createMockPiMonoInstance([
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Let me check." } as never },
+      { type: "tool_execution_start", toolCallId: "call-1", toolName: "shell", args: { cmd: "ls" } },
+      { type: "tool_execution_end", toolCallId: "call-1", result: "a.txt\nb.txt" },
       { type: "turn_end" },
-      { type: "text_delta", text: "Done." },
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Done." } as never },
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -245,9 +245,9 @@ describe("runAgentLoop", () => {
 
   it("truncates oversized tool_result output when persisting", async () => {
     const big = "x".repeat(30_000);
-    const agent = createMockAgentInstance([
-      { type: "tool_call", id: "c", name: "read_file", args: {} },
-      { type: "tool_result", id: "c", output: big },
+    const agent = createMockPiMonoInstance([
+      { type: "tool_execution_start", toolCallId: "c", toolName: "read_file", args: {} },
+      { type: "tool_execution_end", toolCallId: "c", result: big },
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -271,9 +271,9 @@ describe("runAgentLoop", () => {
   });
 
   it("propagates isError on tool_result blocks", async () => {
-    const agent = createMockAgentInstance([
-      { type: "tool_call", id: "c", name: "shell", args: {} },
-      { type: "tool_result", id: "c", output: "boom", isError: true },
+    const agent = createMockPiMonoInstance([
+      { type: "tool_execution_start", toolCallId: "c", toolName: "shell", args: {} },
+      { type: "tool_execution_end", toolCallId: "c", result: "boom", isError: true },
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -294,9 +294,9 @@ describe("runAgentLoop", () => {
   });
 
   it("flushes accumulated tool_calls at agent_end when turn_end is missing", async () => {
-    const agent = createMockAgentInstance([
-      { type: "text_delta", text: "partial" },
-      { type: "tool_call", id: "c", name: "t", args: {} },
+    const agent = createMockPiMonoInstance([
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "partial" } as never },
+      { type: "tool_execution_start", toolCallId: "c", toolName: "t", args: {} },
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();

--- a/src/core/agent-runner.test.ts
+++ b/src/core/agent-runner.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { runAgentLoop } from "./agent-runner.js";
-import { createMockPiMonoInstance, createMockSessionStore } from "./test-helpers.js";
+import { createMockAgentInstance, createMockSessionStore } from "./test-helpers.js";
 import { msgField } from "./messages.js";
 import type { Logger } from "./logger.js";
 
@@ -21,7 +21,7 @@ function createMockLogger(): Logger {
 
 describe("runAgentLoop", () => {
   it("accumulates text_delta events into responseText", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Hello " } as never },
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "world!" } as never },
       { type: "agent_end", messages: [] },
@@ -41,7 +41,7 @@ describe("runAgentLoop", () => {
   });
 
   it("stores assistant message on agent_end", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Reply" } as never },
       { type: "agent_end", messages: [] },
     ]);
@@ -65,7 +65,7 @@ describe("runAgentLoop", () => {
   });
 
   it("does not store assistant message when responseText is empty", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "agent_end", messages: [] },
     ]);
     const sessionStore = createMockSessionStore();
@@ -82,7 +82,7 @@ describe("runAgentLoop", () => {
   });
 
   it("captures error message on agent_end with error stopReason", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "agent_end", messages: [{ role: "assistant", content: [], stopReason: "error", errorMessage: "API key invalid", timestamp: Date.now() } as never] },
     ]);
     const log = createMockLogger();
@@ -100,7 +100,7 @@ describe("runAgentLoop", () => {
   });
 
   it("defaults errorMessage to 'Unknown agent error'", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "agent_end", messages: [{ role: "assistant", content: [], stopReason: "error", timestamp: Date.now() } as never] },
     ]);
 
@@ -116,7 +116,7 @@ describe("runAgentLoop", () => {
   });
 
   it("calls onTextDelta with accumulated text", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "a" } as never },
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "b" } as never },
       { type: "agent_end", messages: [] },
@@ -136,7 +136,7 @@ describe("runAgentLoop", () => {
   });
 
   it("calls onToolComplete after turn_end and injects via steer", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -162,7 +162,7 @@ describe("runAgentLoop", () => {
   });
 
   it("does not call steer if onToolComplete returns null", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -183,7 +183,7 @@ describe("runAgentLoop", () => {
   });
 
   it("does not call onToolComplete if not provided", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -202,7 +202,7 @@ describe("runAgentLoop", () => {
   });
 
   it("persists tool_call blocks on the assistant message and tool_result as its own message", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Let me check." } as never },
       { type: "tool_execution_start", toolCallId: "call-1", toolName: "shell", args: { cmd: "ls" } },
       { type: "tool_execution_end", toolCallId: "call-1", result: "a.txt\nb.txt" },
@@ -245,7 +245,7 @@ describe("runAgentLoop", () => {
 
   it("truncates oversized tool_result output when persisting", async () => {
     const big = "x".repeat(30_000);
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "tool_execution_start", toolCallId: "c", toolName: "read_file", args: {} },
       { type: "tool_execution_end", toolCallId: "c", result: big },
       { type: "turn_end" },
@@ -271,7 +271,7 @@ describe("runAgentLoop", () => {
   });
 
   it("propagates isError on tool_result blocks", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "tool_execution_start", toolCallId: "c", toolName: "shell", args: {} },
       { type: "tool_execution_end", toolCallId: "c", result: "boom", isError: true },
       { type: "turn_end" },
@@ -294,7 +294,7 @@ describe("runAgentLoop", () => {
   });
 
   it("flushes accumulated tool_calls at agent_end when turn_end is missing", async () => {
-    const agent = createMockPiMonoInstance([
+    const agent = createMockAgentInstance([
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "partial" } as never },
       { type: "tool_execution_start", toolCallId: "c", toolName: "t", args: {} },
       { type: "agent_end", messages: [] },

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -146,7 +146,7 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
       }
 
       if (hooks && agentId) {
-        await hooks.emit("agent_end", { agentId, stopReason: event.stopReason });
+        await hooks.emit("agent_end", { agentId, stopReason });
       }
     }
   }

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -80,35 +80,40 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
   };
 
   for await (const event of agent.prompt(input)) {
-    if (event.type === "text_delta") {
-      responseText += event.text;
-      turnText += event.text;
-      if (onTextDelta) {
-        await onTextDelta(responseText);
+    if (event.type === "message_update") {
+      const ame = event.assistantMessageEvent;
+      if (ame.type === "text_delta") {
+        responseText += ame.delta;
+        turnText += ame.delta;
+        if (onTextDelta) {
+          await onTextDelta(responseText);
+        }
       }
-    } else if (event.type === "tool_call") {
-      log.debug(`Tool call: ${event.name}`, { id: event.id });
-      toolNameById.set(event.id, event.name);
+    } else if (event.type === "tool_execution_start") {
+      log.debug(`Tool call: ${event.toolName}`, { id: event.toolCallId });
+      toolNameById.set(event.toolCallId, event.toolName);
       turnToolCalls.push({
         type: "toolCall",
-        id: event.id,
-        name: event.name,
+        id: event.toolCallId,
+        name: event.toolName,
         input: event.args,
       });
-    } else if (event.type === "tool_result") {
-      log.debug(`Tool result: ${event.id}`);
-      const toolName = toolNameById.get(event.id) ?? "unknown";
+    } else if (event.type === "tool_execution_end") {
+      log.debug(`Tool result: ${event.toolCallId}`);
+      const toolName = toolNameById.get(event.toolCallId) ?? "unknown";
+      const output = typeof event.result === "string" ? event.result : JSON.stringify(event.result);
       turnToolResults.push(
         toolResultMessage(
-          truncateToolResult(event.output),
-          event.id,
+          truncateToolResult(output),
+          event.toolCallId,
           toolName,
           { isError: event.isError },
         ),
       );
     } else if (event.type === "turn_end") {
-      if (usageTracker && event.usage) {
-        usageTracker.record(sessionId, event.usage);
+      const msg = event.message;
+      if (usageTracker && msg && "usage" in msg) {
+        usageTracker.record(sessionId, (msg as unknown as { usage: unknown }).usage as Parameters<typeof usageTracker.record>[1]);
       }
 
       await flushTurn();
@@ -131,8 +136,11 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
         });
       }
 
-      if (event.stopReason === "error") {
-        const msg = event.errorMessage ?? "Unknown agent error";
+      const lastAssistant = [...event.messages].reverse().find((m) => m.role === "assistant");
+      const stopReason = (lastAssistant as unknown as { stopReason?: string })?.stopReason;
+      const errMsg = (lastAssistant as unknown as { errorMessage?: string })?.errorMessage;
+      if (stopReason === "error") {
+        const msg = errMsg ?? "Unknown agent error";
         log.error(`Agent ended with error: ${msg}`);
         errorMessage = msg;
       }

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -1,7 +1,8 @@
 // src/core/agent-runner.ts — Shared agent event loop
 
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { AgentInstance, SessionStore } from "./types.js";
+import type {  SessionStore } from "./types.js";
+import type { PiMonoInstance } from "./pi-mono.js";
 import { userMessage, assistantMessage, toolResultMessage } from "./messages.js";
 import type { Logger } from "./logger.js";
 import type { UsageTracker } from "./usage-tracker.js";
@@ -23,7 +24,7 @@ export interface AgentRunResult {
 export type OnTextDelta = (currentText: string) => void | Promise<void>;
 
 export interface RunAgentOptions {
-  agent: AgentInstance;
+  agent: PiMonoInstance;
   input: string | AgentMessage[];
   sessionId: string;
   sessionStore: SessionStore;

--- a/src/core/compaction.ts
+++ b/src/core/compaction.ts
@@ -68,10 +68,10 @@ export function resolveCompactionConfig(
 function toSdkSettings(config: CompactionConfig): SdkCompactionSettings {
   const contextWindow = config.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
   const threshold = config.threshold ?? DEFAULT_THRESHOLDS[config.mode];
-  const reserveTokens = Math.floor(contextWindow * (1 - threshold));
+  const fromThreshold = Math.floor(contextWindow * (1 - threshold));
   return {
     enabled: config.mode !== "off",
-    reserveTokens: Math.max(reserveTokens, DEFAULT_RESERVE_TOKENS),
+    reserveTokens: config.reserveTokens ?? Math.max(fromThreshold, DEFAULT_RESERVE_TOKENS),
     keepRecentTokens: DEFAULT_KEEP_RECENT_TOKENS,
   } satisfies SdkCompactionSettings;
 }

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -382,7 +382,7 @@ describe("prompt() event mapping", () => {
     const events = await collectEvents([
       { type: "turn_end", message: {}, toolResults: [] },
     ]);
-    expect(events).toContainEqual({ type: "turn_end" });
+    expect(events).toContainEqual(expect.objectContaining({ type: "turn_end" }));
   });
 
   it("maps message_update with text_delta", async () => {
@@ -405,12 +405,12 @@ describe("prompt() event mapping", () => {
         args: { path: "/foo" },
       },
     ]);
-    expect(events).toContainEqual({
-      type: "tool_call",
-      id: "tc-1",
-      name: "readFile",
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "tool_execution_start",
+      toolCallId: "tc-1",
+      toolName: "readFile",
       args: { path: "/foo" },
-    });
+    }));
   });
 
   it("maps tool_execution_end to tool_result", async () => {
@@ -423,12 +423,10 @@ describe("prompt() event mapping", () => {
         isError: false,
       },
     ]);
-    expect(events).toContainEqual({
-      type: "tool_result",
-      id: "tc-2",
-      output: "file contents",
-      isError: false,
-    });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "tool_execution_end",
+      toolCallId: "tc-2",
+    }));
   });
 
   it("maps agent_end with converted messages", async () => {
@@ -484,13 +482,14 @@ describe("prompt() event mapping", () => {
     expect(msgField(agentEnd.messages[0], "errorMessage")).toBe("No API provider registered for api: undefined");
   });
 
-  it("skips unknown event types", async () => {
+  it("passes through all SDK event types without filtering", async () => {
     const events = await collectEvents([
       { type: "agent_start" },
-      { type: "message_start", message: {} },
-      { type: "unknown_future_event" },
+      { type: "turn_start" },
     ]);
-    expect(events).toHaveLength(0);
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("agent_start");
+    expect(events[1].type).toBe("turn_start");
   });
 
   it("handles multiple events in sequence", async () => {
@@ -507,7 +506,7 @@ describe("prompt() event mapping", () => {
     expect(events).toHaveLength(3);
     expect(events.map((e) => e.type)).toEqual([
       "turn_start",
-      "text_delta",
+      "message_update",
       "turn_end",
     ]);
   });

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -478,8 +478,8 @@ describe("prompt() event mapping", () => {
     ]);
 
     const agentEnd = events[0] as Extract<AgentEvent, { type: "agent_end" }>;
-    expect(agentEnd.stopReason).toBe("error");
-    expect(agentEnd.errorMessage).toBe("No API provider registered for api: undefined");
+    expect(msgField(agentEnd.messages[agentEnd.messages.length-1], "stopReason")).toBe("error");
+    expect(msgField(agentEnd.messages[agentEnd.messages.length-1], "errorMessage")).toBe("No API provider registered for api: undefined");
     expect(msgField(agentEnd.messages[0], "stopReason")).toBe("error");
     expect(msgField(agentEnd.messages[0], "errorMessage")).toBe("No API provider registered for api: undefined");
   });

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -393,7 +393,7 @@ describe("prompt() event mapping", () => {
         assistantMessageEvent: { type: "text_delta", delta: "hello world" },
       },
     ]);
-    expect(events).toContainEqual({ type: "text_delta", text: "hello world" });
+    expect(events).toContainEqual({ type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "hello world" } as never });
   });
 
   it("maps tool_execution_start to tool_call", async () => {

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -1,16 +1,11 @@
-// src/core/pi-mono.ts — Thin wrapper around @mariozechner/pi-agent-core Agent
-// Implements the AgentCore / AgentInstance interfaces from types.ts.
+// src/core/pi-mono.ts — Wrapper around @mariozechner/pi-agent-core Agent
 
-import { Agent, type AgentEvent as CoreEvent, type AgentMessage, type AgentTool } from "@mariozechner/pi-agent-core";
+import { Agent, type AgentEvent, type AgentMessage, type AgentTool } from "@mariozechner/pi-agent-core";
 import { getModel, type Model, type Api } from "@mariozechner/pi-ai";
 
 import {
   type AgentConfig,
-  type AgentCore,
-  type AgentEvent,
-  type AgentInstance,
   type Tool,
-  type Usage,
 } from "./types.js";
 import type { ToolRegistry } from "./tools.js";
 import {
@@ -99,18 +94,6 @@ function resolveModel(config: AgentConfig): Model<Api> {
   return model;
 }
 
-function getAgentEndMetadata(messages: AgentMessage[]): {
-  stopReason?: string;
-  errorMessage?: string;
-} {
-  const last = [...messages].reverse().find((m) => m.role === "assistant");
-  if (!last) return {};
-  const m = last as unknown as { stopReason?: string; errorMessage?: string };
-  return {
-    stopReason: typeof m.stopReason === "string" ? m.stopReason : undefined,
-    errorMessage: typeof m.errorMessage === "string" ? m.errorMessage : undefined,
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Orphaned toolResult stripping (#146)
@@ -193,7 +176,7 @@ interface CompactionContext {
  * {@link AgentInstance}s that stream {@link AgentEvent}s. Supports
  * context compaction, tool registries, and configurable LLM providers.
  */
-export class PiMonoCore implements AgentCore {
+export class PiMonoCore {
   private toolRegistries = new Map<string, ToolRegistry>();
 
   /**
@@ -211,7 +194,7 @@ export class PiMonoCore implements AgentCore {
     this.toolRegistries.delete(agentId);
   }
 
-  createAgent(config: AgentConfig): AgentInstance {
+  createAgent(config: AgentConfig): PiMonoInstance {
     const model = resolveModel(config);
 
     // Convert registered tools to AgentTools
@@ -282,7 +265,7 @@ export class PiMonoCore implements AgentCore {
 /** Maximum number of overflow recovery attempts */
 const MAX_OVERFLOW_RETRIES = 2;
 
-class PiMonoInstance implements AgentInstance {
+export class PiMonoInstance {
   private promptQueue: Promise<void> = Promise.resolve();
 
   constructor(
@@ -291,7 +274,7 @@ class PiMonoInstance implements AgentInstance {
   ) {
     // Debug payload logger — logs LLM request context on each turn
     if (process.env.LOG_LEVEL === "debug" || process.env.DEBUG) {
-      this.agent.subscribe((e: CoreEvent) => {
+      this.agent.subscribe((e: AgentEvent) => {
         if (e.type === "agent_start") {
           this.logDebugPayload();
         }
@@ -361,19 +344,18 @@ class PiMonoInstance implements AgentInstance {
     input: string | AgentMessage[],
     retryCount = 0,
   ): AsyncIterable<AgentEvent> {
-    const events: (CoreEvent | null)[] = [];
+    const events: (AgentEvent | null)[] = [];
     let resolve: (() => void) | null = null;
     let overflowDetected = false;
     let overflowErrorMessage: string | undefined;
 
-    const unsub = this.agent.subscribe((e: CoreEvent) => {
-      // Check for overflow in agent_end events
+    const unsub = this.agent.subscribe((e: AgentEvent) => {
       if (e.type === "agent_end") {
-        const messages = e.messages;
-        const { errorMessage } = getAgentEndMetadata(messages);
-        if (errorMessage && isContextOverflow(errorMessage)) {
+        const last = [...e.messages].reverse().find((m) => m.role === "assistant");
+        const err = (last as unknown as { errorMessage?: string })?.errorMessage;
+        if (err && isContextOverflow(err)) {
           overflowDetected = true;
-          overflowErrorMessage = errorMessage;
+          overflowErrorMessage = err;
         }
       }
       events.push(e);
@@ -419,10 +401,7 @@ class PiMonoInstance implements AgentInstance {
             finished = true;
             break;
           }
-          const mapped = mapEvent(ev);
-          if (mapped) {
-            collectedEvents.push(mapped);
-          }
+          collectedEvents.push(ev);
         }
       }
 
@@ -563,71 +542,3 @@ class PiMonoInstance implements AgentInstance {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Event mapping: pi-agent-core AgentEvent → our AgentEvent
-// ---------------------------------------------------------------------------
-
-function mapEvent(e: CoreEvent): AgentEvent | null {
-  switch (e.type) {
-    case "turn_start":
-      return { type: "turn_start" };
-
-    case "turn_end": {
-      const msg = e.message;
-      if (msg && "role" in msg && msg.role === "assistant" && "usage" in msg) {
-        return { type: "turn_end", usage: msg.usage as Usage };
-      }
-      return { type: "turn_end" };
-    }
-
-    case "message_update": {
-      // Extract text deltas from the assistant message event
-      const ame = e.assistantMessageEvent;
-      if (ame.type === "text_delta") {
-        return { type: "text_delta", text: ame.delta };
-      }
-      // Other sub-events (thinking, toolcall deltas) — skip for now
-      return null;
-    }
-
-    case "tool_execution_start":
-      return {
-        type: "tool_call",
-        id: e.toolCallId,
-        name: e.toolName,
-        args: e.args,
-      };
-
-    case "tool_execution_end":
-      return {
-        type: "tool_result",
-        id: e.toolCallId,
-        output:
-          typeof e.result === "string"
-            ? e.result
-            : JSON.stringify(e.result),
-        isError: e.isError,
-      };
-
-    case "agent_end": {
-      const messages = e.messages;
-      const { stopReason, errorMessage } = getAgentEndMetadata(messages);
-      return {
-        type: "agent_end",
-        messages,
-        stopReason,
-        errorMessage,
-      };
-    }
-
-    // Events we intentionally skip
-    case "agent_start":
-    case "message_start":
-    case "message_end":
-    case "tool_execution_update":
-      return null;
-
-    default:
-      return null;
-  }
-}

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -452,6 +452,7 @@ export class PiMonoInstance {
           );
 
           // Replace agent messages with sanitized compacted version
+          // pi-agent-core 0.66: state.messages setter copies the array (replaceMessages was removed)
           this.agent.state.messages = sanitized;
 
           // Retry the prompt with compacted context
@@ -533,6 +534,7 @@ export class PiMonoInstance {
         compactedMessages,
       );
 
+      // pi-agent-core 0.66: state.messages setter copies the array
       this.agent.state.messages = sanitized;
       return true;
     } catch (err) {

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -178,8 +178,8 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
         if (!agent) throw new Error(`Agent "${agentId}" not found`);
         let responseText = "";
         for await (const event of agent.prompt(prompt)) {
-          if (event.type === "text_delta") {
-            responseText += event.text;
+          if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+            responseText += event.assistantMessageEvent.delta;
           }
         }
         return responseText;
@@ -246,8 +246,8 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     try {
       let responseText = "";
       for await (const event of agent.prompt(prompt)) {
-        if (event.type === "text_delta") {
-          responseText += event.text;
+        if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+          responseText += event.assistantMessageEvent.delta;
         }
       }
       log.info(`Cron "${job.name}" completed (${responseText.length} chars)`);

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -3,7 +3,9 @@
 // and SessionStore mocks. Centralise them here.
 
 import { vi } from "vitest";
-import type {  AgentManager, SessionStore, AgentEvent } from "./types.js";
+import type {  SessionStore, AgentEvent } from "./types.js";
+import type { PiMonoInstance } from "./pi-mono.js";
+import type { DefaultAgentManager } from "./agent-manager.js";
 
 /**
  * Create a mock PiMonoInstance whose prompt() yields the given events.

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -3,20 +3,15 @@
 // and SessionStore mocks. Centralise them here.
 
 import { vi } from "vitest";
-import type {  SessionStore, AgentEvent } from "./types.js";
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import type { SessionStore } from "./types.js";
 import type { PiMonoInstance } from "./pi-mono.js";
 import type { DefaultAgentManager } from "./agent-manager.js";
 
-/**
- * Create a mock PiMonoInstance whose prompt() yields the given events.
- *
- * If no events are provided, yields two text_delta events ("Hello ", "world!")
- * followed by an agent_end event.
- */
-export function createMockPiMonoInstance(events?: AgentEvent[]): PiMonoInstance {
+export function createMockAgentInstance(events?: AgentEvent[]): PiMonoInstance {
   const defaultEvents: AgentEvent[] = [
-    { type: "text_delta", text: "Hello " },
-    { type: "text_delta", text: "world!" },
+    { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Hello " } as never },
+    { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "world!" } as never },
     { type: "agent_end", messages: [] },
   ];
 
@@ -31,18 +26,11 @@ export function createMockPiMonoInstance(events?: AgentEvent[]): PiMonoInstance 
     abort: vi.fn(),
     steer: vi.fn(),
     followUp: vi.fn(),
-  };
+  } as unknown as PiMonoInstance;
 }
 
-/**
- * Create a mock AgentManager that returns a single shared PiMonoInstance
- * from get().
- *
- * @param instance — optional pre-built mock instance; defaults to
- *   createMockPiMonoInstance() with the standard text_delta sequence.
- */
-export function createMockAgentManager(instance?: PiMonoInstance): AgentManager {
-  const mockInstance = instance ?? createMockPiMonoInstance();
+export function createMockAgentManager(instance?: PiMonoInstance): DefaultAgentManager {
+  const mockInstance = instance ?? createMockAgentInstance();
 
   return {
     create: vi.fn(),
@@ -53,7 +41,7 @@ export function createMockAgentManager(instance?: PiMonoInstance): AgentManager 
     getPrompt: vi.fn(),
     updatePrompt: vi.fn(),
     reloadWorkspace: vi.fn(),
-  };
+  } as unknown as DefaultAgentManager;
 }
 
 /**

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -3,15 +3,15 @@
 // and SessionStore mocks. Centralise them here.
 
 import { vi } from "vitest";
-import type { AgentInstance, AgentManager, SessionStore, AgentEvent } from "./types.js";
+import type {  AgentManager, SessionStore, AgentEvent } from "./types.js";
 
 /**
- * Create a mock AgentInstance whose prompt() yields the given events.
+ * Create a mock PiMonoInstance whose prompt() yields the given events.
  *
  * If no events are provided, yields two text_delta events ("Hello ", "world!")
  * followed by an agent_end event.
  */
-export function createMockAgentInstance(events?: AgentEvent[]): AgentInstance {
+export function createMockPiMonoInstance(events?: AgentEvent[]): PiMonoInstance {
   const defaultEvents: AgentEvent[] = [
     { type: "text_delta", text: "Hello " },
     { type: "text_delta", text: "world!" },
@@ -33,14 +33,14 @@ export function createMockAgentInstance(events?: AgentEvent[]): AgentInstance {
 }
 
 /**
- * Create a mock AgentManager that returns a single shared AgentInstance
+ * Create a mock AgentManager that returns a single shared PiMonoInstance
  * from get().
  *
  * @param instance — optional pre-built mock instance; defaults to
- *   createMockAgentInstance() with the standard text_delta sequence.
+ *   createMockPiMonoInstance() with the standard text_delta sequence.
  */
-export function createMockAgentManager(instance?: AgentInstance): AgentManager {
-  const mockInstance = instance ?? createMockAgentInstance();
+export function createMockAgentManager(instance?: PiMonoInstance): AgentManager {
+  const mockInstance = instance ?? createMockPiMonoInstance();
 
   return {
     create: vi.fn(),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -283,14 +283,12 @@ export type CompactionMode = 'off' | 'safeguard' | 'aggressive';
 
 /** Configuration for context compaction */
 export interface CompactionConfig {
-  /** Compaction mode. Default: 'safeguard' */
   mode: CompactionMode;
-  /** Maximum context window size in tokens. Default: 128000 */
   contextWindow?: number;
-  /** Threshold ratio (0–1) at which compaction triggers. Default: 0.8 for safeguard, 0.5 for aggressive */
   threshold?: number;
-  /** Number of recent messages to preserve (not summarized). Default: 10 */
   preserveRecent?: number;
+  /** Absolute token reserve before compaction triggers. Overrides threshold if set. */
+  reserveTokens?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,7 @@
 // src/core/types.ts — Core interfaces for the Isotopes agent framework
 
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
 import type { SandboxConfig } from "../sandbox/config.js";
 import type { ReplyToMode } from "../transports/reply-directive.js";
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,82 +1,36 @@
 // src/core/types.ts — Core interfaces for the Isotopes agent framework
 
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SandboxConfig } from "../sandbox/config.js";
 import type { ReplyToMode } from "../transports/reply-directive.js";
 
 // ---------------------------------------------------------------------------
-// Messages — re-export AgentMessage as the canonical message type
+// Re-exports from SDK
 // ---------------------------------------------------------------------------
 
-export type { AgentMessage } from "@mariozechner/pi-agent-core";
+export type { AgentMessage, AgentEvent } from "@mariozechner/pi-agent-core";
+export type { Usage } from "@mariozechner/pi-ai";
 
 // ---------------------------------------------------------------------------
 // Tools
 // ---------------------------------------------------------------------------
 
-/** Schema definition for a tool exposed to an agent. */
 export interface Tool {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
 }
 
-/** File system access policy for agent tools. */
 export interface FileToolPolicy {
   workspaceOnly?: boolean;
 }
 
-/** Per-agent tool policy (CLI access, file system restrictions, per-tool allow/deny). */
 export interface AgentToolSettings {
-  /** Enable web_search and web_fetch tools */
   web?: boolean;
   cli?: boolean;
   fs?: FileToolPolicy;
-  /** Tool names to explicitly allow (if set, only these are available) */
   allow?: string[];
-  /** Tool names to explicitly deny (takes precedence over allow) */
   deny?: string[];
 }
-
-// ---------------------------------------------------------------------------
-// Usage — token consumption and cost tracking
-// ---------------------------------------------------------------------------
-
-/** Token usage and cost breakdown for a single LLM turn. */
-export interface Usage {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  totalTokens: number;
-  cost: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheWrite: number;
-    total: number;
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Events (streamed from AgentInstance.prompt)
-// ---------------------------------------------------------------------------
-
-/**
- * Discriminated union of events streamed from {@link AgentInstance.prompt}.
- *
- * Lifecycle events bracket turns (`turn_start` / `turn_end`) and the overall
- * agent run (`agent_end`). Content events carry text deltas, tool calls, and
- * tool results as they happen.
- */
-export type AgentEvent =
-  | { type: 'turn_start' }
-  | { type: 'text_delta'; text: string }
-  | { type: 'tool_call'; id: string; name: string; args: unknown }
-  | { type: 'tool_result'; id: string; output: string; isError?: boolean }
-  | { type: 'turn_end'; usage?: Usage }
-  | { type: 'agent_end'; messages: AgentMessage[]; stopReason?: string; errorMessage?: string }
-  | { type: 'error'; error: Error };
 
 // ---------------------------------------------------------------------------
 // Provider config
@@ -117,47 +71,6 @@ export interface AgentConfig {
    * - 'auto': Agent chooses based on task complexity (default)
    */
   codingMode?: "subagent" | "direct" | "auto";
-}
-
-/**
- * A running agent instance that can be prompted and yields streaming events.
- *
- * Created by {@link AgentCore.createAgent} and managed by {@link AgentManager}.
- */
-export interface AgentInstance {
-  prompt(input: string | AgentMessage[]): AsyncIterable<AgentEvent>;
-  abort(): void;
-  steer(msg: AgentMessage): void;
-  followUp(msg: AgentMessage): void;
-  forceCompact?(): Promise<boolean>;
-  clearMessages?(): void;
-  getMessages?(): AgentMessage[];
-}
-
-// ---------------------------------------------------------------------------
-// Agent core — pluggable backend
-// ---------------------------------------------------------------------------
-
-/** Pluggable backend that creates {@link AgentInstance}s from configuration. */
-export interface AgentCore {
-  createAgent(config: AgentConfig): AgentInstance;
-}
-
-// ---------------------------------------------------------------------------
-// Agent manager
-// ---------------------------------------------------------------------------
-
-/** Registry for creating, retrieving, updating, and deleting agents. */
-export interface AgentManager {
-  create(config: AgentConfig): Promise<AgentInstance>;
-  get(id: string): AgentInstance | undefined;
-  list(): AgentConfig[];
-  update(id: string, updates: Partial<AgentConfig>): Promise<AgentInstance>;
-  delete(id: string): Promise<void>;
-  getPrompt(id: string): Promise<string>;
-  updatePrompt(id: string, prompt: string): Promise<void>;
-  /** Reload workspace context for an agent (hot-reload support) */
-  reloadWorkspace(id: string): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -3,7 +3,8 @@
 
 import type { Logger } from "../core/logger.js";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { Transport, AgentManager } from "../core/types.js";
+import type { Transport } from "../core/types.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
 import type { SessionStoreManager } from "../core/session-store-manager.js";
 import type { IsotopesConfigFile } from "../core/config.js";
 
@@ -76,7 +77,7 @@ export interface UIPluginConfig {
 export type TransportFactory = (ctx: TransportFactoryContext) => Transport | Promise<Transport>;
 
 export interface TransportFactoryContext {
-  agentManager: AgentManager;
+  agentManager: DefaultAgentManager;
   sessionStoreManager: SessionStoreManager;
   config: IsotopesConfigFile;
 }

--- a/src/subagent/backend.ts
+++ b/src/subagent/backend.ts
@@ -16,7 +16,7 @@ import {
 import type { SubagentClaudeConfigFile, SubagentPermissionMode } from "../core/config.js";
 import type { SubagentRunner } from "./runner.js";
 import { ClaudeRunner } from "./runners/claude.js";
-import { BuiltinRunner, type PiMonoCore } from "../core/pi-mono.js";
+import { BuiltinRunner, type BuiltinPiMonoCore } from "./runners/builtin.js";
 
 const log = createLogger("subagent:backend");
 
@@ -49,7 +49,7 @@ export interface SubagentBackendOptions {
    * BuiltinRunner is registered for the "builtin" agent. When omitted,
    * spawning a "builtin" agent throws.
    */
-  core?: PiMonoCore;
+  core?: BuiltinPiMonoCore;
   /**
    * Pre-built runners. When provided, replaces the runners that would have
    * been built from the other options. Primarily a hook for tests.

--- a/src/subagent/backend.ts
+++ b/src/subagent/backend.ts
@@ -16,7 +16,7 @@ import {
 import type { SubagentClaudeConfigFile, SubagentPermissionMode } from "../core/config.js";
 import type { SubagentRunner } from "./runner.js";
 import { ClaudeRunner } from "./runners/claude.js";
-import { BuiltinRunner, type BuiltinAgentCore } from "./runners/builtin.js";
+import { BuiltinRunner, type PiMonoCore } from "../core/pi-mono.js";
 
 const log = createLogger("subagent:backend");
 
@@ -49,7 +49,7 @@ export interface SubagentBackendOptions {
    * BuiltinRunner is registered for the "builtin" agent. When omitted,
    * spawning a "builtin" agent throws.
    */
-  core?: BuiltinAgentCore;
+  core?: PiMonoCore;
   /**
    * Pre-built runners. When provided, replaces the runners that would have
    * been built from the other options. Primarily a hook for tests.

--- a/src/subagent/builtin/event-bridge.test.ts
+++ b/src/subagent/builtin/event-bridge.test.ts
@@ -21,7 +21,7 @@ describe("bridgeAgentEvents", () => {
       { type: "turn_start" },
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Hello, " } as never },
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "world." } as never },
-      { type: "turn_end" },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     expect(out).toEqual([
@@ -34,7 +34,7 @@ describe("bridgeAgentEvents", () => {
     const out = await collect([
       { type: "turn_start" },
       { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "   " } as never },
-      { type: "turn_end" },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     expect(out).toEqual([{ type: "done", exitCode: 0 }]);
@@ -50,8 +50,8 @@ describe("bridgeAgentEvents", () => {
 
   it("translates tool_result and surfaces error flag", async () => {
     const out = await collect([
-      { type: "tool_execution_end", toolCallId: "1", result: "ok" },
-      { type: "tool_execution_end", toolCallId: "2", result: "boom", isError: true },
+      { type: "tool_execution_end", toolCallId: "1", toolName: "test", args: {}, result: "ok", isError: false },
+      { type: "tool_execution_end", toolCallId: "2", toolName: "test", args: {}, result: "boom", isError: false, isError: true },
       { type: "agent_end", messages: [] },
     ]);
     expect(out[0]).toEqual({ type: "tool_result", toolResult: "ok" });
@@ -60,7 +60,7 @@ describe("bridgeAgentEvents", () => {
 
   it("emits error+done(1) when agent_end carries errorMessage", async () => {
     const out = await collect([
-      { type: "agent_end", messages: [], errorMessage: "boom" },
+      { type: "agent_end", messages: [{ role: "assistant", errorMessage: "boom", content: [], timestamp: Date.now() } as never] },
     ]);
     expect(out).toEqual([
       { type: "error", error: "boom" },

--- a/src/subagent/builtin/event-bridge.test.ts
+++ b/src/subagent/builtin/event-bridge.test.ts
@@ -1,7 +1,7 @@
 // src/subagent/builtin/event-bridge.test.ts — Tests for AgentEvent → SubagentEvent bridge
 
 import { describe, it, expect } from "vitest";
-import type { AgentEvent } from "../../core/types.js";
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { SubagentEvent } from "../types.js";
 import { bridgeAgentEvents } from "./event-bridge.js";
 
@@ -50,8 +50,8 @@ describe("bridgeAgentEvents", () => {
 
   it("translates tool_result and surfaces error flag", async () => {
     const out = await collect([
-      { type: "tool_execution_end", toolCallId: "1", toolName: "test", args: {}, result: "ok", isError: false },
-      { type: "tool_execution_end", toolCallId: "2", toolName: "test", args: {}, result: "boom", isError: false, isError: true },
+      { type: "tool_execution_end", toolCallId: "1", toolName: "test", result: "ok", isError: false },
+      { type: "tool_execution_end", toolCallId: "2", toolName: "test", result: "boom", isError: true },
       { type: "agent_end", messages: [] },
     ]);
     expect(out[0]).toEqual({ type: "tool_result", toolResult: "ok" });
@@ -68,9 +68,9 @@ describe("bridgeAgentEvents", () => {
     ]);
   });
 
-  it("emits error+done(1) for an error event", async () => {
+  it("emits error+done(1) when agent_end has errorMessage", async () => {
     const out = await collect([
-      { type: "error", error: new Error("kaboom") },
+      { type: "agent_end", messages: [{ role: "assistant", errorMessage: "kaboom", content: [], timestamp: 0 } as never] },
     ]);
     expect(out).toEqual([
       { type: "error", error: "kaboom" },

--- a/src/subagent/builtin/event-bridge.test.ts
+++ b/src/subagent/builtin/event-bridge.test.ts
@@ -19,8 +19,8 @@ describe("bridgeAgentEvents", () => {
   it("buffers text_delta and emits a single message at turn_end", async () => {
     const out = await collect([
       { type: "turn_start" },
-      { type: "text_delta", text: "Hello, " },
-      { type: "text_delta", text: "world." },
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Hello, " } as never },
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "world." } as never },
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -33,7 +33,7 @@ describe("bridgeAgentEvents", () => {
   it("skips empty messages", async () => {
     const out = await collect([
       { type: "turn_start" },
-      { type: "text_delta", text: "   " },
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "   " } as never },
       { type: "turn_end" },
       { type: "agent_end", messages: [] },
     ]);
@@ -42,7 +42,7 @@ describe("bridgeAgentEvents", () => {
 
   it("translates tool_call → tool_use", async () => {
     const out = await collect([
-      { type: "tool_call", id: "1", name: "shell", args: { cmd: "ls" } },
+      { type: "tool_execution_start", toolCallId: "1", toolName: "shell", args: { cmd: "ls" } },
       { type: "agent_end", messages: [] },
     ]);
     expect(out[0]).toEqual({ type: "tool_use", toolName: "shell", toolInput: { cmd: "ls" } });
@@ -50,8 +50,8 @@ describe("bridgeAgentEvents", () => {
 
   it("translates tool_result and surfaces error flag", async () => {
     const out = await collect([
-      { type: "tool_result", id: "1", output: "ok" },
-      { type: "tool_result", id: "2", output: "boom", isError: true },
+      { type: "tool_execution_end", toolCallId: "1", result: "ok" },
+      { type: "tool_execution_end", toolCallId: "2", result: "boom", isError: true },
       { type: "agent_end", messages: [] },
     ]);
     expect(out[0]).toEqual({ type: "tool_result", toolResult: "ok" });
@@ -81,7 +81,7 @@ describe("bridgeAgentEvents", () => {
   it("flushes trailing text and emits done if stream ends without agent_end", async () => {
     const out = await collect([
       { type: "turn_start" },
-      { type: "text_delta", text: "tail" },
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "tail" } as never },
     ]);
     expect(out).toEqual([
       { type: "message", content: "tail" },

--- a/src/subagent/builtin/event-bridge.ts
+++ b/src/subagent/builtin/event-bridge.ts
@@ -1,19 +1,8 @@
-// src/subagent/builtin/event-bridge.ts — Bridge AgentEvent stream to SubagentEvent stream
-// AgentEvent (pi-mono) is delta-oriented; SubagentEvent is message-oriented. The bridge
-// buffers text deltas across a turn and emits a single "message" event at turn_end.
+// src/subagent/builtin/event-bridge.ts — Bridge SDK AgentEvent stream to SubagentEvent stream
 
-import type { AgentEvent } from "../../core/types.js";
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { SubagentEvent } from "../types.js";
 
-/**
- * Translate a stream of {@link AgentEvent}s from {@link AgentInstance.prompt}
- * into a stream of {@link SubagentEvent}s used by the subagent backend.
- *
- * - text_delta: buffered, flushed as "message" on turn_end (only if non-empty).
- * - tool_call → tool_use; tool_result → tool_result.
- * - agent_end → "done" with exitCode 0 (or 1 if `errorMessage` set).
- * - error → "error" + "done" exitCode 1.
- */
 export async function* bridgeAgentEvents(
   events: AsyncIterable<AgentEvent>,
 ): AsyncGenerator<SubagentEvent, void, void> {
@@ -25,35 +14,43 @@ export async function* bridgeAgentEvents(
       case "turn_start":
         buffer = "";
         break;
-      case "text_delta":
-        buffer += event.text;
+      case "message_update": {
+        const ame = event.assistantMessageEvent;
+        if (ame.type === "text_delta") {
+          buffer += ame.delta;
+        }
         break;
+      }
       case "turn_end": {
         const text = buffer.trim();
         if (text.length > 0) yield { type: "message", content: text };
         buffer = "";
         break;
       }
-      case "tool_call":
+      case "tool_execution_start":
         yield {
           type: "tool_use",
-          toolName: event.name,
+          toolName: event.toolName,
           toolInput: event.args,
         };
         break;
-      case "tool_result":
+      case "tool_execution_end": {
+        const output = typeof event.result === "string" ? event.result : JSON.stringify(event.result);
         yield {
           type: "tool_result",
-          toolResult: event.output,
+          toolResult: output,
           ...(event.isError ? { error: "tool error" } : {}),
         };
         break;
+      }
       case "agent_end": {
         const trailing = buffer.trim();
         if (trailing.length > 0) yield { type: "message", content: trailing };
         buffer = "";
-        if (event.errorMessage) {
-          yield { type: "error", error: event.errorMessage };
+        const lastAssistant = [...event.messages].reverse().find((m) => m.role === "assistant");
+        const errMsg = (lastAssistant as unknown as { errorMessage?: string })?.errorMessage;
+        if (errMsg) {
+          yield { type: "error", error: errMsg };
           yield { type: "done", exitCode: 1 };
         } else {
           yield { type: "done", exitCode: 0 };
@@ -61,11 +58,6 @@ export async function* bridgeAgentEvents(
         endedNormally = true;
         break;
       }
-      case "error":
-        yield { type: "error", error: event.error.message };
-        yield { type: "done", exitCode: 1 };
-        endedNormally = true;
-        break;
     }
   }
 

--- a/src/subagent/runners/builtin.test.ts
+++ b/src/subagent/runners/builtin.test.ts
@@ -4,7 +4,8 @@ import { describe, it, expect } from "vitest";
 import type { AgentConfig, AgentEvent, ProviderConfig } from "../../core/types.js";
 import { ToolRegistry } from "../../core/tools.js";
 import type { SubagentEvent } from "../types.js";
-import { BuiltinRunner, type Builtin } from "./builtin.js";
+import { BuiltinRunner, type BuiltinPiMonoCore } from "./builtin.js";
+import type { PiMonoInstance } from "../../core/pi-mono.js";
 
 function makeRegistry(names: string[]): ToolRegistry {
   const r = new ToolRegistry("test");
@@ -22,7 +23,7 @@ function fakeProvider(): ProviderConfig {
 }
 
 function makeCore(events: AgentEvent[]): {
-  core: Builtin;
+  core: BuiltinPiMonoCore;
   setIds: string[];
   clearedIds: string[];
   capturedConfig: AgentConfig | undefined;
@@ -48,18 +49,18 @@ function makeCore(events: AgentEvent[]): {
     followUp: () => {},
   } as unknown as PiMonoInstance;
 
-  const core: Builtin = {
-    setToolRegistry: (id) => {
+  const core = {
+    setToolRegistry: (id: string) => {
       setIds.push(id);
     },
-    clearToolRegistry: (id) => {
+    clearToolRegistry: (id: string) => {
       clearedIds.push(id);
     },
-    createAgent: (config) => {
+    createAgent: (config: AgentConfig) => {
       capturedConfig = config;
       return instance;
     },
-  };
+  } as unknown as BuiltinPiMonoCore;
 
   return {
     core,
@@ -98,8 +99,8 @@ describe("BuiltinRunner", () => {
   it("registers a filtered tool registry, runs, and clears it", async () => {
     const harness = makeCore([
       { type: "turn_start" },
-      { type: "text_delta", text: "ok" },
-      { type: "turn_end" },
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "ok" } as never },
+      { type: "turn_end", message: {} as never, toolResults: [] },
       { type: "agent_end", messages: [] },
     ]);
     const runner = new BuiltinRunner(harness.core);
@@ -170,11 +171,11 @@ describe("BuiltinRunner", () => {
       steer: () => {},
       followUp: () => {},
     } as unknown as PiMonoInstance;
-    const core: Builtin = {
-      setToolRegistry: (id) => setIds.push(id),
-      clearToolRegistry: (id) => clearedIds.push(id),
+    const core = {
+      setToolRegistry: (id: string) => setIds.push(id),
+      clearToolRegistry: (id: string) => clearedIds.push(id),
       createAgent: () => errInstance,
-    };
+    } as unknown as BuiltinPiMonoCore;
     const runner = new BuiltinRunner(core);
 
     await expect(

--- a/src/subagent/runners/builtin.test.ts
+++ b/src/subagent/runners/builtin.test.ts
@@ -1,10 +1,10 @@
 // src/subagent/runners/builtin.test.ts — Tests for BuiltinRunner
 
 import { describe, it, expect } from "vitest";
-import type { AgentConfig, AgentEvent, AgentInstance, ProviderConfig } from "../../core/types.js";
+import type { AgentConfig, AgentEvent, ProviderConfig } from "../../core/types.js";
 import { ToolRegistry } from "../../core/tools.js";
 import type { SubagentEvent } from "../types.js";
-import { BuiltinRunner, type BuiltinAgentCore } from "./builtin.js";
+import { BuiltinRunner, type Builtin } from "./builtin.js";
 
 function makeRegistry(names: string[]): ToolRegistry {
   const r = new ToolRegistry("test");
@@ -22,7 +22,7 @@ function fakeProvider(): ProviderConfig {
 }
 
 function makeCore(events: AgentEvent[]): {
-  core: BuiltinAgentCore;
+  core: Builtin;
   setIds: string[];
   clearedIds: string[];
   capturedConfig: AgentConfig | undefined;
@@ -33,7 +33,7 @@ function makeCore(events: AgentEvent[]): {
   let capturedConfig: AgentConfig | undefined;
   let abortCalled = 0;
 
-  const instance: AgentInstance = {
+  const instance: PiMonoInstance = {
     async *[Symbol.asyncIterator]() {
       // unused
     },
@@ -46,9 +46,9 @@ function makeCore(events: AgentEvent[]): {
     },
     steer: () => {},
     followUp: () => {},
-  } as unknown as AgentInstance;
+  } as unknown as PiMonoInstance;
 
-  const core: BuiltinAgentCore = {
+  const core: Builtin = {
     setToolRegistry: (id) => {
       setIds.push(id);
     },
@@ -160,7 +160,7 @@ describe("BuiltinRunner", () => {
   it("clears the tool registry even if the agent throws", async () => {
     const setIds: string[] = [];
     const clearedIds: string[] = [];
-    const errInstance: AgentInstance = {
+    const errInstance: PiMonoInstance = {
       prompt: () =>
         (async function* () {
           throw new Error("boom");
@@ -169,8 +169,8 @@ describe("BuiltinRunner", () => {
       abort: () => {},
       steer: () => {},
       followUp: () => {},
-    } as unknown as AgentInstance;
-    const core: BuiltinAgentCore = {
+    } as unknown as PiMonoInstance;
+    const core: Builtin = {
       setToolRegistry: (id) => setIds.push(id),
       clearToolRegistry: (id) => clearedIds.push(id),
       createAgent: () => errInstance,

--- a/src/subagent/runners/builtin.ts
+++ b/src/subagent/runners/builtin.ts
@@ -1,33 +1,35 @@
-// src/subagent/runners/builtin.ts — In-process subagent runner backed by AgentCore
+// src/subagent/runners/builtin.ts — In-process subagent runner backed by PiMonoCore
 // Reuses the parent agent's pi-mono core, provider config, and (filtered) tool
 // registry — no separate API key, no separate SDK process.
 
 import { randomUUID } from "node:crypto";
 import { createLogger } from "../../core/logger.js";
-import type { AgentCore } from "../../core/types.js";
+import type { PiMonoCore } from "../../core/types.js";
+import { PiMonoCore } from "./pi-mono.js";
 import type { ToolRegistry } from "../../core/tools.js";
 import { bridgeAgentEvents } from "../builtin/event-bridge.js";
 import { buildBuiltinSubagentSystemPrompt } from "../builtin/system-prompt.js";
 import { filterToolRegistry, resolveBuiltinToolPolicy } from "../builtin/tool-policy.js";
 import type { RunnerSignals, SubagentRunner } from "../runner.js";
 import type { SubagentAgent, SubagentEvent, SubagentSpawnOptions } from "../types.js";
+import { PiMonoCore } from "./pi-mono.js";
 
 const log = createLogger("subagent:runner:builtin");
 
 /**
- * Narrow shape over {@link AgentCore} that supports per-agent tool registries.
+ * Narrow shape over {@link PiMonoCore} that supports per-agent tool registries.
  * `PiMonoCore` satisfies this interface.
  */
-export interface BuiltinAgentCore extends AgentCore {
+export interface BuiltinPiMonoCore extends PiMonoCore {
   setToolRegistry(agentId: string, registry: ToolRegistry): void;
   clearToolRegistry(agentId: string): void;
 }
 
-/** Runner that runs a subagent in-process via the supplied AgentCore. */
+/** Runner that runs a subagent in-process via the supplied PiMonoCore. */
 export class BuiltinRunner implements SubagentRunner {
   readonly agent: SubagentAgent = "builtin";
 
-  constructor(private readonly core: BuiltinAgentCore) {}
+  constructor(private readonly core: BuiltinPiMonoCore) {}
 
   async *run(
     taskId: string,

--- a/src/subagent/runners/builtin.ts
+++ b/src/subagent/runners/builtin.ts
@@ -5,14 +5,12 @@
 import { randomUUID } from "node:crypto";
 import { createLogger } from "../../core/logger.js";
 import { PiMonoCore } from "../../core/pi-mono.js";
-import { PiMonoCore } from "./pi-mono.js";
 import type { ToolRegistry } from "../../core/tools.js";
 import { bridgeAgentEvents } from "../builtin/event-bridge.js";
 import { buildBuiltinSubagentSystemPrompt } from "../builtin/system-prompt.js";
 import { filterToolRegistry, resolveBuiltinToolPolicy } from "../builtin/tool-policy.js";
 import type { RunnerSignals, SubagentRunner } from "../runner.js";
 import type { SubagentAgent, SubagentEvent, SubagentSpawnOptions } from "../types.js";
-import { PiMonoCore } from "./pi-mono.js";
 
 const log = createLogger("subagent:runner:builtin");
 

--- a/src/subagent/runners/builtin.ts
+++ b/src/subagent/runners/builtin.ts
@@ -4,7 +4,7 @@
 
 import { randomUUID } from "node:crypto";
 import { createLogger } from "../../core/logger.js";
-import type { PiMonoCore } from "../../core/types.js";
+import { PiMonoCore } from "../../core/pi-mono.js";
 import { PiMonoCore } from "./pi-mono.js";
 import type { ToolRegistry } from "../../core/tools.js";
 import { bridgeAgentEvents } from "../builtin/event-bridge.js";

--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -10,7 +10,7 @@ import {
   type SubagentEvent,
 } from "../subagent/index.js";
 import type { BuiltinSubagentOptions } from "../subagent/types.js";
-import type { BuiltinAgentCore } from "../subagent/runners/builtin.js";
+import type { BuiltinPiMonoCore } from "../subagent/runners/builtin.js";
 import { taskRegistry } from "../subagent/task-registry.js";
 import { createSubagentRecorder } from "../subagent/persistence.js";
 import type { SessionStore } from "../core/types.js";
@@ -31,7 +31,7 @@ export interface SubagentBackendConfig {
   /** Claude-specific settings (auth, base URL, executable path) */
   claude?: SubagentClaudeConfigFile;
   /** AgentCore used to host in-process builtin subagents. */
-  core?: BuiltinAgentCore;
+  core?: BuiltinPiMonoCore;
 }
 
 /** Options for spawning a sub-agent */

--- a/src/transports/discord-manager.ts
+++ b/src/transports/discord-manager.ts
@@ -2,7 +2,6 @@
 // Each Discord bot account gets its own transport (Client, token, identity).
 
 import type {
-  AgentManager,
   ChannelsConfig,
   DiscordAccountConfig,
   SessionStore,
@@ -21,7 +20,7 @@ const VALID_REPLY_TO_MODES = new Set<ReplyToMode>(["off", "first", "all"]);
 
 /** Shared infrastructure injected into every Discord account transport. */
 export interface DiscordSharedConfig {
-  agentManager: AgentManager;
+  agentManager: DefaultAgentManager;
   sessionStore: SessionStore;
   sessionStoreForAgent?: (agentId: string) => SessionStore;
   /** Full channels block — passed through for per-guild lookups (e.g. requireMention). */

--- a/src/transports/discord-manager.ts
+++ b/src/transports/discord-manager.ts
@@ -7,6 +7,7 @@ import type {
   DiscordAccountConfig,
   SessionStore,
 } from "../core/types.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
 import { getDiscordToken } from "../core/config.js";
 import { DiscordTransport } from "./discord.js";
 import { ThreadBindingManager } from "../core/thread-bindings.js";

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -2,9 +2,9 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DiscordTransport } from "./discord.js";
-import type { AgentManager, SessionStore, AgentInstance, ChannelsConfig } from "../core/types.js";
+import type { AgentManager, SessionStore, PiMonoInstance, ChannelsConfig } from "../core/types.js";
 import { ThreadBindingManager } from "../core/thread-bindings.js";
-import { createMockAgentManager, createMockAgentInstance, createMockSessionStore } from "../core/test-helpers.js";
+import { createMockAgentManager, createMockPiMonoInstance, createMockSessionStore } from "../core/test-helpers.js";
 
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -130,7 +130,7 @@ describe("DiscordTransport", () => {
 
   describe("runAgentAndRespond", () => {
     it("logs and sends a message when agent_end reports an error", async () => {
-      const erroringAgent = createMockAgentInstance([
+      const erroringAgent = createMockPiMonoInstance([
         {
           type: "agent_end",
           messages: [],
@@ -148,7 +148,7 @@ describe("DiscordTransport", () => {
       await (
         transport as unknown as {
           runAgentAndRespond: (
-            agent: AgentInstance,
+            agent: PiMonoInstance,
             input: string,
             channel: MockChannel,
             sessionId: string,
@@ -1290,7 +1290,7 @@ describe("DiscordTransport", () => {
       const localSessionStore = createMockSessionStore();
 
       // Agent that completes normally
-      const completingAgent = createMockAgentInstance([
+      const completingAgent = createMockPiMonoInstance([
         { type: "text_delta", text: "Done!" },
         { type: "agent_end", messages: [] },
       ]);

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -2,9 +2,9 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DiscordTransport } from "./discord.js";
-import type { AgentManager, SessionStore, PiMonoInstance, ChannelsConfig } from "../core/types.js";
+import type { SessionStore, PiMonoInstance, ChannelsConfig } from "../core/types.js";
 import { ThreadBindingManager } from "../core/thread-bindings.js";
-import { createMockAgentManager, createMockPiMonoInstance, createMockSessionStore } from "../core/test-helpers.js";
+import { createMockcreateMockPiMonoInstance, createMockSessionStore } from "../core/test-helpers.js";
 
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -2,9 +2,11 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DiscordTransport } from "./discord.js";
-import type { SessionStore, PiMonoInstance, ChannelsConfig } from "../core/types.js";
+import type { SessionStore, ChannelsConfig } from "../core/types.js";
+import type { PiMonoInstance } from "../core/pi-mono.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
 import { ThreadBindingManager } from "../core/thread-bindings.js";
-import { createMockcreateMockPiMonoInstance, createMockSessionStore } from "../core/test-helpers.js";
+import { createMockAgentInstance, createMockAgentManager, createMockSessionStore } from "../core/test-helpers.js";
 
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -64,7 +66,7 @@ vi.mock("discord.js", () => {
 
 describe("DiscordTransport", () => {
   let transport: DiscordTransport;
-  let agentManager: AgentManager;
+  let agentManager: DefaultAgentManager;
   let sessionStore: SessionStore;
 
   beforeEach(() => {
@@ -130,14 +132,20 @@ describe("DiscordTransport", () => {
 
   describe("runAgentAndRespond", () => {
     it("logs and sends a message when agent_end reports an error", async () => {
-      const erroringAgent = createMockPiMonoInstance([
+      const erroringAgent = createMockAgentInstance([
         {
           type: "agent_end",
-          messages: [],
-          stopReason: "error",
-          errorMessage: "No API provider registered for api: undefined",
+          messages: [{ role: "assistant", stopReason: "error", errorMessage: "No API provider registered for api: undefined", content: [], timestamp: 0 } as never],
         },
       ]);
+
+
+
+
+
+
+
+
 
       const channel: MockChannel = {
         sendTyping: vi.fn().mockResolvedValue(undefined),
@@ -1057,12 +1065,12 @@ describe("DiscordTransport", () => {
     }
 
     it("responds to thread messages by default (threads.respond undefined)", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1078,12 +1086,12 @@ describe("DiscordTransport", () => {
     });
 
     it("does NOT respond in threads when threads.respond=false", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
         threads: { respond: false },
@@ -1100,12 +1108,12 @@ describe("DiscordTransport", () => {
     });
 
     it("still responds in regular channels when threads.respond=false", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
         threads: { respond: false },
@@ -1122,12 +1130,12 @@ describe("DiscordTransport", () => {
     });
 
     it("ignores thread messages completely when both respond=false and observe=false", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
         threads: { respond: false, observe: false },
@@ -1174,7 +1182,7 @@ describe("DiscordTransport", () => {
     }
 
     it("buffers messages when session is active (in-flight prompt)", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
 
       // Create a promise that we can control to simulate a long-running agent
@@ -1192,12 +1200,12 @@ describe("DiscordTransport", () => {
         steer: vi.fn(),
         followUp: vi.fn(),
       };
-      localAgentManager.get = vi.fn().mockReturnValue(hangingAgent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(hangingAgent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1224,7 +1232,7 @@ describe("DiscordTransport", () => {
     });
 
     it("persists drained pending messages to SessionStore (issue #371)", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
 
       let resolveAgent: () => void;
@@ -1242,12 +1250,12 @@ describe("DiscordTransport", () => {
         steer: vi.fn(),
         followUp: vi.fn(),
       };
-      localAgentManager.get = vi.fn().mockReturnValue(agent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1286,20 +1294,20 @@ describe("DiscordTransport", () => {
     });
 
     it("clears active session and pending buffer after agent completes", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
 
       // Agent that completes normally
-      const completingAgent = createMockPiMonoInstance([
-        { type: "text_delta", text: "Done!" },
+      const completingAgent = createMockAgentInstance([
+        { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Done!" } as never },
         { type: "agent_end", messages: [] },
       ]);
-      localAgentManager.get = vi.fn().mockReturnValue(completingAgent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(completingAgent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1373,15 +1381,15 @@ describe("DiscordTransport", () => {
     }
 
     it("/stop aborts an in-flight main-agent turn and acks with 🛑", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = makeStatefulSessionStore();
       const { agent, release } = makeHangingAgent();
-      localAgentManager.get = vi.fn().mockReturnValue(agent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1404,15 +1412,15 @@ describe("DiscordTransport", () => {
     });
 
     it("/cancel also aborts the in-flight turn", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = makeStatefulSessionStore();
       const { agent, release } = makeHangingAgent();
-      localAgentManager.get = vi.fn().mockReturnValue(agent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1434,7 +1442,7 @@ describe("DiscordTransport", () => {
     });
 
     it("/stop with no active turn does not abort and does not dispatch to model", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const agent = {
         prompt: vi.fn(),
@@ -1442,12 +1450,12 @@ describe("DiscordTransport", () => {
         steer: vi.fn(),
         followUp: vi.fn(),
       };
-      localAgentManager.get = vi.fn().mockReturnValue(agent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1464,15 +1472,15 @@ describe("DiscordTransport", () => {
     });
 
     it("normal messages during an in-flight turn do NOT abort (steer-at-turn_end preserved)", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = createMockSessionStore();
       const { agent, release } = makeHangingAgent();
-      localAgentManager.get = vi.fn().mockReturnValue(agent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1495,15 +1503,15 @@ describe("DiscordTransport", () => {
       await inFlight;
     });
     it("/stop in a group channel without @mention is ignored (multi-bot safety)", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = makeStatefulSessionStore();
       const { agent, release } = makeHangingAgent();
-      localAgentManager.get = vi.fn().mockReturnValue(agent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
       });
@@ -1526,15 +1534,15 @@ describe("DiscordTransport", () => {
     });
 
     it("/stop in a DM (no guild) works without @mention", async () => {
-      const localAgentManager = createMockAgentManager();
+      const localDefaultAgentManager = createMockAgentManager();
       const localSessionStore = makeStatefulSessionStore();
       const { agent, release } = makeHangingAgent();
-      localAgentManager.get = vi.fn().mockReturnValue(agent);
+      localDefaultAgentManager.get = vi.fn().mockReturnValue(agent);
 
       const localTransport = new DiscordTransport({
         groupAccess: { policy: "open" },
         token: "test-token",
-        agentManager: localAgentManager,
+        agentManager: localDefaultAgentManager,
         sessionStore: localSessionStore,
         defaultAgentId: "default",
         dmAccess: { policy: "allowlist", allowlist: ["user-1"] },

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -148,7 +148,7 @@ export class SegmentedStreamBuffer {
 export interface DiscordTransportConfig {
   /** Discord bot token from Developer Portal */
   token: string;
-  agentManager: AgentManager;
+  agentManager: DefaultAgentManager;
   sessionStore: SessionStore;
   sessionStoreForAgent?: (agentId: string) => SessionStore;
   /** Default agent ID to use when no @mention routing */

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -12,14 +12,14 @@ import {
   type ThreadChannel,
 } from "discord.js";
 import {
-  type AgentInstance,
-  type AgentManager,
   type ChannelsConfig,
   type AgentMessage,
   type SessionStore,
   type ThreadBindingConfig,
   type Transport,
 } from "../core/types.js";
+import type { PiMonoInstance } from "../core/pi-mono.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
 import { userMessage as mkUserMsg, assistantMessage as mkAssistantMsg } from "../core/messages.js";
 import type { ContextConfigFile } from "../core/config.js";
 import { shouldRespondToMessage } from "../core/mention.js";
@@ -808,8 +808,7 @@ export class DiscordTransport implements Transport {
   // ---------------------------------------------------------------------------
 
   private async runAgentAndRespond(
-    agent: AgentInstance,
-    input: string | AgentMessage[],
+    agent: PiMonoInstance,    input: string | AgentMessage[],
     channel: SendableChannel,
     sessionId: string,
     sessionStore: SessionStore,

--- a/src/transports/feishu.test.ts
+++ b/src/transports/feishu.test.ts
@@ -11,7 +11,7 @@ import {
   resolveAgentId,
   type FeishuMessageEvent,
 } from "./feishu.js";
-import type { AgentManager, SessionStore, PiMonoInstance, AgentEvent, ChannelsConfig, Binding } from "../core/types.js";
+import type { SessionStore, PiMonoInstance, AgentEvent, ChannelsConfig, Binding } from "../core/types.js";
 import {
   createMockAgentManager,
   createMockPiMonoInstance,

--- a/src/transports/feishu.test.ts
+++ b/src/transports/feishu.test.ts
@@ -11,10 +11,12 @@ import {
   resolveAgentId,
   type FeishuMessageEvent,
 } from "./feishu.js";
-import type { SessionStore, PiMonoInstance, AgentEvent, ChannelsConfig, Binding } from "../core/types.js";
+import type { SessionStore, AgentEvent, ChannelsConfig, Binding } from "../core/types.js";
+import type { PiMonoInstance } from "../core/pi-mono.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
 import {
   createMockAgentManager,
-  createMockPiMonoInstance,
+  createMockAgentInstance,
   createMockSessionStore,
 } from "../core/test-helpers.js";
 
@@ -372,16 +374,16 @@ describe("shouldRespondToGroupMessage", () => {
 
 describe("FeishuTransport", () => {
   let transport: FeishuTransport;
-  let agentManager: AgentManager;
+  let agentManager: DefaultAgentManager;
   let sessionStore: SessionStore;
 
   beforeEach(() => {
     vi.clearAllMocks();
     capturedEventHandler = null;
     agentManager = createMockAgentManager(
-      createMockPiMonoInstance([
-        { type: "text_delta", text: "Hello " },
-        { type: "text_delta", text: "from Feishu!" },
+      createMockAgentInstance([
+        { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "Hello " } as never },
+        { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "from Feishu!" } as never },
         { type: "agent_end", messages: [] },
       ]),
     );
@@ -726,15 +728,15 @@ describe("FeishuTransport", () => {
             async next() {
               throw new Error("Agent crashed");
             },
-          };
+          } as AsyncIterator<AgentEvent>;
         },
       };
-      const errorAgent: PiMonoInstance = {
+      const errorAgent = {
         prompt: vi.fn(() => throwingIterable),
         abort: vi.fn(),
         steer: vi.fn(),
         followUp: vi.fn(),
-      };
+      } as unknown as PiMonoInstance;
       agentManager.get = vi.fn(() => errorAgent);
 
       const event = createDMEvent();
@@ -751,12 +753,10 @@ describe("FeishuTransport", () => {
     });
 
     it("handles agent_end with error stopReason", async () => {
-      const errorAgent = createMockPiMonoInstance([
+      const errorAgent = createMockAgentInstance([
         {
           type: "agent_end",
-          messages: [],
-          stopReason: "error",
-          errorMessage: "API key invalid",
+          messages: [{ role: "assistant", stopReason: "error", errorMessage: "API key invalid", content: [], timestamp: 0 } as never],
         },
       ]);
       agentManager.get = vi.fn(() => errorAgent);

--- a/src/transports/feishu.test.ts
+++ b/src/transports/feishu.test.ts
@@ -11,10 +11,10 @@ import {
   resolveAgentId,
   type FeishuMessageEvent,
 } from "./feishu.js";
-import type { AgentManager, SessionStore, AgentInstance, AgentEvent, ChannelsConfig, Binding } from "../core/types.js";
+import type { AgentManager, SessionStore, PiMonoInstance, AgentEvent, ChannelsConfig, Binding } from "../core/types.js";
 import {
   createMockAgentManager,
-  createMockAgentInstance,
+  createMockPiMonoInstance,
   createMockSessionStore,
 } from "../core/test-helpers.js";
 
@@ -379,7 +379,7 @@ describe("FeishuTransport", () => {
     vi.clearAllMocks();
     capturedEventHandler = null;
     agentManager = createMockAgentManager(
-      createMockAgentInstance([
+      createMockPiMonoInstance([
         { type: "text_delta", text: "Hello " },
         { type: "text_delta", text: "from Feishu!" },
         { type: "agent_end", messages: [] },
@@ -729,7 +729,7 @@ describe("FeishuTransport", () => {
           };
         },
       };
-      const errorAgent: AgentInstance = {
+      const errorAgent: PiMonoInstance = {
         prompt: vi.fn(() => throwingIterable),
         abort: vi.fn(),
         steer: vi.fn(),
@@ -751,7 +751,7 @@ describe("FeishuTransport", () => {
     });
 
     it("handles agent_end with error stopReason", async () => {
-      const errorAgent = createMockAgentInstance([
+      const errorAgent = createMockPiMonoInstance([
         {
           type: "agent_end",
           messages: [],

--- a/src/transports/feishu.ts
+++ b/src/transports/feishu.ts
@@ -139,7 +139,7 @@ export interface FeishuTransportConfig {
   appId: string;
   /** Feishu app secret from Developer Console */
   appSecret: string;
-  agentManager: AgentManager;
+  agentManager: DefaultAgentManager;
   sessionStore: SessionStore;
   /** Default agent ID to use for incoming messages */
   defaultAgentId?: string;

--- a/src/transports/feishu.ts
+++ b/src/transports/feishu.ts
@@ -3,8 +3,6 @@
 
 import * as lark from "@larksuiteoapi/node-sdk";
 import {
-  type AgentInstance,
-  type AgentManager,
   type Binding,
   type BindingPeer,
   type ChannelsConfig,
@@ -12,6 +10,8 @@ import {
   type SessionStore,
   type Transport,
 } from "../core/types.js";
+import type { PiMonoInstance } from "../core/pi-mono.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
 import type { ContextConfigFile } from "../core/config.js";
 import { resolveBinding } from "../core/bindings.js";
 import { loggers } from "../core/logger.js";
@@ -449,8 +449,7 @@ export class FeishuTransport implements Transport {
   // ---------------------------------------------------------------------------
 
   private async runAgentAndReply(
-    agent: AgentInstance,
-    input: AgentMessage[],
+    agent: PiMonoInstance,    input: AgentMessage[],
     chatId: string,
     sessionId: string,
   ): Promise<void> {

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Box, Text, useInput, useApp } from "ink";
-import type { AgentMessage, PiMonoInstance } from "../core/types.js";
+import type { AgentMessage } from "../core/types.js";
+import type { PiMonoInstance } from "../core/pi-mono.js";
 import { loadConfig } from "../core/config.js";
 import { PiMonoCore } from "../core/pi-mono.js";
 import { DefaultAgentManager } from "../core/agent-manager.js";
@@ -89,8 +90,8 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     const toolCalls: ToolCallEntry[] = [];
     try {
       for await (const event of agentRef.current.prompt(historyRef.current)) {
-        if (event.type === "text_delta") {
-          responseText += event.text;
+        if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+          responseText += event.assistantMessageEvent.delta;
           setMessages((prev) => {
             const last = prev[prev.length - 1];
             if (last?.role === "assistant") {
@@ -98,8 +99,8 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
             }
             return [...prev, { role: "assistant", content: responseText, toolCalls: [...toolCalls], timestamp: new Date() }];
           });
-        } else if (event.type === "tool_call") {
-          toolCalls.push({ id: event.id, name: event.name, args: typeof event.args === "string" ? event.args : JSON.stringify(event.args) });
+        } else if (event.type === "tool_execution_start") {
+          toolCalls.push({ id: event.toolCallId, name: event.toolName, args: typeof event.args === "string" ? event.args : JSON.stringify(event.args) });
           setMessages((prev) => {
             const last = prev[prev.length - 1];
             if (last?.role === "assistant") {
@@ -107,14 +108,13 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
             }
             return prev;
           });
-        } else if (event.type === "tool_result") {
-          const tc = toolCalls.find((t) => t.id === event.id);
+        } else if (event.type === "tool_execution_end") {
+          const output = typeof event.result === "string" ? event.result : JSON.stringify(event.result);
+          const tc = toolCalls.find((t) => t.id === event.toolCallId);
           if (tc) {
-            tc.result = event.output;
+            tc.result = output;
             tc.isError = event.isError;
           }
-        } else if (event.type === "error") {
-          setMessages((prev) => [...prev, { role: "system", content: `Error: ${event.error}`, timestamp: new Date() }]);
         }
       }
     } catch (err) {

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Box, Text, useInput, useApp } from "ink";
-import type { AgentMessage, AgentInstance } from "../core/types.js";
+import type { AgentMessage, PiMonoInstance } from "../core/types.js";
 import { loadConfig } from "../core/config.js";
 import { PiMonoCore } from "../core/pi-mono.js";
 import { DefaultAgentManager } from "../core/agent-manager.js";
@@ -24,7 +24,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
   const [agentReady, setAgentReady] = useState(false);
   const [agentId, setAgentId] = useState(options.agent ?? "");
   const [error, setError] = useState<string | null>(null);
-  const agentRef = useRef<AgentInstance | null>(null);
+  const agentRef = useRef<PiMonoInstance | null>(null);
   const historyRef = useRef<AgentMessage[]>([]);
   const autoMessageSent = useRef(false);
 

--- a/src/workspace/hot-reload.test.ts
+++ b/src/workspace/hot-reload.test.ts
@@ -10,7 +10,7 @@ import {
   IGNORE_PATTERNS,
   type WorkspaceReloadedEvent,
 } from "./hot-reload.js";
-import type { AgentManager, AgentInstance, AgentConfig } from "../core/types.js";
+import type { AgentConfig } from "../core/types.js";
 
 // ---------------------------------------------------------------------------
 // Mock AgentManager
@@ -21,17 +21,17 @@ function createMockAgentManager(): AgentManager & { reloadWorkspaceCalls: string
 
   return {
     reloadWorkspaceCalls,
-    async create(config: AgentConfig): Promise<AgentInstance> {
-      return { id: config.id } as unknown as AgentInstance;
+    async create(config: AgentConfig): Promise<PiMonoInstance> {
+      return { id: config.id } as unknown as PiMonoInstance;
     },
-    get(id: string): AgentInstance | undefined {
-      return { id } as unknown as AgentInstance;
+    get(id: string): PiMonoInstance | undefined {
+      return { id } as unknown as PiMonoInstance;
     },
     list(): AgentConfig[] {
       return [];
     },
-    async update(_id: string, _updates: Partial<AgentConfig>): Promise<AgentInstance> {
-      return { id: _id } as unknown as AgentInstance;
+    async update(_id: string, _updates: Partial<AgentConfig>): Promise<PiMonoInstance> {
+      return { id: _id } as unknown as PiMonoInstance;
     },
     async delete(_id: string): Promise<void> {},
     async getPrompt(_id: string): Promise<string> {

--- a/src/workspace/hot-reload.test.ts
+++ b/src/workspace/hot-reload.test.ts
@@ -11,12 +11,14 @@ import {
   type WorkspaceReloadedEvent,
 } from "./hot-reload.js";
 import type { AgentConfig } from "../core/types.js";
+import type { PiMonoInstance } from "../core/pi-mono.js";
+import type { DefaultAgentManager } from "../core/agent-manager.js";
 
 // ---------------------------------------------------------------------------
-// Mock AgentManager
+// Mock DefaultAgentManager
 // ---------------------------------------------------------------------------
 
-function createMockAgentManager(): AgentManager & { reloadWorkspaceCalls: string[] } {
+function createMockDefaultAgentManager(): DefaultAgentManager & { reloadWorkspaceCalls: string[] } {
   const reloadWorkspaceCalls: string[] = [];
 
   return {
@@ -41,7 +43,7 @@ function createMockAgentManager(): AgentManager & { reloadWorkspaceCalls: string
     async reloadWorkspace(id: string): Promise<void> {
       reloadWorkspaceCalls.push(id);
     },
-  };
+  } as unknown as DefaultAgentManager & { reloadWorkspaceCalls: string[] };
 }
 
 // ---------------------------------------------------------------------------
@@ -50,12 +52,12 @@ function createMockAgentManager(): AgentManager & { reloadWorkspaceCalls: string
 
 describe("HotReloadManager", () => {
   let tempDir: string;
-  let mockManager: ReturnType<typeof createMockAgentManager>;
+  let mockManager: ReturnType<typeof createMockDefaultAgentManager>;
   let hotReload: HotReloadManager;
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hot-reload-test-"));
-    mockManager = createMockAgentManager();
+    mockManager = createMockDefaultAgentManager();
     hotReload = new HotReloadManager(mockManager, {
       enabled: true,
       debounceMs: 50, // Fast debounce for tests

--- a/src/workspace/hot-reload.ts
+++ b/src/workspace/hot-reload.ts
@@ -3,7 +3,7 @@
 
 import path from "node:path";
 import { createLogger } from "../core/logger.js";
-import type { AgentManager } from "../core/types.js";
+import type { DefaultAgentManager } from '../core/agent-manager.js';;
 import { WorkspaceWatcher } from "./watcher.js";
 
 const log = createLogger("hot-reload");
@@ -77,7 +77,7 @@ export class HotReloadManager {
   private started = false;
 
   constructor(
-    private agentManager: AgentManager,
+    private agentManager: DefaultAgentManager,
     private config: HotReloadConfig = { enabled: true },
   ) {}
 


### PR DESCRIPTION
## Summary

删除 isotopes 自定义的 5 个抽象接口，直接用pi-mono。

### 删除 (types.ts)
- `AgentCore` 接口 → 直接用 `PiMonoCore` 类
- `AgentInstance` 接口 → 直接用 `PiMonoInstance` 类 (新 export)
- `AgentManager` 接口 → 直接用 `DefaultAgentManager` 类
- `AgentEvent` (自定义) → re-export SDK 的 `AgentEvent`
- `Usage` (自定义) → re-export SDK 的 `Usage`

### 删除 (pi-mono.ts)
- `mapEvent` 函数 (~60 行) — 不再映射事件,SDK 事件直接 pass-through
- `getAgentEndMetadata` (~12 行) — inline 到 overflow detection

### 事件类型迁移 (所有 consumer)
| 旧 (isotopes) | 新 (SDK) |
|---|---|
| `text_delta` | `message_update` + `assistantMessageEvent.type === "text_delta"` |
| `tool_call` | `tool_execution_start` |
| `tool_result` | `tool_execution_end` |
| `turn_end` (无字段) | `turn_end` (有 `message` + `toolResults`) |
| `agent_end.stopReason` | 从 last assistant message 读取 |

### 影响文件
29 files changed — 所有 transport、API、command、subagent consumer 更新

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] 907 tests pass
- [ ] CI

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)