### PR TITLE
feat(discord): support image attachments

### DIFF
--- a/src/core/messages.test.ts
+++ b/src/core/messages.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { userMessage, userMessageWithImages, messageText } from "./messages.js";
+
+describe("userMessageWithImages", () => {
+  const images = [
+    { type: "image" as const, data: "base64data", mimeType: "image/png" },
+  ];
+
+  it("produces content array with text and image blocks", () => {
+    const msg = userMessageWithImages("hello", images, 1000);
+    const m = msg as unknown as { role: string; content: unknown[]; timestamp: number };
+
+    expect(m.role).toBe("user");
+    expect(m.timestamp).toBe(1000);
+    expect(m.content).toEqual([
+      { type: "text", text: "hello" },
+      { type: "image", data: "base64data", mimeType: "image/png" },
+    ]);
+  });
+
+  it("includes multiple images", () => {
+    const twoImages = [
+      { type: "image" as const, data: "img1", mimeType: "image/png" },
+      { type: "image" as const, data: "img2", mimeType: "image/jpeg" },
+    ];
+    const msg = userMessageWithImages("text", twoImages);
+    const m = msg as unknown as { content: unknown[] };
+
+    expect(m.content).toHaveLength(3);
+  });
+
+  it("messageText extracts text from multimodal message", () => {
+    const msg = userMessageWithImages("extracted", images);
+    expect(messageText(msg)).toBe("extracted");
+  });
+
+  it("messageText works on plain text user message", () => {
+    const msg = userMessage("plain");
+    expect(messageText(msg)).toBe("plain");
+  });
+});

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -5,8 +5,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 
-export type { ImageContent } from "@mariozechner/pi-ai";
-
 /** Create a user message with text content. */
 export function userMessage(text: string, timestamp?: number): AgentMessage {
   return { role: "user", content: text, timestamp: timestamp ?? Date.now() };
@@ -22,6 +20,8 @@ export function userMessageWithImages(
     role: "user",
     content: [{ type: "text" as const, text }, ...images],
     timestamp: timestamp ?? Date.now(),
+  // pi-agent-core's AgentMessage type doesn't expose pi-ai's multimodal content union;
+  // the runtime accepts it but the typedef is narrower — same pattern as assistantMessage/toolResultMessage.
   } as unknown as AgentMessage;
 }
 

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -3,10 +3,26 @@
 // with the pi-agent-core AgentMessage union.
 
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ImageContent } from "@mariozechner/pi-ai";
+
+export type { ImageContent } from "@mariozechner/pi-ai";
 
 /** Create a user message with text content. */
 export function userMessage(text: string, timestamp?: number): AgentMessage {
   return { role: "user", content: text, timestamp: timestamp ?? Date.now() };
+}
+
+/** Create a user message with text and image content blocks. */
+export function userMessageWithImages(
+  text: string,
+  images: ImageContent[],
+  timestamp?: number,
+): AgentMessage {
+  return {
+    role: "user",
+    content: [{ type: "text" as const, text }, ...images],
+    timestamp: timestamp ?? Date.now(),
+  } as unknown as AgentMessage;
 }
 
 /** Create an assistant message with text content. */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -10,7 +10,7 @@ import type { ReplyToMode } from "../transports/reply-directive.js";
 // ---------------------------------------------------------------------------
 
 export type { AgentMessage, AgentEvent } from "@mariozechner/pi-agent-core";
-export type { Usage } from "@mariozechner/pi-ai";
+export type { Usage, ImageContent } from "@mariozechner/pi-ai";
 
 // ---------------------------------------------------------------------------
 // Tools
