### PR TITLE
fix(discord): prevent session corruption on LLM connection error

### DIFF
--- a/src/core/usage-tracker.ts
+++ b/src/core/usage-tracker.ts
@@ -57,7 +57,6 @@ export class UsageTracker {
 }
 
 function accumulate(acc: AccumulatedUsage, usage: Usage): void {
-  if (!usage) return;
   acc.totalTokens += usage.totalTokens;
   acc.input += usage.input;
   acc.output += usage.output;

--- a/src/core/usage-tracker.ts
+++ b/src/core/usage-tracker.ts
@@ -57,6 +57,7 @@ export class UsageTracker {
 }
 
 function accumulate(acc: AccumulatedUsage, usage: Usage): void {
+  if (!usage) return;
   acc.totalTokens += usage.totalTokens;
   acc.input += usage.input;
   acc.output += usage.output;

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -20,7 +20,7 @@ import {
 } from "../core/types.js";
 import type { AgentServiceCache } from "../core/pi-mono.js";
 import type { DefaultAgentManager } from "../core/agent-manager.js";
-import { userMessage as mkUserMsg, assistantMessage as mkAssistantMsg } from "../core/messages.js";
+import { userMessage as mkUserMsg } from "../core/messages.js";
 import type { ContextConfigFile } from "../core/config.js";
 import { shouldRespondToMessage } from "../core/mention.js";
 import { loggers } from "../core/logger.js";
@@ -913,7 +913,6 @@ export class DiscordTransport implements Transport {
 
       if (errorMessage) {
         const finalErrorMessage = `❌ ${errorMessage}`;
-        await sessionStore.addMessage(sessionId, mkAssistantMsg(finalErrorMessage));
         await channel.send(finalErrorMessage);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- When the LLM endpoint returns a connection error, the SDK already persists an assistant error message to the session JSONL. The Discord transport then appended a **second** synthetic assistant message (`❌ ...`), creating two consecutive assistant messages that break user/assistant alternation. This corrupted the session permanently — all subsequent prompts crash with `Cannot read properties of undefined (reading 'totalTokens')`, even after fixing the endpoint.
- Removed the `addMessage` call so the error text is only sent to Discord without being persisted
- Added a defensive guard in `UsageTracker.accumulate()` to handle undefined usage gracefully

## Test plan
- [x] `pnpm test` — usage-tracker and discord transport tests pass
- [ ] Reproduce: configure a bad LLM endpoint, send a message, fix endpoint, verify session recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)