### PR TITLE
fix: restore usage + stopReason in SSE events (#475)

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -3,7 +3,7 @@
 
 import { addRoute } from "./routes.js";
 import { sendJson, sendError } from "./middleware.js";
-import { userMessage as mkUserMsg, assistantMessage as mkAssistantMsg, messageText } from "../core/messages.js";
+import { userMessage as mkUserMsg, assistantMessage as mkAssistantMsg, messageText, getAgentEndMeta, getUsage } from "../core/messages.js";
 import { createLogger } from "../core/logger.js";
 import { randomUUID } from "node:crypto";
 
@@ -162,11 +162,13 @@ addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
           writeEvent("turn_start", {});
           break;
         case "turn_end":
-          writeEvent("turn_end", {});
+          writeEvent("turn_end", { usage: getUsage(event.message) });
           break;
-        case "agent_end":
-          writeEvent("agent_end", {});
+        case "agent_end": {
+          const { stopReason, errorMessage } = getAgentEndMeta(event.messages);
+          writeEvent("agent_end", { stopReason, errorMessage });
           break;
+        }
       }
     }
 

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -3,7 +3,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type {  SessionStore } from "./types.js";
 import type { PiMonoInstance } from "./pi-mono.js";
-import { userMessage, assistantMessage, toolResultMessage } from "./messages.js";
+import { userMessage, assistantMessage, toolResultMessage, getAgentEndMeta, getUsage } from "./messages.js";
 import type { Logger } from "./logger.js";
 import type { UsageTracker } from "./usage-tracker.js";
 import type { HookRegistry } from "../plugins/hooks.js";
@@ -111,9 +111,9 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
         ),
       );
     } else if (event.type === "turn_end") {
-      const msg = event.message;
-      if (usageTracker && msg && "usage" in msg) {
-        usageTracker.record(sessionId, (msg as unknown as { usage: unknown }).usage as Parameters<typeof usageTracker.record>[1]);
+      const usage = getUsage(event.message);
+      if (usageTracker && usage) {
+        usageTracker.record(sessionId, usage as Parameters<typeof usageTracker.record>[1]);
       }
 
       await flushTurn();
@@ -136,9 +136,7 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
         });
       }
 
-      const lastAssistant = [...event.messages].reverse().find((m) => m.role === "assistant");
-      const stopReason = (lastAssistant as unknown as { stopReason?: string })?.stopReason;
-      const errMsg = (lastAssistant as unknown as { errorMessage?: string })?.errorMessage;
+      const { stopReason, errorMessage: errMsg } = getAgentEndMeta(event.messages);
       if (stopReason === "error") {
         const msg = errMsg ?? "Unknown agent error";
         log.error(`Agent ended with error: ${msg}`);

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -56,3 +56,19 @@ export function messageText(msg: AgentMessage): string {
 export function msgField<T = unknown>(msg: AgentMessage, field: string): T {
   return (msg as unknown as Record<string, unknown>)[field] as T;
 }
+
+/** Extract stopReason + errorMessage from the last assistant message in an agent_end event. */
+export function getAgentEndMeta(messages: AgentMessage[]): { stopReason?: string; errorMessage?: string } {
+  const last = [...messages].reverse().find((m) => m.role === "assistant");
+  if (!last) return {};
+  return {
+    stopReason: msgField<string | undefined>(last, "stopReason"),
+    errorMessage: msgField<string | undefined>(last, "errorMessage"),
+  };
+}
+
+/** Extract usage from an assistant message (SDK turn_end.message). */
+export function getUsage(msg: AgentMessage | undefined): unknown {
+  if (!msg || !("usage" in msg)) return undefined;
+  return (msg as unknown as { usage: unknown }).usage;
+}

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -17,6 +17,7 @@ import {
   estimateTotalTokens,
 } from "./compaction.js";
 import { sanitizeToolUseResultPairing } from "./context.js";
+import { getAgentEndMeta } from "./messages.js";
 import { createLogger } from "./logger.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -351,8 +352,7 @@ export class PiMonoInstance {
 
     const unsub = this.agent.subscribe((e: AgentEvent) => {
       if (e.type === "agent_end") {
-        const last = [...e.messages].reverse().find((m) => m.role === "assistant");
-        const err = (last as unknown as { errorMessage?: string })?.errorMessage;
+        const { errorMessage: err } = getAgentEndMeta(e.messages);
         if (err && isContextOverflow(err)) {
           overflowDetected = true;
           overflowErrorMessage = err;


### PR DESCRIPTION
## Summary

#477 迁移到 SDK 事件后,chat.ts 的 SSE 端点丢失了 `turn_end.usage` 和 `agent_end.stopReason/errorMessage`,导致 API consumer 无法获取 token 用量和错误信息。

### 修复
- `messages.ts`: 新增 `getAgentEndMeta()` 和 `getUsage()` helper,集中提取 SDK 事件中的 metadata
- `chat.ts`: SSE `turn_end` 现在传 `{ usage }`,`agent_end` 传 `{ stopReason, errorMessage }`
- `agent-runner.ts`: 用 helper 替换 inline `as unknown as` cast
- `pi-mono.ts`: overflow detection 用 helper 替换 inline cast

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors  
- [x] agent-runner + pi-mono tests pass (43/43)

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)