### PR TITLE
chore: bump version to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ghostcomplex/isotopes",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Lightweight, self-hostable AI agent framework",
   "type": "module",
   "bin": {

--- a/src/tui/api.test.ts
+++ b/src/tui/api.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 
 describe("fetchStatus", () => {
   it("returns parsed status", async () => {
-    const data = { version: "0.0.2", uptime: 123, cronJobs: 2 };
+    const data = { version: "0.1.0", uptime: 123, cronJobs: 2 };
     mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(data) });
     const result = await fetchStatus();
     expect(result).toEqual(data);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.0.2";
+export const VERSION = "0.1.0";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,6 @@
-export const VERSION = "0.1.0";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+export const VERSION = pkg.version;


### PR DESCRIPTION
## Summary
- Bump package version from 0.0.2 to 0.1.0 for first public npm release

## Context
Relates to #260 — all package.json fields (`name`, `bin`, `files`, `publishConfig`) and README install instructions are already in place. This is the version bump before `npm publish`.

## Test plan
- [ ] `pnpm build` succeeds
- [ ] `npm pack --dry-run` includes expected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)