### PR TITLE
feat(plugins): add registerTool to plugin API

### DIFF
--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -19,6 +19,7 @@ import { ThreadBindingManager } from "./thread-bindings.js";
 import { createLogger } from "./logger.js";
 import { LazyTransportContext } from "../tools/react.js";
 import { ProcessRegistry } from "../tools/exec.js";
+import { ToolRegistry } from "./tools.js";
 import { ContainerManager, SandboxExecutor } from "../sandbox/index.js";
 import { initializeAgent } from "./agent-init.js";
 import {
@@ -91,6 +92,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   const agentWorkspaces = new Map<string, string>();
   const transportContexts = new Map<string, LazyTransportContext>();
   const processRegistries = new Map<string, ProcessRegistry>();
+  const toolRegistries = new Map<string, ToolRegistry>();
 
   // Build sandbox executor if any agent uses sandboxing
   let sandboxExecutor: SandboxExecutor | undefined;
@@ -139,6 +141,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     agentWorkspaces.set(result.agentConfig.id, result.workspacePath);
     transportContexts.set(result.agentConfig.id, transportCtx);
     processRegistries.set(result.agentConfig.id, result.processRegistry);
+    toolRegistries.set(result.agentConfig.id, result.toolRegistry);
   }
 
   // Hot-reload workspace files
@@ -151,6 +154,25 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     ...[...agentWorkspaces.values()].map((w) => path.join(w, "plugins")),
   ];
   await pluginManager.discoverAndLoad(pluginDirs, config.plugins);
