### PR TITLE
fix(core): toolResultMessage content must be block array, not string

### DIFF
--- a/src/core/agent-runner.test.ts
+++ b/src/core/agent-runner.test.ts
@@ -234,7 +234,7 @@ describe("runAgentLoop", () => {
 
     // Turn 1: tool_result-role message paired to call-1, with toolName
     expect(msgField(calls[1][1], "role")).toBe("toolResult");
-    expect(msgField(calls[1][1], "content")).toBe("a.txt\nb.txt");
+    expect(msgField(calls[1][1], "content")).toEqual([{ type: "text", text: "a.txt\nb.txt" }]);
     expect(msgField(calls[1][1], "toolCallId")).toBe("call-1");
     expect(msgField(calls[1][1], "toolName")).toBe("shell");
 
@@ -265,7 +265,8 @@ describe("runAgentLoop", () => {
       (c) => c[1].role === "toolResult",
     );
     expect(toolResultCall).toBeDefined();
-    const output = msgField(toolResultCall![1], "content") as string;
+    const contentBlocks = msgField(toolResultCall![1], "content") as Array<{ type: string; text: string }>;
+    const output = contentBlocks.map((b) => b.text).join("");
     expect(output.length).toBeLessThan(big.length);
     expect(output).toContain("[truncated");
   });

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -27,7 +27,7 @@ export function toolResultMessage(
 ): AgentMessage {
   return {
     role: "toolResult",
-    content: output,
+    content: [{ type: "text", text: output }],
     toolCallId,
     toolName,
     ...(opts?.isError !== undefined ? { isError: opts.isError } : {}),

--- a/src/core/types.test.ts
+++ b/src/core/types.test.ts
@@ -30,8 +30,8 @@ describe("toolResultMessage", () => {
   it("creates a toolResult message", () => {
     const msg = toolResultMessage("output", "call-1", "shell");
     expect(msg.role).toBe("toolResult");
-    const m = msg as unknown as { content: string; toolCallId: string; toolName: string };
-    expect(m.content).toBe("output");
+    const m = msg as unknown as { content: Array<{ type: string; text: string }>; toolCallId: string; toolName: string };
+    expect(m.content).toEqual([{ type: "text", text: "output" }]);
     expect(m.toolCallId).toBe("call-1");
     expect(m.toolName).toBe("shell");
   });


### PR DESCRIPTION
## Summary

- `toolResultMessage()` in `messages.ts` was setting `content` to a plain string, but `ToolResultMessage.content` requires `(TextContent | ImageContent)[]`
- When these messages were replayed from session store on subsequent prompts, the Anthropic provider's `convertContentBlocks()` called `content.some()` on the string, causing `content.some is not a function`
- Same class of bug as #469 (summary message), reintroduced in #473/#474 refactor

## Test plan

- [x] All 496 core tests pass
- [x] Typecheck passes
- [x] Verified fix matches the pattern used by `createSummaryMessage()` and `pi-agent-core`'s own `emitToolCallOutcome()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)