### PR TITLE
feat(core): add head+tail tool result truncation at send-time

### DIFF
--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -5,6 +5,7 @@
 // the SDK's AgentSession.
 
 import { getModel, type Model, type Api } from "@mariozechner/pi-ai";
+import { truncateToolResultText } from "./tool-result-truncation.js";
 import {
   type AgentSession,
   AuthStorage,
@@ -112,7 +113,7 @@ function toToolDefinition(tool: Tool, handler: (args: unknown) => Promise<string
     execute: async (_toolCallId, params) => {
       const result = await handler(params);
       return {
-        content: [{ type: "text", text: result }],
+        content: [{ type: "text", text: truncateToolResultText(result) }],
         details: {},
       };
     },

--- a/src/core/tool-result-truncation.test.ts
+++ b/src/core/tool-result-truncation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  truncateToolResultText,
+  DEFAULT_MAX_TOOL_RESULT_CHARS,
+} from "./tool-result-truncation.js";
+
+describe("truncateToolResultText", () => {
+  it("returns text unchanged when under limit", () => {
+    const text = "hello world";
+    expect(truncateToolResultText(text, 1000)).toBe(text);
+  });
+
+  it("truncates text exceeding limit", () => {
+    const text = "a".repeat(20_000);
+    const result = truncateToolResultText(text, 5_000);
+    expect(result.length).toBeLessThan(text.length);
+    expect(result).toContain("truncated");
+  });
+
+  it("uses DEFAULT_MAX_TOOL_RESULT_CHARS when no maxChars given", () => {
+    expect(DEFAULT_MAX_TOOL_RESULT_CHARS).toBe(16_000);
+    const text = "x".repeat(20_000);
+    const result = truncateToolResultText(text);
+    expect(result.length).toBeLessThanOrEqual(DEFAULT_MAX_TOOL_RESULT_CHARS + 100);
+  });
+
+  it("preserves error content at the tail (head+tail split)", () => {
+    const head = "Line 1\n".repeat(500);
+    const middle = "data data data\n".repeat(500);
+    const tail = "\nError: something failed\nStack trace: at foo.ts:42\n";
+    const text = head + middle + tail;
+    const result = truncateToolResultText(text, 5000);
+    expect(result).toContain("Line 1");
+    expect(result).toContain("Error: something failed");
+    expect(result).toContain("middle content omitted");
+  });
+
+  it("uses head-only truncation when tail has no important content", () => {
+    const text = "normal line\n".repeat(1000);
+    const result = truncateToolResultText(text, 5000);
+    expect(result).toContain("normal line");
+    expect(result).not.toContain("middle content omitted");
+    expect(result).toContain("truncated");
+  });
+
+  it("tries to break at newline boundaries", () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `line ${i}: ${"x".repeat(50)}`).join("\n");
+    const result = truncateToolResultText(lines, 3000);
+    expect(result).toContain("truncated");
+    expect(result.length).toBeLessThan(lines.length);
+  });
+
+  it("detects JSON closing structure as important tail", () => {
+    const json = "{\n" + '  "items": [\n' + '    {"id": 1},\n'.repeat(500) + "  ]\n}";
+    const result = truncateToolResultText(json, 5000);
+    expect(result).toContain("middle content omitted");
+    expect(result).toContain("}");
+  });
+
+  it("detects traceback as important tail", () => {
+    const output = "output line\n".repeat(500) + "\nTraceback (most recent call last):\n  File 'x.py'\n";
+    const result = truncateToolResultText(output, 5000);
+    expect(result).toContain("middle content omitted");
+    expect(result).toContain("Traceback");
+  });
+
+  it("includes char count in truncation suffix", () => {
+    const text = "x".repeat(10_000);
+    const result = truncateToolResultText(text, 3000);
+    expect(result).toMatch(/\d+ more characters truncated/);
+  });
+});

--- a/src/core/tool-result-truncation.ts
+++ b/src/core/tool-result-truncation.ts
@@ -1,0 +1,63 @@
+export const DEFAULT_MAX_TOOL_RESULT_CHARS = 16_000;
+
+const MIN_KEEP_CHARS = 2_000;
+
+const MIDDLE_OMISSION_MARKER =
+  "\n\n⚠️ [... middle content omitted — showing head and tail ...]\n\n";
+
+function formatTruncationSuffix(truncatedChars: number): string {
+  return `\n\n[... ${Math.max(1, Math.floor(truncatedChars))} more characters truncated]`;
+}
+
+function hasImportantTail(text: string): boolean {
+  const tail = text.slice(-2000).toLowerCase();
+  return (
+    /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/.test(tail) ||
+    /\}\s*$/.test(tail.trim()) ||
+    /\b(total|summary|result|complete|finished|done)\b/.test(tail)
+  );
+}
+
+export function truncateToolResultText(
+  text: string,
+  maxChars: number = DEFAULT_MAX_TOOL_RESULT_CHARS,
+): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+
+  const suffix = formatTruncationSuffix(text.length - maxChars);
+  const budget = Math.max(MIN_KEEP_CHARS, maxChars - suffix.length);
+
+  if (hasImportantTail(text) && budget > MIN_KEEP_CHARS * 2) {
+    const tailBudget = Math.min(Math.floor(budget * 0.3), 4_000);
+    const headBudget = budget - tailBudget - MIDDLE_OMISSION_MARKER.length;
+
+    if (headBudget > MIN_KEEP_CHARS) {
+      let headCut = headBudget;
+      const headNewline = text.lastIndexOf("\n", headBudget);
+      if (headNewline > headBudget * 0.8) {
+        headCut = headNewline;
+      }
+
+      let tailStart = text.length - tailBudget;
+      const tailNewline = text.indexOf("\n", tailStart);
+      if (tailNewline !== -1 && tailNewline < tailStart + tailBudget * 0.2) {
+        tailStart = tailNewline + 1;
+      }
+
+      const kept = text.slice(0, headCut) + MIDDLE_OMISSION_MARKER + text.slice(tailStart);
+      const actualSuffix = formatTruncationSuffix(text.length - kept.length);
+      return kept + actualSuffix;
+    }
+  }
+
+  let cutPoint = budget;
+  const lastNewline = text.lastIndexOf("\n", budget);
+  if (lastNewline > budget * 0.8) {
+    cutPoint = lastNewline;
+  }
+
+  const kept = text.slice(0, cutPoint);
+  return kept + formatTruncationSuffix(text.length - kept.length);
+}


### PR DESCRIPTION
## Summary

- Port `truncateToolResultText` from openclaw with head+tail strategy: preserves error/traceback/JSON-closing content at the tail using 70/30 budget split, falls back to head-only truncation otherwise
- Wire truncation into `toToolDefinition` so all tool results are capped at 16k chars before entering the LLM context
- 9 unit tests covering: head-only, head+tail split, newline boundary alignment, error/traceback/JSON detection, char count suffix

Closes #487

## Test plan

- [x] `npx vitest run src/core/tool-result-truncation.test.ts` — 9 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Discord runtime test: verify large tool outputs (e.g. `cat` of a big file) are truncated with visible `[... N more characters truncated]` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)