### PR TITLE
fix(core): pass agent workspace path as cwd to agent sessions

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -132,12 +132,14 @@ addRoute("POST", "/api/chat/sessions/:id/message", async (req, res, deps) => {
 
   try {
     const systemPrompt = deps.agentManager.getSystemPrompt?.(session.agentId) ?? "";
+    const cwd = deps.agentManager.getWorkspacePath?.(session.agentId);
     let lastTextLen = 0;
     const result = await runAgentLoop({
       cache,
       sessionStore: store,
       sessionId,
       systemPrompt,
+      cwd,
       textInput: body.message,
       log,
       onTextDelta: (currentText) => {

--- a/src/core/agent-manager.test.ts
+++ b/src/core/agent-manager.test.ts
@@ -151,6 +151,17 @@ describe("DefaultAgentManager", () => {
     });
   });
 
+  describe("getWorkspacePath", () => {
+    it("returns workspacePath for an existing agent", async () => {
+      await manager.create(makeConfig(), { workspacePath: "/home/agent" });
+      expect(manager.getWorkspacePath("test-agent")).toBe("/home/agent");
+    });
+
+    it("returns undefined for unknown agent", () => {
+      expect(manager.getWorkspacePath("non-existent")).toBeUndefined();
+    });
+  });
+
   describe("getPrompt / updatePrompt", () => {
     it("getPrompt returns system prompt", async () => {
       await manager.create(makeConfig(), { initialSystemPrompt: "Hello world" });

--- a/src/core/agent-manager.ts
+++ b/src/core/agent-manager.ts
@@ -82,6 +82,10 @@ export class DefaultAgentManager {
     return this.agents.get(id)?.workspace ?? undefined;
   }
 
+  getWorkspacePath(id: string): string | undefined {
+    return this.agents.get(id)?.workspacePath;
+  }
+
   list(): AgentConfig[] {
     return Array.from(this.agents.values()).map((e) => e.config);
   }

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -57,8 +57,6 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
     cwd,
   });
 
-  log.debug(`Session started (id=${sessionId}, systemPrompt=${systemPrompt.length} chars)`, { systemPrompt });
-
   let responseText = "";
   let errorMessage: string | null = null;
   let activeSession: AgentSession | undefined = session;
@@ -123,8 +121,6 @@ export async function startAgentLoop(opts: RunAgentOptions): Promise<ActiveAgent
   }
 
   const session = await cache.createSession({ sessionManager, systemPrompt, cwd });
-
-  log.debug(`Session started (id=${sessionId}, systemPrompt=${systemPrompt.length} chars)`, { systemPrompt });
 
   const done = runSessionEvents(session, {
     textInput,

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -23,6 +23,7 @@ export interface RunAgentOptions {
   sessionStore: SessionStore;
   sessionId: string;
   systemPrompt: string;
+  cwd?: string;
   textInput?: string;
   log: Logger;
   onTextDelta?: OnTextDelta;
@@ -35,7 +36,7 @@ export interface RunAgentOptions {
 
 
 export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResult> {
-  const { cache, sessionStore, sessionId, systemPrompt, textInput, log, onTextDelta, onToolEvent, usageTracker, onToolComplete, agentId, hooks } = opts;
+  const { cache, sessionStore, sessionId, systemPrompt, cwd, textInput, log, onTextDelta, onToolEvent, usageTracker, onToolComplete, agentId, hooks } = opts;
 
   if (hooks && agentId && textInput) {
     await hooks.emit("message_received", {
@@ -53,7 +54,10 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
   const session = await cache.createSession({
     sessionManager,
     systemPrompt,
+    cwd,
   });
+
+  log.debug(`Session started (id=${sessionId}, systemPrompt=${systemPrompt.length} chars)`, { systemPrompt });
 
   let responseText = "";
   let errorMessage: string | null = null;
@@ -103,7 +107,7 @@ export interface ActiveAgentHandle {
  * The session is NOT disposed automatically — caller must dispose.
  */
 export async function startAgentLoop(opts: RunAgentOptions): Promise<ActiveAgentHandle> {
-  const { cache, sessionStore, sessionId, systemPrompt, textInput, log, onTextDelta, onToolEvent, usageTracker, onToolComplete, agentId, hooks } = opts;
+  const { cache, sessionStore, sessionId, systemPrompt, cwd, textInput, log, onTextDelta, onToolEvent, usageTracker, onToolComplete, agentId, hooks } = opts;
 
   if (hooks && agentId && textInput) {
     await hooks.emit("message_received", {
@@ -118,7 +122,9 @@ export async function startAgentLoop(opts: RunAgentOptions): Promise<ActiveAgent
     throw new Error(`Session "${sessionId}" not found or has no SessionManager`);
   }
 
-  const session = await cache.createSession({ sessionManager, systemPrompt });
+  const session = await cache.createSession({ sessionManager, systemPrompt, cwd });
+
+  log.debug(`Session started (id=${sessionId}, systemPrompt=${systemPrompt.length} chars)`, { systemPrompt });
 
   const done = runSessionEvents(session, {
     textInput,

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -205,6 +205,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
           sessionStore: store,
           sessionId: session.id,
           systemPrompt: agentManager.getSystemPrompt(agentId) ?? "",
+          cwd: agentManager.getWorkspacePath(agentId),
           textInput: prompt,
           log,
         });
@@ -277,6 +278,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
         sessionStore: store,
         sessionId: session.id,
         systemPrompt: agentManager.getSystemPrompt(job.agentId) ?? "",
+        cwd: agentManager.getWorkspacePath(job.agentId),
         textInput: prompt,
         log,
       });

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -54,6 +54,7 @@ export function createMockAgentManager(cache?: AgentServiceCache): DefaultAgentM
     get: vi.fn(() => mockCache),
     getConfig: vi.fn(() => ({})),
     getSystemPrompt: vi.fn(() => "test prompt"),
+    getWorkspacePath: vi.fn(() => undefined),
     list: vi.fn(() => []),
     update: vi.fn(),
     delete: vi.fn(),

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -167,10 +167,11 @@ describe("DiscordTransport", () => {
             sessionId: string,
             sessionStore: SessionStore,
             systemPrompt: string,
+            cwd: string | undefined,
             channel: MockChannel,
           ) => Promise<void>;
         }
-      ).runAgentAndRespond(erroringAgent, "session-123", sessionStore, "", channel);
+      ).runAgentAndRespond(erroringAgent, "session-123", sessionStore, "", undefined, channel);
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Agent ended with error: No API provider registered for api: undefined"),

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -546,7 +546,7 @@ export class DiscordTransport implements Transport {
 
     // 9. Run agent — SDK loads history from SessionManager automatically
     const systemPrompt = this.config.agentManager.getSystemPrompt(agentId) ?? "";
-    const cwd = this.config.agentManager.getWorkspacePath?.(agentId);
+    const cwd = this.config.agentManager.getWorkspacePath(agentId);
     await this.runAgentAndRespond(agent, session.id, sessionStore, systemPrompt, cwd, msg.channel as SendableChannel, msg.id);
   }
 

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -546,7 +546,8 @@ export class DiscordTransport implements Transport {
 
     // 9. Run agent — SDK loads history from SessionManager automatically
     const systemPrompt = this.config.agentManager.getSystemPrompt(agentId) ?? "";
-    await this.runAgentAndRespond(agent, session.id, sessionStore, systemPrompt, msg.channel as SendableChannel, msg.id);
+    const cwd = this.config.agentManager.getWorkspacePath?.(agentId);
+    await this.runAgentAndRespond(agent, session.id, sessionStore, systemPrompt, cwd, msg.channel as SendableChannel, msg.id);
   }
 
   private isDmAllowed(userId: string): boolean {
@@ -799,6 +800,7 @@ export class DiscordTransport implements Transport {
     sessionId: string,
     sessionStore: SessionStore,
     systemPrompt: string,
+    cwd: string | undefined,
     channel: SendableChannel,
     triggerMessageId?: string,
   ): Promise<void> {
@@ -844,6 +846,7 @@ export class DiscordTransport implements Transport {
           sessionStore,
           sessionId,
           systemPrompt,
+          cwd,
           log,
           onTextDelta: async (currentText) => {
             // Extract only the new delta text since last callback

--- a/src/transports/feishu.ts
+++ b/src/transports/feishu.ts
@@ -416,7 +416,7 @@ export class FeishuTransport implements Transport {
 
     // Run agent — SDK loads history from SessionManager automatically
     const systemPrompt = this.config.agentManager.getSystemPrompt?.(agentId) ?? "";
-    const cwd = this.config.agentManager.getWorkspacePath?.(agentId);
+    const cwd = this.config.agentManager.getWorkspacePath(agentId);
     await this.runAgentAndReply(agent, session.id, systemPrompt, cwd, message.chat_id);
   }
 

--- a/src/transports/feishu.ts
+++ b/src/transports/feishu.ts
@@ -416,7 +416,8 @@ export class FeishuTransport implements Transport {
 
     // Run agent — SDK loads history from SessionManager automatically
     const systemPrompt = this.config.agentManager.getSystemPrompt?.(agentId) ?? "";
-    await this.runAgentAndReply(agent, session.id, systemPrompt, message.chat_id);
+    const cwd = this.config.agentManager.getWorkspacePath?.(agentId);
+    await this.runAgentAndReply(agent, session.id, systemPrompt, cwd, message.chat_id);
   }
 
   private async findOrCreateSession(sessionKey: string, agentId: string) {
@@ -439,6 +440,7 @@ export class FeishuTransport implements Transport {
     cache: AgentServiceCache,
     sessionId: string,
     systemPrompt: string,
+    cwd: string | undefined,
     chatId: string,
   ): Promise<void> {
     try {
@@ -447,6 +449,7 @@ export class FeishuTransport implements Transport {
         sessionStore: this.config.sessionStore,
         sessionId,
         systemPrompt,
+        cwd,
         log,
         usageTracker: this.config.usageTracker,
       });


### PR DESCRIPTION
## Summary
- All agent entry points (chat API, Discord, Feishu, cron, heartbeat) defaulted to `process.cwd()` instead of the agent's configured workspace path, causing agents to operate in the wrong directory
- Added `cwd` to `RunAgentOptions` and piped it through `createSession` in all callers
- Added `getWorkspacePath()` to `DefaultAgentManager` for convenient access

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1343 tests)
- [x] Updated `discord.test.ts` for new `runAgentAndRespond` signature
- [ ] Manual: verify pet plugin agent sees correct workspace via web UI chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)