### PR TITLE
chore: add plugins/ and .teamwork to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ isotopes.yml
 
 # Local Claude Code working dirs (plans, scratch, etc.)
 .claude/
+
+# plugins
+plugins/
+
+# teamwork
+.teamwork


### PR DESCRIPTION
## Summary
- Add `plugins/` and `.teamwork` to `.gitignore`

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)