+
+  // Inject plugin-registered tools into each agent's tool registry
+  const toolPluginRegistry = pluginManager.getToolPluginRegistry();
+  for (const [agentId, toolRegistry] of toolRegistries) {
+    const resolved = toolPluginRegistry.resolve({
+      agentId,
+      workspacePath: agentWorkspaces.get(agentId)!,
+    });
+    for (const { tool, handler } of resolved) {
+      if (toolRegistry.has(tool.name)) {
+        log.warn(`Plugin tool "${tool.name}" conflicts with existing tool for agent "${agentId}" — skipping`);
+        continue;
+      }
+      toolRegistry.register(tool, handler);
+    }
+    if (resolved.length > 0) {
+      log.info(`Injected ${resolved.length} plugin tool(s) into agent "${agentId}"`);
+    }
+  }
 
   for (const [agentId, workspacePath] of agentWorkspaces) {
     hotReload.register(agentId, workspacePath);

--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -4,17 +4,22 @@ import path from "node:path";
 import { createLogger } from "../core/logger.js";
 import type { HookRegistry } from "./hooks.js";
 import type { UIRegistry } from "./ui-registry.js";
+import type { ToolPluginRegistry } from "./tool-registry.js";
+import type { Tool } from "../core/types.js";
+import type { ToolHandler } from "../core/tools.js";
 import type {
   IsotopesPluginApi,
   TransportFactory,
   UIPluginConfig,
   PluginManifest,
+  PluginToolFactory,
 } from "./types.js";
 
 export interface CreatePluginApiDeps {
   hooks: HookRegistry;
   uiRegistry: UIRegistry;
   transportFactories: Map<string, TransportFactory>;
+  toolPluginRegistry: ToolPluginRegistry;
   pluginConfig?: Record<string, unknown>;
 }
 
@@ -45,6 +50,16 @@ export function createPluginApi(
       };
       deps.uiRegistry.register(resolved);
       log.info(`Registered UI "${config.id}" at ${resolved.mountPath ?? `/ui/${config.id}`}`);
+    },
+
+    registerTool(
+      tool: { tool: Tool; handler: ToolHandler } | PluginToolFactory,
+    ): void {
+      const factory: PluginToolFactory =
+        typeof tool === "function" ? tool : () => tool;
+      deps.toolPluginRegistry.register(manifest.id, factory);
+      cleanup.push(() => deps.toolPluginRegistry.remove(manifest.id));
+      log.info(`Registered tool from plugin "${manifest.id}"`);
     },
 
     on(hook, handler) {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -3,6 +3,7 @@
 export { PluginManager } from "./manager.js";
 export { HookRegistry } from "./hooks.js";
 export { UIRegistry } from "./ui-registry.js";
+export { ToolPluginRegistry } from "./tool-registry.js";
 export { discoverPlugins } from "./discovery.js";
 export { createPluginApi } from "./api.js";
 export type {
@@ -16,4 +17,6 @@ export type {
   TransportFactory,
   TransportFactoryContext,
   PluginConfigEntry,
+  PluginToolContext,
+  PluginToolFactory,
 } from "./types.js";

--- a/src/plugins/manager.ts
+++ b/src/plugins/manager.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { createLogger } from "../core/logger.js";
 import { HookRegistry } from "./hooks.js";
 import { UIRegistry } from "./ui-registry.js";
+import { ToolPluginRegistry } from "./tool-registry.js";
 import { discoverPlugins } from "./discovery.js";
 import { createPluginApi } from "./api.js";
 import type {
@@ -28,6 +29,7 @@ export class PluginManager {
   private hooks = new HookRegistry();
   private uiRegistry = new UIRegistry();
   private transportFactories = new Map<string, TransportFactory>();
+  private toolPluginRegistry = new ToolPluginRegistry();
 
   async discoverAndLoad(
     searchDirs: string[],
@@ -73,6 +75,7 @@ export class PluginManager {
       hooks: this.hooks,
       uiRegistry: this.uiRegistry,
       transportFactories: this.transportFactories,
+      toolPluginRegistry: this.toolPluginRegistry,
       pluginConfig,
     });
 
@@ -94,6 +97,10 @@ export class PluginManager {
     return this.transportFactories;
   }
 
+  getToolPluginRegistry(): ToolPluginRegistry {
+    return this.toolPluginRegistry;
+  }
+
   getLoadedPlugins(): PluginManifest[] {
     return [...this.plugins.values()].map((p) => p.manifest);
   }
@@ -111,5 +118,6 @@ export class PluginManager {
     }
     this.plugins.clear();
     this.hooks.clear();
+    this.toolPluginRegistry.clear();
   }
 }

--- a/src/plugins/plugins.test.ts
+++ b/src/plugins/plugins.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { HookRegistry } from "./hooks.js";
 import { UIRegistry } from "./ui-registry.js";
+import { ToolPluginRegistry } from "./tool-registry.js";
 import { createPluginApi } from "./api.js";
-import type { PluginManifest, TransportFactory } from "./types.js";
+import type { PluginManifest, TransportFactory, PluginToolContext } from "./types.js";
+import type { Tool } from "../core/types.js";
 import fs from "node:fs";
 
 // ---------------------------------------------------------------------------
@@ -113,10 +115,13 @@ describe("createPluginApi", () => {
     const uiRegistry = new UIRegistry();
     const transportFactories = new Map<string, TransportFactory>();
 
+    const toolPluginRegistry = new ToolPluginRegistry();
+
     const { api, cleanup } = createPluginApi(manifest, "/tmp/plugin", {
       hooks,
       uiRegistry,
       transportFactories,
+      toolPluginRegistry,
     });
 
     const factory: TransportFactory = async () => ({ start: async () => {}, stop: async () => {} });
@@ -132,11 +137,13 @@ describe("createPluginApi", () => {
     const hooks = new HookRegistry();
     const uiRegistry = new UIRegistry();
     const transportFactories = new Map<string, TransportFactory>();
+    const toolPluginRegistry = new ToolPluginRegistry();
 
     const { api, cleanup } = createPluginApi(manifest, "/tmp/plugin", {
       hooks,
       uiRegistry,
       transportFactories,
+      toolPluginRegistry,
     });
 
     const handler = vi.fn();
@@ -154,11 +161,13 @@ describe("createPluginApi", () => {
     const hooks = new HookRegistry();
     const uiRegistry = new UIRegistry();
     const transportFactories = new Map<string, TransportFactory>();
+    const toolPluginRegistry = new ToolPluginRegistry();
 
     const { api } = createPluginApi(manifest, "/tmp/plugin", {
       hooks,
       uiRegistry,
       transportFactories,
+      toolPluginRegistry,
       pluginConfig: { theme: "dark" },
     });
 
@@ -169,14 +178,125 @@ describe("createPluginApi", () => {
     const hooks = new HookRegistry();
     const uiRegistry = new UIRegistry();
     const transportFactories = new Map<string, TransportFactory>();
+    const toolPluginRegistry = new ToolPluginRegistry();
 
     const { api } = createPluginApi(manifest, "/tmp/plugin", {
       hooks,
       uiRegistry,
       transportFactories,
+      toolPluginRegistry,
     });
 
     expect(api.log).toBeDefined();
     expect(api.log.info).toBeInstanceOf(Function);
+  });
+
+  it("registers tool and tracks cleanup", () => {
+    const hooks = new HookRegistry();
+    const uiRegistry = new UIRegistry();
+    const transportFactories = new Map<string, TransportFactory>();
+    const toolPluginRegistry = new ToolPluginRegistry();
+
+    const { api, cleanup } = createPluginApi(manifest, "/tmp/plugin", {
+      hooks,
+      uiRegistry,
+      transportFactories,
+      toolPluginRegistry,
+    });
+
+    const tool: Tool = { name: "my-tool", description: "test", parameters: {} };
+    api.registerTool({ tool, handler: async () => "ok" });
+
+    const ctx: PluginToolContext = { agentId: "a1", workspacePath: "/tmp" };
+    expect(toolPluginRegistry.resolve(ctx)).toHaveLength(1);
+
+    for (const fn of cleanup) fn();
+    expect(toolPluginRegistry.resolve(ctx)).toHaveLength(0);
+  });
+
+  it("registers tool factory and tracks cleanup", () => {
+    const hooks = new HookRegistry();
+    const uiRegistry = new UIRegistry();
+    const transportFactories = new Map<string, TransportFactory>();
+    const toolPluginRegistry = new ToolPluginRegistry();
+
+    const { api, cleanup } = createPluginApi(manifest, "/tmp/plugin", {
+      hooks,
+      uiRegistry,
+      transportFactories,
+      toolPluginRegistry,
+    });
+
+    api.registerTool((ctx) => ({
+      tool: { name: `tool-${ctx.agentId}`, description: "dynamic", parameters: {} },
+      handler: async () => "ok",
+    }));
+
+    const result = toolPluginRegistry.resolve({ agentId: "bot1", workspacePath: "/tmp" });
+    expect(result).toHaveLength(1);
+    expect(result[0].tool.name).toBe("tool-bot1");
+
+    for (const fn of cleanup) fn();
+    expect(toolPluginRegistry.resolve({ agentId: "bot1", workspacePath: "/tmp" })).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ToolPluginRegistry
+// ---------------------------------------------------------------------------
+
+describe("ToolPluginRegistry", () => {
+  let registry: ToolPluginRegistry;
+  const ctx: PluginToolContext = { agentId: "a1", workspacePath: "/tmp/ws" };
+
+  beforeEach(() => {
+    registry = new ToolPluginRegistry();
+  });
+
+  it("resolves a static tool", () => {
+    const tool: Tool = { name: "echo", description: "echo", parameters: {} };
+    registry.register("p1", () => ({ tool, handler: async () => "ok" }));
+    const result = registry.resolve(ctx);
+    expect(result).toHaveLength(1);
+    expect(result[0].tool.name).toBe("echo");
+  });
+
+  it("resolves a factory returning array", () => {
+    registry.register("p1", () => [
+      { tool: { name: "t1", description: "", parameters: {} }, handler: async () => "1" },
+      { tool: { name: "t2", description: "", parameters: {} }, handler: async () => "2" },
+    ]);
+    expect(registry.resolve(ctx)).toHaveLength(2);
+  });
+
+  it("skips factory returning null", () => {
+    registry.register("p1", () => null);
+    expect(registry.resolve(ctx)).toHaveLength(0);
+  });
+
+  it("catches and skips factory errors", () => {
+    registry.register("p1", () => { throw new Error("boom"); });
+    expect(registry.resolve(ctx)).toHaveLength(0);
+  });
+
+  it("detects name conflicts", () => {
+    registry.register("p1", () => ({ tool: { name: "dup", description: "", parameters: {} }, handler: async () => "" }));
+    registry.register("p2", () => ({ tool: { name: "dup", description: "", parameters: {} }, handler: async () => "" }));
+    expect(registry.resolve(ctx)).toHaveLength(1);
+  });
+
+  it("removes entries by pluginId", () => {
+    registry.register("p1", () => ({ tool: { name: "t1", description: "", parameters: {} }, handler: async () => "" }));
+    registry.register("p2", () => ({ tool: { name: "t2", description: "", parameters: {} }, handler: async () => "" }));
+    registry.remove("p1");
+    const result = registry.resolve(ctx);
+    expect(result).toHaveLength(1);
+    expect(result[0].tool.name).toBe("t2");
+  });
+
+  it("clears all entries", () => {
+    registry.register("p1", () => ({ tool: { name: "t1", description: "", parameters: {} }, handler: async () => "" }));
+    registry.clear();
+    expect(registry.resolve(ctx)).toHaveLength(0);
   });
 });

--- a/src/plugins/tool-registry.ts
+++ b/src/plugins/tool-registry.ts
@@ -1,0 +1,55 @@
+// src/plugins/tool-registry.ts — Collects plugin tool registrations and resolves them per-agent
+
+import type { ToolEntry } from "../core/tools.js";
+import type { PluginToolContext, PluginToolFactory } from "./types.js";
+import { createLogger } from "../core/logger.js";
+
+const log = createLogger("plugins:tools");
+
+interface ToolPluginEntry {
+  pluginId: string;
+  factory: PluginToolFactory;
+}
+
+export class ToolPluginRegistry {
+  private entries: ToolPluginEntry[] = [];
+
+  register(pluginId: string, factory: PluginToolFactory): void {
+    this.entries.push({ pluginId, factory });
+  }
+
+  resolve(ctx: PluginToolContext): ToolEntry[] {
+    const results: ToolEntry[] = [];
+    const seen = new Set<string>();
+
+    for (const entry of this.entries) {
+      let resolved;
+      try {
+        resolved = entry.factory(ctx);
+      } catch (err) {
+        log.error(`Plugin tool factory failed (${entry.pluginId}): ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+      if (!resolved) continue;
+
+      const list = Array.isArray(resolved) ? resolved : [resolved];
+      for (const item of list) {
+        if (seen.has(item.tool.name)) {
+          log.error(`Plugin tool name conflict (${entry.pluginId}): ${item.tool.name}`);
+          continue;
+        }
+        seen.add(item.tool.name);
+        results.push(item);
+      }
+    }
+    return results;
+  }
+
+  remove(pluginId: string): void {
+    this.entries = this.entries.filter((e) => e.pluginId !== pluginId);
+  }
+
+  clear(): void {
+    this.entries = [];
+  }
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -3,7 +3,8 @@
 
 import type { Logger } from "../core/logger.js";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { Transport } from "../core/types.js";
+import type { Tool, Transport } from "../core/types.js";
+import type { ToolHandler } from "../core/tools.js";
 import type { DefaultAgentManager } from "../core/agent-manager.js";
 import type { SessionStoreManager } from "../core/session-store-manager.js";
 import type { IsotopesConfigFile } from "../core/config.js";
@@ -83,12 +84,29 @@ export interface TransportFactoryContext {
 }
 
 // ---------------------------------------------------------------------------
+// Tool plugin types
+// ---------------------------------------------------------------------------
+
+export interface PluginToolContext {
+  agentId: string;
+  workspacePath: string;
+  config?: Record<string, unknown>;
+}
+
+export type PluginToolFactory = (
+  ctx: PluginToolContext,
+) => { tool: Tool; handler: ToolHandler } | { tool: Tool; handler: ToolHandler }[] | null | undefined;
+
+// ---------------------------------------------------------------------------
 // Plugin API — the object passed to plugin.register()
 // ---------------------------------------------------------------------------
 
 export interface IsotopesPluginApi {
   registerTransport(id: string, factory: TransportFactory): void;
   registerUI(config: UIPluginConfig): void;
+  registerTool(
+    tool: { tool: Tool; handler: ToolHandler } | PluginToolFactory,
+  ): void;
   on<H extends HookName>(
     hook: H,
     handler: (payload: HookPayloads[H]) => void | Promise<void>,


### PR DESCRIPTION
## Summary

- Add `registerTool` to `IsotopesPluginApi`, allowing plugins to register custom tools via static tool entries or factory functions (matching OpenClaw's pattern)
- New `ToolPluginRegistry` class collects plugin tool registrations and resolves them per-agent with error handling and name conflict detection
- Plugin tools are injected into agent tool registries after plugin loading in `runtime.ts`

## Test plan

- [x] `ToolPluginRegistry`: static tool resolve, factory returning array, null skip, error catch, name conflict detection, remove, clear
- [x] `createPluginApi`: registerTool static + factory with cleanup tracking
- [x] All 22 plugin tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)