### PR TITLE
feat(api): support session resumption via sessionKey

### DIFF
--- a/src/api/chat.test.ts
+++ b/src/api/chat.test.ts
@@ -1,0 +1,131 @@
+// src/api/chat.test.ts — Unit tests for chat session creation with sessionKey
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import { ApiServer } from "./server.js";
+import { CronScheduler } from "../automation/cron-job.js";
+import { createMockAgentManager } from "../core/test-helpers.js";
+import { SessionStoreManager } from "../core/session-store-manager.js";
+
+function request(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; data: unknown }> {
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method,
+        headers: {
+          ...(payload
+            ? {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(payload),
+              }
+            : {}),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf-8");
+          let data: unknown;
+          try {
+            data = JSON.parse(raw);
+          } catch {
+            data = raw;
+          }
+          resolve({ status: res.statusCode ?? 0, data });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+describe("POST /api/chat/sessions — sessionKey", () => {
+  let server: ApiServer;
+  let agentManager: ReturnType<typeof createMockAgentManager>;
+  let sessionStoreManager: SessionStoreManager;
+
+  beforeEach(async () => {
+    agentManager = createMockAgentManager();
+    sessionStoreManager = new SessionStoreManager();
+    server = new ApiServer(
+      { port: 0 },
+      { cronScheduler: new CronScheduler(), agentManager, sessionStoreManager },
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  function getPort(): number {
+    const addr = server.address();
+    if (!addr) throw new Error("Server not listening");
+    return addr.port;
+  }
+
+  function agentId(): string {
+    return agentManager.list()[0]?.id ?? "mock";
+  }
+
+  it("creates a new session without sessionKey (default path)", async () => {
+    const { status, data } = await request(getPort(), "POST", "/api/chat/sessions", {
+      agentId: agentId(),
+    });
+    expect(status).toBe(201);
+    const body = data as { sessionId: string; agentId: string; resumed: boolean };
+    expect(body.sessionId).toBeTruthy();
+    expect(body.resumed).toBe(false);
+  });
+
+  it("resumes an existing session when same sessionKey is provided", async () => {
+    const key = "pet:testbot";
+    const first = await request(getPort(), "POST", "/api/chat/sessions", {
+      agentId: agentId(),
+      sessionKey: key,
+    });
+    expect(first.status).toBe(201);
+    const firstBody = first.data as { sessionId: string; resumed: boolean };
+    expect(firstBody.resumed).toBe(false);
+
+    const second = await request(getPort(), "POST", "/api/chat/sessions", {
+      agentId: agentId(),
+      sessionKey: key,
+    });
+    expect(second.status).toBe(200);
+    const secondBody = second.data as { sessionId: string; resumed: boolean };
+    expect(secondBody.resumed).toBe(true);
+    expect(secondBody.sessionId).toBe(firstBody.sessionId);
+  });
+
+  it("returns 400 for invalid sessionKey format", async () => {
+    const { status, data } = await request(getPort(), "POST", "/api/chat/sessions", {
+      agentId: agentId(),
+      sessionKey: "no-colon-here",
+    });
+    expect(status).toBe(400);
+    expect((data as { error: string }).error).toContain("Invalid sessionKey format");
+  });
+
+  it("returns 400 for sessionKey exceeding max length", async () => {
+    const longKey = "a".repeat(100) + ":" + "b".repeat(100);
+    const { status, data } = await request(getPort(), "POST", "/api/chat/sessions", {
+      agentId: agentId(),
+      sessionKey: longKey,
+    });
+    expect(status).toBe(400);
+    expect((data as { error: string }).error).toContain("max length");
+  });
+});

--- a/src/api/chat.test.ts
+++ b/src/api/chat.test.ts
@@ -91,7 +91,7 @@ describe("POST /api/chat/sessions — sessionKey", () => {
   });
 
   it("resumes an existing session when same sessionKey is provided", async () => {
-    const key = "pet:testbot";
+    const key = `pet:test-${Date.now()}`;
     const first = await request(getPort(), "POST", "/api/chat/sessions", {
       agentId: agentId(),
       sessionKey: key,

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -13,7 +13,6 @@ const log = createLogger("api:chat");
 interface ChatSession {
   id: string;
   agentId: string;
-  createdAt: Date;
   lastActivity: number;
   abortController?: AbortController;
 }
@@ -86,13 +85,11 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
 
   let sessionId: string;
   let resumed = false;
-  let createdAt = new Date();
   if (deps.sessionStoreManager) {
     const store = await deps.sessionStoreManager.getOrCreate(agentId);
     const existing = await store.findByKey(sessionKey);
     if (existing) {
       sessionId = existing.id;
-      createdAt = existing.lastActiveAt ?? createdAt;
       resumed = true;
     } else {
       const session = await store.create(agentId, { key: sessionKey });
@@ -103,7 +100,7 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
   }
 
   evictStaleSessions();
-  chatSessions.set(sessionId, { id: sessionId, agentId, createdAt, lastActivity: Date.now() });
+  chatSessions.set(sessionId, { id: sessionId, agentId, lastActivity: Date.now() });
 
   log.info(`Chat session ${resumed ? "resumed" : "created"}: ${sessionId} (agent: ${agentId}, key: ${sessionKey})`);
   sendJson(res, resumed ? 200 : 201, { sessionId, agentId, resumed });

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -66,7 +66,18 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
     return;
   }
 
-  const sessionKey = body?.sessionKey ?? `chat:${agentId}:${randomUUID()}`;
+  const SESSION_KEY_RE = /^[a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+$/;
+
+  let sessionKey: string;
+  if (body?.sessionKey) {
+    if (!SESSION_KEY_RE.test(body.sessionKey)) {
+      sendError(res, 400, "Invalid sessionKey format — expected 'namespace:identifier'");
+      return;
+    }
+    sessionKey = `${agentId}:${body.sessionKey}`;
+  } else {
+    sessionKey = `chat:${agentId}:${randomUUID()}`;
+  }
 
   let sessionId: string;
   let resumed = false;

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -47,7 +47,7 @@ function evictStaleSessions() {
 // ---------------------------------------------------------------------------
 
 addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
-  const body = req.body as { agentId?: string } | undefined;
+  const body = req.body as { agentId?: string; sessionKey?: string } | undefined;
   if (!deps.agentManager) {
     sendError(res, 503, "Agent manager not available");
     return;
@@ -66,11 +66,20 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
     return;
   }
 
+  const sessionKey = body?.sessionKey ?? `chat:${agentId}:${randomUUID()}`;
+
   let sessionId: string;
+  let resumed = false;
   if (deps.sessionStoreManager) {
     const store = await deps.sessionStoreManager.getOrCreate(agentId);
-    const session = await store.create(agentId, { key: `chat:${agentId}:${randomUUID()}` });
-    sessionId = session.id;
+    const existing = await store.findByKey(sessionKey);
+    if (existing) {
+      sessionId = existing.id;
+      resumed = true;
+    } else {
+      const session = await store.create(agentId, { key: sessionKey });
+      sessionId = session.id;
+    }
   } else {
     sessionId = randomUUID();
   }
@@ -78,8 +87,8 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
   evictStaleSessions();
   chatSessions.set(sessionId, { id: sessionId, agentId, createdAt: new Date(), lastActivity: Date.now() });
 
-  log.info(`Chat session created: ${sessionId} (agent: ${agentId})`);
-  sendJson(res, 201, { sessionId, agentId });
+  log.info(`Chat session ${resumed ? "resumed" : "created"}: ${sessionId} (agent: ${agentId}, key: ${sessionKey})`);
+  sendJson(res, resumed ? 200 : 201, { sessionId, agentId, resumed });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -67,9 +67,14 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
   }
 
   const SESSION_KEY_RE = /^[a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+$/;
+  const SESSION_KEY_MAX_LEN = 128;
 
   let sessionKey: string;
   if (body?.sessionKey) {
+    if (body.sessionKey.length > SESSION_KEY_MAX_LEN) {
+      sendError(res, 400, `sessionKey exceeds max length of ${SESSION_KEY_MAX_LEN}`);
+      return;
+    }
     if (!SESSION_KEY_RE.test(body.sessionKey)) {
       sendError(res, 400, "Invalid sessionKey format — expected 'namespace:identifier'");
       return;
@@ -81,11 +86,13 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
 
   let sessionId: string;
   let resumed = false;
+  let createdAt = new Date();
   if (deps.sessionStoreManager) {
     const store = await deps.sessionStoreManager.getOrCreate(agentId);
     const existing = await store.findByKey(sessionKey);
     if (existing) {
       sessionId = existing.id;
+      createdAt = existing.lastActiveAt ?? createdAt;
       resumed = true;
     } else {
       const session = await store.create(agentId, { key: sessionKey });
@@ -96,7 +103,7 @@ addRoute("POST", "/api/chat/sessions", async (req, res, deps) => {
   }
 
   evictStaleSessions();
-  chatSessions.set(sessionId, { id: sessionId, agentId, createdAt: new Date(), lastActivity: Date.now() });
+  chatSessions.set(sessionId, { id: sessionId, agentId, createdAt, lastActivity: Date.now() });
 
   log.info(`Chat session ${resumed ? "resumed" : "created"}: ${sessionId} (agent: ${agentId}, key: ${sessionKey})`);
   sendJson(res, resumed ? 200 : 201, { sessionId, agentId, resumed });


### PR DESCRIPTION
## Summary
- `POST /api/chat/sessions` now accepts optional `sessionKey` field
- If a session with the same key already exists on disk, it resumes that session instead of creating a new one
- Enables persistent chat history across page reloads for the pet plugin (and any future WebUI)

## Test plan
- [ ] Create a session with `sessionKey: "test:1"`, send a message
- [ ] Call the same endpoint with the same key — verify it returns the existing session with `resumed: true`
- [ ] Verify `GET /api/chat/sessions/:id/messages` returns the previous history
- [ ] Without `sessionKey`, behavior is unchanged (random UUID key as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)