### PR TITLE
refactor(core): remove systemPrompt from AgentConfig

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -137,7 +137,7 @@ addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
       cache,
       sessionStore: store,
       sessionId,
-      systemPrompt: systemPrompt,
+      systemPrompt,
       textInput: body.message,
       log,
       onTextDelta: (currentText) => {

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -131,13 +131,13 @@ addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
   };
 
   try {
-    const agentConfig = deps.agentManager.getConfig?.(session.agentId);
+    const systemPrompt = deps.agentManager.getSystemPrompt?.(session.agentId) ?? "";
     let lastTextLen = 0;
     const result = await runAgentLoop({
       cache,
       sessionStore: store,
       sessionId,
-      systemPrompt: agentConfig?.systemPrompt ?? "",
+      systemPrompt: systemPrompt,
       textInput: body.message,
       log,
       onTextDelta: (currentText) => {

--- a/src/commands/slash-commands.test.ts
+++ b/src/commands/slash-commands.test.ts
@@ -110,7 +110,7 @@ describe("SlashCommandHandler", () => {
     it("returns uptime, model, agent, and session info", async () => {
       const agentManager = createMockAgentManager();
       (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
-        { id: "agent-1", systemPrompt: "", provider: { type: "anthropic", model: "claude-sonnet-4" } },
+        { id: "agent-1", provider: { type: "anthropic", model: "claude-sonnet-4" } },
       ]);
 
       const sessionStore = createMockSessionStore();
@@ -131,7 +131,7 @@ describe("SlashCommandHandler", () => {
     it("shows default model when no provider configured", async () => {
       const agentManager = createMockAgentManager();
       (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
-        { id: "agent-1", systemPrompt: "" },
+        { id: "agent-1" },
       ]);
 
       const ctx = createContext({ agentManager });
@@ -178,7 +178,7 @@ describe("SlashCommandHandler", () => {
     it("shows current model when no args given", async () => {
       const agentManager = createMockAgentManager();
       (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
-        { id: "agent-1", systemPrompt: "", provider: { type: "anthropic", model: "claude-sonnet-4" } },
+        { id: "agent-1", provider: { type: "anthropic", model: "claude-sonnet-4" } },
       ]);
 
       const ctx = createContext({ agentManager });
@@ -191,7 +191,7 @@ describe("SlashCommandHandler", () => {
     it("switches model on agent", async () => {
       const agentManager = createMockAgentManager();
       (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
-        { id: "agent-1", systemPrompt: "", provider: { type: "anthropic", model: "claude-opus-4.5" } },
+        { id: "agent-1", provider: { type: "anthropic", model: "claude-opus-4.5" } },
       ]);
       (agentManager.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
@@ -208,7 +208,7 @@ describe("SlashCommandHandler", () => {
     it("reports errors on invalid model", async () => {
       const agentManager = createMockAgentManager();
       (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
-        { id: "agent-1", systemPrompt: "" },
+        { id: "agent-1" },
       ]);
       (agentManager.update as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error("Unknown anthropic model: fake-model"),

--- a/src/core/agent-init.test.ts
+++ b/src/core/agent-init.test.ts
@@ -109,7 +109,7 @@ describe("initializeAgent", () => {
       expect.objectContaining({
         workspacePath: expect.any(String),
         toolGuardPrompt: expect.any(String),
-        baseSystemPrompt: expect.any(String),
+        initialSystemPrompt: expect.any(String),
       }),
     );
   });

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -83,6 +83,7 @@ export interface InitAgentResult {
   transportContext?: LazyTransportContext;
   baseSystemPrompt: string;
   toolGuardPrompt: string;
+  systemPrompt: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -131,8 +132,8 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
 
   // 6. Load workspace context (SOUL.md, TOOLS.md, MEMORY.md, etc.)
   const workspaceContext = await loadWorkspaceContext(workspacePath, { bundledPath: resolveBundledSkillsDir() });
-  const baseSystemPrompt = agentConfig.systemPrompt;
-  agentConfig.systemPrompt = buildSystemPrompt(agentConfig.systemPrompt, workspaceContext);
+  const baseSystemPrompt = "";
+  let systemPrompt = buildSystemPrompt(baseSystemPrompt, workspaceContext);
   log.debug(`Loaded workspace context for ${agentConfig.id}: systemPrompt=${workspaceContext.systemPromptAdditions.length > 0}, memory=${workspaceContext.memory !== null}`);
 
   // 7. Create tool registry and process registry
@@ -199,8 +200,8 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
 
   // 12. Build tool guard prompt and append to system prompt
   const toolGuardPrompt = buildToolGuardPrompt(toolRegistry.list(), resolvedToolGuards, workspacePath, agentAllowedWorkspaces);
-  agentConfig.systemPrompt = [
-    agentConfig.systemPrompt,
+  systemPrompt = [
+    systemPrompt,
     toolGuardPrompt,
   ].filter(Boolean).join("\n\n---\n\n");
 
@@ -210,7 +211,7 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
     toolRegistry.setHooks(opts.hooks);
     await opts.hooks.emit("before_agent_start", { agentId: agentConfig.id });
   }
-  const instance = await agentManager.create(agentConfig, { workspacePath, toolGuardPrompt, baseSystemPrompt });
+  const instance = await agentManager.create(agentConfig, { workspacePath, toolGuardPrompt, baseSystemPrompt, initialSystemPrompt: systemPrompt });
   log.info(`Created agent: ${agentConfig.id} (workspace: ${workspacePath}, tools: ${toolRegistry.list().length})`);
 
   return {
@@ -222,5 +223,6 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
     transportContext,
     baseSystemPrompt,
     toolGuardPrompt,
+    systemPrompt,
   };
 }

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -81,7 +81,6 @@ export interface InitAgentResult {
   toolRegistry: ToolRegistry;
   processRegistry: ProcessRegistry;
   transportContext?: LazyTransportContext;
-  baseSystemPrompt: string;
   toolGuardPrompt: string;
   systemPrompt: string;
 }
@@ -132,8 +131,7 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
 
   // 6. Load workspace context (SOUL.md, TOOLS.md, MEMORY.md, etc.)
   const workspaceContext = await loadWorkspaceContext(workspacePath, { bundledPath: resolveBundledSkillsDir() });
-  const baseSystemPrompt = "";
-  let systemPrompt = buildSystemPrompt(baseSystemPrompt, workspaceContext);
+  let systemPrompt = buildSystemPrompt("", workspaceContext);
   log.debug(`Loaded workspace context for ${agentConfig.id}: systemPrompt=${workspaceContext.systemPromptAdditions.length > 0}, memory=${workspaceContext.memory !== null}`);
 
   // 7. Create tool registry and process registry
@@ -211,7 +209,7 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
     toolRegistry.setHooks(opts.hooks);
     await opts.hooks.emit("before_agent_start", { agentId: agentConfig.id });
   }
-  const instance = await agentManager.create(agentConfig, { workspacePath, toolGuardPrompt, baseSystemPrompt, initialSystemPrompt: systemPrompt });
+  const instance = await agentManager.create(agentConfig, { workspacePath, toolGuardPrompt, initialSystemPrompt: systemPrompt });
   log.info(`Created agent: ${agentConfig.id} (workspace: ${workspacePath}, tools: ${toolRegistry.list().length})`);
 
   return {
@@ -221,7 +219,6 @@ export async function initializeAgent(opts: InitAgentOptions): Promise<InitAgent
     toolRegistry,
     processRegistry,
     transportContext,
-    baseSystemPrompt,
     toolGuardPrompt,
     systemPrompt,
   };

--- a/src/core/agent-manager.test.ts
+++ b/src/core/agent-manager.test.ts
@@ -26,7 +26,6 @@ function createMockCore(): PiMonoCore {
 function makeConfig(overrides?: Partial<AgentConfig>): AgentConfig {
   return {
     id: "test-agent",
-    systemPrompt: "You are a test agent.",
     ...overrides,
   };
 }
@@ -108,14 +107,14 @@ describe("DefaultAgentManager", () => {
       await manager.create(config);
 
       const updated = await manager.update("test-agent", {
-        systemPrompt: "Updated prompt",
+        compaction: { mode: "off" },
       });
 
       expect(updated).toBeDefined();
       expect(core.createServiceCache).toHaveBeenCalledTimes(2);
 
       const configs = manager.list();
-      expect(configs[0].systemPrompt).toBe("Updated prompt");
+      expect(configs[0].compaction).toEqual({ mode: "off" });
     });
 
     it("preserves id even if update tries to change it", async () => {
@@ -123,7 +122,6 @@ describe("DefaultAgentManager", () => {
 
       await manager.update("test-agent", {
         id: "different-id",
-        systemPrompt: "Updated",
       } as Partial<AgentConfig>);
 
       const configs = manager.list();
@@ -132,7 +130,7 @@ describe("DefaultAgentManager", () => {
 
     it("throws if agent not found", async () => {
       await expect(
-        manager.update("non-existent", { systemPrompt: "New" }),
+        manager.update("non-existent", { compaction: { mode: "off" } }),
       ).rejects.toThrow('Agent "non-existent" not found');
     });
   });
@@ -155,7 +153,7 @@ describe("DefaultAgentManager", () => {
 
   describe("getPrompt / updatePrompt", () => {
     it("getPrompt returns system prompt", async () => {
-      await manager.create(makeConfig({ systemPrompt: "Hello world" }));
+      await manager.create(makeConfig(), { initialSystemPrompt: "Hello world" });
 
       const prompt = await manager.getPrompt("test-agent");
       expect(prompt).toBe("Hello world");

--- a/src/core/agent-manager.ts
+++ b/src/core/agent-manager.ts
@@ -18,6 +18,8 @@ export interface AgentCreateOptions {
   toolGuardPrompt?: string;
   /** Base system prompt before workspace assembly (for hot-reload rebuild) */
   baseSystemPrompt?: string;
+  /** Fully assembled system prompt (workspace + tool guards already merged) */
+  initialSystemPrompt?: string;
 }
 
 /** Internal entry combining config, cache, and workspace */
@@ -25,6 +27,8 @@ interface AgentEntry {
   config: AgentConfig;
   cache: AgentServiceCache;
   workspace: WorkspaceContext | null;
+  /** Assembled system prompt (workspace context + tool guards) */
+  systemPrompt: string;
   /** Base system prompt before workspace assembly (for hot-reload) */
   baseSystemPrompt: string;
   /** Resolved workspace path */
@@ -56,7 +60,8 @@ export class DefaultAgentManager {
       config,
       cache,
       workspace: null,
-      baseSystemPrompt: options?.baseSystemPrompt ?? config.systemPrompt,
+      systemPrompt: options?.initialSystemPrompt ?? "",
+      baseSystemPrompt: options?.baseSystemPrompt ?? "",
       workspacePath: options?.workspacePath,
       toolGuardPrompt: options?.toolGuardPrompt,
     });
@@ -69,6 +74,10 @@ export class DefaultAgentManager {
 
   getConfig(id: string): AgentConfig | undefined {
     return this.agents.get(id)?.config;
+  }
+
+  getSystemPrompt(id: string): string | undefined {
+    return this.agents.get(id)?.systemPrompt;
   }
 
   getWorkspace(id: string): WorkspaceContext | undefined {
@@ -112,11 +121,15 @@ export class DefaultAgentManager {
     if (!entry) {
       throw new Error(`Agent "${id}" not found`);
     }
-    return entry.config.systemPrompt;
+    return entry.systemPrompt;
   }
 
   async updatePrompt(id: string, prompt: string): Promise<void> {
-    await this.update(id, { systemPrompt: prompt });
+    const entry = this.agents.get(id);
+    if (!entry) {
+      throw new Error(`Agent "${id}" not found`);
+    }
+    entry.systemPrompt = prompt;
   }
 
   async reloadWorkspace(id: string): Promise<void> {
@@ -139,6 +152,6 @@ export class DefaultAgentManager {
       systemPrompt = [systemPrompt, entry.toolGuardPrompt].filter(Boolean).join("\n\n---\n\n");
     }
 
-    await this.update(id, { systemPrompt });
+    entry.systemPrompt = systemPrompt;
   }
 }

--- a/src/core/agent-manager.ts
+++ b/src/core/agent-manager.ts
@@ -16,8 +16,6 @@ export interface AgentCreateOptions {
   workspacePath?: string;
   /** Tool guard prompt section (stored for hot-reload persistence) */
   toolGuardPrompt?: string;
-  /** Base system prompt before workspace assembly (for hot-reload rebuild) */
-  baseSystemPrompt?: string;
   /** Fully assembled system prompt (workspace + tool guards already merged) */
   initialSystemPrompt?: string;
 }
@@ -61,7 +59,7 @@ export class DefaultAgentManager {
       cache,
       workspace: null,
       systemPrompt: options?.initialSystemPrompt ?? "",
-      baseSystemPrompt: options?.baseSystemPrompt ?? "",
+      baseSystemPrompt: "",
       workspacePath: options?.workspacePath,
       toolGuardPrompt: options?.toolGuardPrompt,
     });

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -260,7 +260,6 @@ agents:
       const config = toAgentConfig(agentFile);
 
       expect(config.id).toBe("test");
-      expect(config.systemPrompt).toBe("");
     });
 
     it("uses default provider when agent has none", () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -576,7 +576,6 @@ export function toAgentConfig(
 
   return {
     id: agent.id,
-    systemPrompt: "",
     toolSettings: resolveToolSettings(tools),
     provider: provider as ProviderConfig | undefined,
     compaction,

--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -36,7 +36,6 @@ import { ToolRegistry } from "./tools.js";
 function makeConfig(overrides?: Partial<AgentConfig>): AgentConfig {
   return {
     id: "test-agent",
-    systemPrompt: "You are a test agent.",
     ...overrides,
   };
 }

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -211,6 +211,8 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
         return result.responseText;
       },
     });
+
+    hb.start();
     heartbeatManagers.push(hb);
     log.info(`Heartbeat enabled for "${agentFile.id}" (every ${agentFile.heartbeat.intervalSeconds ?? 300}s)`);
   }

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -197,7 +197,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       runAgentLoop: async (agentId, prompt, _sessionKey) => {
         const cache = agentManager.get(agentId);
         if (!cache) throw new Error(`Agent "${agentId}" not found`);
-        const agentConfig = agentManager.getConfig(agentId);
         const store = await sessionStoreManager.getOrCreate(agentId);
         const sessionKey = `heartbeat:${agentId}`;
         const session = (await store.findByKey(sessionKey)) ?? (await store.create(agentId, { key: sessionKey }));
@@ -205,15 +204,13 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
           cache,
           sessionStore: store,
           sessionId: session.id,
-          systemPrompt: agentConfig?.systemPrompt ?? "",
+          systemPrompt: agentManager.getSystemPrompt(agentId) ?? "",
           textInput: prompt,
           log,
         });
         return result.responseText;
       },
     });
-
-    hb.start();
     heartbeatManagers.push(hb);
     log.info(`Heartbeat enabled for "${agentFile.id}" (every ${agentFile.heartbeat.intervalSeconds ?? 300}s)`);
   }
@@ -271,14 +268,13 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     log.info(`Cron executing "${job.name}" for agent "${job.agentId}" (session: ${sessionKey})`);
 
     try {
-      const agentConfig = agentManager.getConfig(job.agentId);
       const store = await sessionStoreManager.getOrCreate(job.agentId);
       const session = (await store.findByKey(sessionKey)) ?? (await store.create(job.agentId, { key: sessionKey }));
       const result = await runAgentLoop({
         cache,
         sessionStore: store,
         sessionId: session.id,
-        systemPrompt: agentConfig?.systemPrompt ?? "",
+        systemPrompt: agentManager.getSystemPrompt(job.agentId) ?? "",
         textInput: prompt,
         log,
       });

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -52,7 +52,8 @@ export function createMockAgentManager(cache?: AgentServiceCache): DefaultAgentM
   return {
     create: vi.fn(),
     get: vi.fn(() => mockCache),
-    getConfig: vi.fn(() => ({ systemPrompt: "test prompt" })),
+    getConfig: vi.fn(() => ({})),
+    getSystemPrompt: vi.fn(() => "test prompt"),
     list: vi.fn(() => []),
     update: vi.fn(),
     delete: vi.fn(),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -54,7 +54,6 @@ export interface ProviderConfig {
 /** Complete configuration needed to create an {@link AgentInstance}. */
 export interface AgentConfig {
   id: string;
-  systemPrompt: string;
   tools?: Tool[];
   toolSettings?: AgentToolSettings;
   provider?: ProviderConfig;

--- a/src/subagent/runners/builtin.test.ts
+++ b/src/subagent/runners/builtin.test.ts
@@ -130,7 +130,6 @@ describe("BuiltinRunner", () => {
     expect(harness.setIds[0]).toMatch(/^subagent-builtin-task-2-/);
     expect(harness.clearedIds).toEqual(harness.setIds);
 
-    expect(harness.capturedConfig?.systemPrompt).toContain("do thing");
     expect(harness.capturedConfig?.compaction).toEqual({ mode: "off" });
     expect(harness.capturedConfig?.provider?.type).toBe("anthropic");
 

--- a/src/subagent/runners/builtin.ts
+++ b/src/subagent/runners/builtin.ts
@@ -73,7 +73,6 @@ export class BuiltinRunner implements SubagentRunner {
 
     const cache = this.core.createServiceCache({
       id: subagentId,
-      systemPrompt,
       provider: options.builtin.provider,
       compaction: { mode: "off" },
     });

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -669,7 +669,7 @@ describe("DiscordTransport", () => {
 
     it("routes /model to command handler", async () => {
       (agentManager.list as ReturnType<typeof vi.fn>).mockReturnValue([
-        { id: "default", systemPrompt: "", provider: { type: "anthropic", model: "claude-sonnet-4" } },
+        { id: "default", provider: { type: "anthropic", model: "claude-sonnet-4" } },
       ]);
 
       const transportWithAdmin = new DiscordTransport({

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -545,8 +545,7 @@ export class DiscordTransport implements Transport {
     await sessionStore.addMessage(session.id, userMsg);
 
     // 9. Run agent — SDK loads history from SessionManager automatically
-    const agentConfig = this.config.agentManager.getConfig(agentId);
-    const systemPrompt = agentConfig?.systemPrompt ?? "";
+    const systemPrompt = this.config.agentManager.getSystemPrompt(agentId) ?? "";
     await this.runAgentAndRespond(agent, session.id, sessionStore, systemPrompt, msg.channel as SendableChannel, msg.id);
   }
 

--- a/src/transports/feishu.ts
+++ b/src/transports/feishu.ts
@@ -415,8 +415,7 @@ export class FeishuTransport implements Transport {
     await this.config.sessionStore.addMessage(session.id, userMsg);
 
     // Run agent — SDK loads history from SessionManager automatically
-    const agentConfig = this.config.agentManager.getConfig?.(agentId);
-    const systemPrompt = agentConfig?.systemPrompt ?? "";
+    const systemPrompt = this.config.agentManager.getSystemPrompt?.(agentId) ?? "";
     await this.runAgentAndReply(agent, session.id, systemPrompt, message.chat_id);
   }
 

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -65,7 +65,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
       });
 
       cacheRef.current = result.instance;
-      systemPromptRef.current = result.agentConfig.systemPrompt;
+      systemPromptRef.current = result.systemPrompt;
       sessionManagerRef.current = SessionManager.inMemory();
       setAgentReady(true);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Remove `systemPrompt` from `AgentConfig` interface — it was always `""` from config and immediately overwritten by workspace assembly
- Move system prompt ownership to `AgentEntry` in `DefaultAgentManager` with `initialSystemPrompt` create option
- Add `getSystemPrompt(id)` method on `DefaultAgentManager` for external callers
- Update all consumers (chat API, Discord, Feishu, TUI, runtime) to use `agentManager.getSystemPrompt()` instead of `agentConfig.systemPrompt`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 1343 tests pass
- [ ] Manual: `pnpm dev` → verify agent responds with workspace context (SOUL.md, IDENTITY.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)