@@ -341,7 +341,7 @@ export interface Transport {
   start(): Promise<void>;
   stop(): Promise<void>;
   /** Reply to a specific message by ID. If channelId is provided, skip O(n) channel scan. */
-  reply?(messageId: string, content: string, channelId?: string): Promise<{ messageId: string }>;
+  reply?(messageId: string, content: string, channelId?: string, attachments?: Array<{ buffer: Buffer; name: string }>): Promise<{ messageId: string }>;
   /** Add a reaction emoji to a specific message by ID. If channelId is provided, skip O(n) channel scan. */
   react?(messageId: string, emoji: string, channelId?: string): Promise<void>;
 }

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -1609,4 +1609,209 @@ describe("DiscordTransport", () => {
       await inFlight;
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Image attachment handling
+  // ---------------------------------------------------------------------------
+
+  describe("image attachments", () => {
+    function makeChannel(): MockChannel {
+      return {
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue({ edit: vi.fn().mockResolvedValue(undefined) }),
+        isThread: vi.fn().mockReturnValue(false),
+      };
+    }
+
+    function makeMsg(overrides: Partial<MockIncomingMessage> = {}): MockIncomingMessage {
+      return {
+        author: { bot: false, username: "tester", id: "user-1" },
+        content: "<@bot-123> hello",
+        createdTimestamp: Date.now(),
+        guild: { id: "guild-1" },
+        channelId: "channel-1",
+        channel: makeChannel(),
+        mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        attachments: new Map(),
+        thread: undefined,
+        id: `msg-${Date.now()}`,
+        ...overrides,
+      };
+    }
+
+    it("extracts image attachments and creates multimodal user message", async () => {
+      const sessionStore = createMockSessionStore();
+      const agentManager = createMockAgentManager();
+      const transport = new DiscordTransport({
+        groupAccess: { policy: "open" },
+        token: "test-token",
+        agentManager: agentManager as unknown as DefaultAgentManager,
+        sessionStore,
+        defaultAgentId: "default",
+      });
+      await transport.start();
+
+      const pngBytes = Buffer.from("fakepng");
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(pngBytes, { status: 200 }),
+      );
+
+      const attachments = new Map([
+        ["1", { contentType: "image/png", size: 100, url: "https://cdn.discord.com/img.png" }],
+      ]);
+
+      const msg = makeMsg({ attachments: attachments as Map<string, unknown> });
+      await (transport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      expect(fetchSpy).toHaveBeenCalledWith("https://cdn.discord.com/img.png");
+      expect(sessionStore.addMessage).toHaveBeenCalledWith(
+        "session-123",
+        expect.objectContaining({
+          role: "user",
+          content: expect.arrayContaining([
+            expect.objectContaining({ type: "text" }),
+            expect.objectContaining({ type: "image", data: pngBytes.toString("base64"), mimeType: "image/png" }),
+          ]),
+        }),
+      );
+
+      fetchSpy.mockRestore();
+    });
+
+    it("skips oversized attachments (>10MB)", async () => {
+      const sessionStore = createMockSessionStore();
+      const agentManager = createMockAgentManager();
+      const transport = new DiscordTransport({
+        groupAccess: { policy: "open" },
+        token: "test-token",
+        agentManager: agentManager as unknown as DefaultAgentManager,
+        sessionStore,
+        defaultAgentId: "default",
+      });
+      await transport.start();
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      const attachments = new Map([
+        ["1", { contentType: "image/png", size: 11 * 1024 * 1024, url: "https://cdn.discord.com/big.png" }],
+      ]);
+
+      const msg = makeMsg({ attachments: attachments as Map<string, unknown> });
+      await (transport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // Should still create a plain string message (no images extracted)
+      expect(sessionStore.addMessage).toHaveBeenCalledWith(
+        "session-123",
+        expect.objectContaining({
+          role: "user",
+          content: expect.any(String),
+        }),
+      );
+
+      fetchSpy.mockRestore();
+    });
+
+    it("skips non-image attachments", async () => {
+      const sessionStore = createMockSessionStore();
+      const agentManager = createMockAgentManager();
+      const transport = new DiscordTransport({
+        groupAccess: { policy: "open" },
+        token: "test-token",
+        agentManager: agentManager as unknown as DefaultAgentManager,
+        sessionStore,
+        defaultAgentId: "default",
+      });
+      await transport.start();
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      const attachments = new Map([
+        ["1", { contentType: "application/pdf", size: 1000, url: "https://cdn.discord.com/doc.pdf" }],
+      ]);
+
+      const msg = makeMsg({ attachments: attachments as Map<string, unknown> });
+      await (transport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(sessionStore.addMessage).toHaveBeenCalledWith(
+        "session-123",
+        expect.objectContaining({
+          role: "user",
+          content: expect.any(String),
+        }),
+      );
+
+      fetchSpy.mockRestore();
+    });
+
+    it("handles image-only messages (no text content)", async () => {
+      const sessionStore = createMockSessionStore();
+      const agentManager = createMockAgentManager();
+      const transport = new DiscordTransport({
+        groupAccess: { policy: "open" },
+        dmAccess: { policy: "allowlist", allowlist: ["user-1"] },
+        token: "test-token",
+        agentManager: agentManager as unknown as DefaultAgentManager,
+        sessionStore,
+        defaultAgentId: "default",
+      });
+      await transport.start();
+
+      const pngBytes = Buffer.from("fakepng");
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(pngBytes, { status: 200 }),
+      );
+
+      const attachments = new Map([
+        ["1", { contentType: "image/png", size: 100, url: "https://cdn.discord.com/img.png" }],
+      ]);
+
+      const msg = makeMsg({
+        content: "",
+        guild: null,
+        attachments: attachments as Map<string, unknown>,
+        mentions: { has: vi.fn(() => false) },
+      });
+      await (transport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      // Should NOT be silently dropped — sessionStore.addMessage should be called
+      expect(sessionStore.addMessage).toHaveBeenCalled();
+
+      fetchSpy.mockRestore();
+    });
+
+    it("gracefully handles fetch failure for an attachment", async () => {
+      const sessionStore = createMockSessionStore();
+      const agentManager = createMockAgentManager();
+      const transport = new DiscordTransport({
+        groupAccess: { policy: "open" },
+        token: "test-token",
+        agentManager: agentManager as unknown as DefaultAgentManager,
+        sessionStore,
+        defaultAgentId: "default",
+      });
+      await transport.start();
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("network error"));
+
+      const attachments = new Map([
+        ["1", { contentType: "image/png", size: 100, url: "https://cdn.discord.com/fail.png" }],
+      ]);
+
+      const msg = makeMsg({ attachments: attachments as Map<string, unknown> });
+      await (transport as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
+
+      // Should still process the message (just without images)
+      expect(sessionStore.addMessage).toHaveBeenCalledWith(
+        "session-123",
+        expect.objectContaining({
+          role: "user",
+          content: expect.any(String),
+        }),
+      );
+
+      fetchSpy.mockRestore();
+    });
+  });
 });

--- a/src/transports/discord.test.ts
+++ b/src/transports/discord.test.ts
@@ -25,6 +25,7 @@ type MockIncomingMessage = {
   channelId: string;
   channel: MockChannel;
   mentions: { has: ReturnType<typeof vi.fn> };
+  attachments: Map<string, unknown>;
   thread?: undefined;
   id?: string;
 };
@@ -42,6 +43,7 @@ vi.mock("discord.js", () => {
   };
 
   return {
+    AttachmentBuilder: vi.fn(),
     Client: vi.fn(() => mockClient),
     GatewayIntentBits: {
       Guilds: 1,
@@ -211,6 +213,7 @@ describe("DiscordTransport", () => {
         channelId: "channel-1",
         channel,
         mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        attachments: new Map(),
         thread: undefined,
       };
 
@@ -251,6 +254,7 @@ describe("DiscordTransport", () => {
         channelId: "channel-1",
         channel: makeChannel(),
         mentions: { has: vi.fn(() => false) },
+        attachments: new Map(),
         thread: undefined,
         ...overrides,
       };
@@ -609,6 +613,7 @@ describe("DiscordTransport", () => {
         channelId: "channel-1",
         channel: makeChannel(),
         mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        attachments: new Map(),
         thread: undefined,
         id: `msg-${Date.now()}`,
         ...overrides,
@@ -791,6 +796,7 @@ describe("DiscordTransport", () => {
         channelId: "channel-1",
         channel: makeChannel(),
         mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        attachments: new Map(),
         thread: undefined,
         id: `msg-${Date.now()}`,
         ...overrides,
@@ -951,6 +957,7 @@ describe("DiscordTransport", () => {
         channelId: "channel-1",
         channel: makeChannel(),
         mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        attachments: new Map(),
         thread: undefined,
       };
 
@@ -1017,6 +1024,7 @@ describe("DiscordTransport", () => {
         channelId: "dm-channel",
         channel: { ...makeChannel(), type: 1 }, // DM channel type
         mentions: { has: vi.fn(() => false) },
+        attachments: new Map(),
         thread: undefined,
       };
 
@@ -1054,6 +1062,7 @@ describe("DiscordTransport", () => {
         channelId: "channel-1",
         channel: makeChannel(false),
         mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        attachments: new Map(),
         id: `msg-${Date.now()}`,
         ...overrides,
       };
@@ -1170,6 +1179,7 @@ describe("DiscordTransport", () => {
         channelId: "channel-1",
         channel: makeChannel(),
         mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        attachments: new Map(),
         thread: undefined,
         id: `msg-${Date.now()}`,
         ...overrides,
@@ -1367,6 +1377,7 @@ describe("DiscordTransport", () => {
         channelId: "channel-1",
         channel: makeChannel(),
         mentions: { has: vi.fn((id: string) => id === "bot-123") },
+        attachments: new Map(),
         thread: undefined,
         id: `msg-${Date.now()}`,
         ...overrides,

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -971,7 +971,10 @@ export class DiscordTransport implements Transport {
   }
 
   private hasImageAttachments(msg: DiscordMessage): boolean {
-    return msg.attachments.some((a) => a.contentType?.startsWith("image/"));
+    for (const [, a] of msg.attachments) {
+      if (a.contentType?.startsWith("image/")) return true;
+    }
+    return false;
   }
 
   private async extractAttachmentImages(msg: DiscordMessage): Promise<Array<{ type: "image"; data: string; mimeType: string }>> {
@@ -1011,10 +1014,11 @@ export class DiscordTransport implements Transport {
     replyToId?: string,
   ): Promise<void> {
     const files = attachments.map((a) => new AttachmentBuilder(a.buffer, { name: a.name }));
-    const chunks = text ? this.chunkMessage(text) : [""];
+    const chunks = text ? this.chunkMessage(text) : [undefined];
 
     for (let i = 0; i < chunks.length; i++) {
-      const opts: Record<string, unknown> = { content: chunks[i] || undefined };
+      const opts: Record<string, unknown> = {};
+      if (chunks[i]) opts.content = chunks[i];
       if (i === chunks.length - 1) opts.files = files;
       if (i === 0 && replyToId) opts.reply = { messageReference: replyToId, failIfNotExists: false };
       await channel.send(opts as Parameters<typeof channel.send>[0]);
@@ -1028,11 +1032,11 @@ export class DiscordTransport implements Transport {
   async reply(messageId: string, content: string, channelId?: string, attachments?: Array<{ buffer: Buffer; name: string }>): Promise<{ messageId: string }> {
     if (!this.ready) throw new Error("Discord transport not ready");
 
-    const files = attachments?.map((a) => new AttachmentBuilder(a.buffer, { name: a.name }));
-    const replyOpts = (text: string) => ({
-      content: text,
-      ...(files?.length ? { files } : {}),
-    });
+    const files = attachments?.length
+      ? attachments.map((a) => new AttachmentBuilder(a.buffer, { name: a.name }))
+      : undefined;
+
+    const replyPayload = { content, ...(files ? { files } : {}) };
 
     // Fast path: fetch the channel directly when channelId is provided
     if (channelId) {
@@ -1040,7 +1044,7 @@ export class DiscordTransport implements Transport {
         const channel = await this.client.channels.fetch(channelId);
         if (channel && "messages" in channel) {
           const target = await (channel as SendableChannel).messages.fetch(messageId);
-          const sent = await target.reply(replyOpts(content));
+          const sent = await target.reply(replyPayload);
           return { messageId: sent.id };
         }
       } catch {
@@ -1055,7 +1059,7 @@ export class DiscordTransport implements Transport {
       try {
         const target = await (ch as SendableChannel).messages.fetch(messageId);
         if (target) {
-          const sent = await target.reply(replyOpts(content));
+          const sent = await target.reply(replyPayload);
           return { messageId: sent.id };
         }
       } catch {

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -2,6 +2,7 @@
 // Handles Discord bot connection, message routing, and response streaming.
 
 import {
+  AttachmentBuilder,
   Client,
   GatewayIntentBits,
   Partials,
@@ -20,7 +21,7 @@ import {
 } from "../core/types.js";
 import type { AgentServiceCache } from "../core/pi-mono.js";
 import type { DefaultAgentManager } from "../core/agent-manager.js";
-import { userMessage as mkUserMsg } from "../core/messages.js";
+import { userMessage as mkUserMsg, userMessageWithImages as mkUserMsgWithImages } from "../core/messages.js";
 import type { ContextConfigFile } from "../core/config.js";
 import { shouldRespondToMessage } from "../core/mention.js";
 import { loggers } from "../core/logger.js";
@@ -376,7 +377,7 @@ export class DiscordTransport implements Transport {
 
     // 3. Extract content early for subagent thread interception
     let content = this.extractContent(msg);
-    if (!content.trim()) return;
+    if (!content.trim() && !this.hasImageAttachments(msg)) return;
 
     // 3.5. Subagent thread interception — handle /stop in subagent threads BEFORE shouldRespond check
     // This allows /stop to work without @mention in subagent threads
@@ -536,12 +537,11 @@ export class DiscordTransport implements Transport {
     const chatType = msg.guild ? "group" : "direct";
     const inboundMeta = formatInboundMeta(messageMetadata, chatType);
     const contentWithMeta = `${inboundMeta}\n\n${enrichedContent}`;
-    
-    const userMsg: AgentMessage = {
-      role: "user",
-      content: contentWithMeta,
-      timestamp: msg.createdTimestamp,
-    } as unknown as AgentMessage;
+
+    const images = await this.extractAttachmentImages(msg);
+    const userMsg: AgentMessage = images.length > 0
+      ? mkUserMsgWithImages(contentWithMeta, images, msg.createdTimestamp)
+      : mkUserMsg(contentWithMeta, msg.createdTimestamp);
     await sessionStore.addMessage(session.id, userMsg);
 
     // 9. Run agent — SDK loads history from SessionManager automatically
@@ -970,12 +970,69 @@ export class DiscordTransport implements Transport {
       .trim();
   }
 
+  private hasImageAttachments(msg: DiscordMessage): boolean {
+    return msg.attachments.some((a) => a.contentType?.startsWith("image/"));
+  }
+
+  private async extractAttachmentImages(msg: DiscordMessage): Promise<Array<{ type: "image"; data: string; mimeType: string }>> {
+    const IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+    const MAX_BYTES = 10 * 1024 * 1024; // 10MB
+
+    const images: Array<{ type: "image"; data: string; mimeType: string }> = [];
+
+    for (const [, attachment] of msg.attachments) {
+      const ct = attachment.contentType;
+      if (!ct || !IMAGE_TYPES.has(ct)) continue;
+      if (attachment.size > MAX_BYTES) {
+        log.warn(`Skipping oversized image attachment (${attachment.size} bytes)`);
+        continue;
+      }
+
+      try {
+        const res = await fetch(attachment.url);
+        if (!res.ok) {
+          log.warn(`Failed to fetch attachment ${attachment.url}: ${res.status}`);
+          continue;
+        }
+        const buffer = Buffer.from(await res.arrayBuffer());
+        images.push({ type: "image", data: buffer.toString("base64"), mimeType: ct });
+      } catch (err) {
+        log.warn(`Error downloading attachment: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return images;
+  }
+
+  private async sendWithAttachments(
+    channel: SendableChannel,
+    text: string,
+    attachments: Array<{ buffer: Buffer; name: string }>,
+    replyToId?: string,
+  ): Promise<void> {
+    const files = attachments.map((a) => new AttachmentBuilder(a.buffer, { name: a.name }));
+    const chunks = text ? this.chunkMessage(text) : [""];
+
+    for (let i = 0; i < chunks.length; i++) {
+      const opts: Record<string, unknown> = { content: chunks[i] || undefined };
+      if (i === chunks.length - 1) opts.files = files;
+      if (i === 0 && replyToId) opts.reply = { messageReference: replyToId, failIfNotExists: false };
+      await channel.send(opts as Parameters<typeof channel.send>[0]);
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Reply & reaction
   // ---------------------------------------------------------------------------
 
-  async reply(messageId: string, content: string, channelId?: string): Promise<{ messageId: string }> {
+  async reply(messageId: string, content: string, channelId?: string, attachments?: Array<{ buffer: Buffer; name: string }>): Promise<{ messageId: string }> {
     if (!this.ready) throw new Error("Discord transport not ready");
+
+    const files = attachments?.map((a) => new AttachmentBuilder(a.buffer, { name: a.name }));
+    const replyOpts = (text: string) => ({
+      content: text,
+      ...(files?.length ? { files } : {}),
+    });
 
     // Fast path: fetch the channel directly when channelId is provided
     if (channelId) {
@@ -983,7 +1040,7 @@ export class DiscordTransport implements Transport {
         const channel = await this.client.channels.fetch(channelId);
         if (channel && "messages" in channel) {
           const target = await (channel as SendableChannel).messages.fetch(messageId);
-          const sent = await target.reply(content);
+          const sent = await target.reply(replyOpts(content));
           return { messageId: sent.id };
         }
       } catch {
@@ -998,7 +1055,7 @@ export class DiscordTransport implements Transport {
       try {
         const target = await (ch as SendableChannel).messages.fetch(messageId);
         if (target) {
-          const sent = await target.reply(content);
+          const sent = await target.reply(replyOpts(content));
           return { messageId: sent.id };
         }
       } catch {


### PR DESCRIPTION
## Summary
- **Inbound**: Extract image attachments from Discord messages, download from CDN, base64-encode, and pass to LLM as `ImageContent` blocks (the underlying `@mariozechner/pi-ai` SDK already supports multimodal `UserMessage.content`)
- **Outbound**: Add `sendWithAttachments()` helper using discord.js `AttachmentBuilder`, extend `Transport.reply()` to accept optional file attachments
- Image-only messages (no text, just an image) are no longer silently dropped

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes  
- [x] `pnpm test` — all 1349 tests pass
- [ ] Manual: send an image in Discord → agent acknowledges seeing it
- [ ] Manual: agent tool produces image → sent back as Discord attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)