### PR TITLE
feat(daemon): add process restart wrapper and API endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/cli.ts",
+    "dev:watch": "tsx src/daemon/wrapper.ts -- tsx src/cli.ts",
     "start": "node dist/cli.js",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -355,6 +355,27 @@ addRoute("GET", "/api/logs", async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /api/restart — trigger a graceful process restart
+// ---------------------------------------------------------------------------
+// Convention: exit code 75 (EX_TEMPFAIL) tells the wrapper process
+// (src/daemon/wrapper.ts) to restart the child. The wrapper monitors
+// the exit code and loops on 75, stopping on anything else.
+
+addRoute("POST", "/api/restart", (req, res) => {
+  // Only accept from localhost to prevent remote restarts.
+  const addr = req.socket.remoteAddress;
+  if (addr !== "127.0.0.1" && addr !== "::1" && addr !== "::ffff:127.0.0.1") {
+    sendError(res, 403, "Restart only allowed from localhost");
+    return;
+  }
+
+  sendJson(res, 200, { ok: true, message: "Restarting..." });
+
+  // Delay so the HTTP response has time to flush before we exit.
+  setTimeout(() => process.exit(75), 500);
+});
+
+// ---------------------------------------------------------------------------
 // GET /api/usage — global usage stats
 // ---------------------------------------------------------------------------
 

--- a/src/daemon/wrapper.ts
+++ b/src/daemon/wrapper.ts
@@ -1,0 +1,88 @@
+// src/daemon/wrapper.ts — Process restart wrapper for isotopes.
+// Spawns a child process and restarts it when it exits with code 75.
+// Exit code 75 (EX_TEMPFAIL from sysexits.h) is the restart convention
+// used by the POST /api/restart endpoint.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { createLogger } from "../core/logger.js";
+
+const log = createLogger("wrapper");
+
+/** Exit code that signals "restart the process". */
+const RESTART_EXIT_CODE = 75;
+
+/**
+ * Spawn `command` with `args`, inheriting stdio. Returns a promise that
+ * resolves with the child's exit code (or 1 on signal kill).
+ */
+function spawnChild(command: string, args: string[]): Promise<number> {
+  return new Promise((resolve) => {
+    const child: ChildProcess = spawn(command, args, {
+      stdio: "inherit",
+      // On Windows, spawn in a shell so .cmd/.bat scripts resolve correctly.
+      shell: process.platform === "win32",
+    });
+
+    // Forward SIGINT / SIGTERM to the child so it can shut down gracefully.
+    const forwardSignal = (signal: NodeJS.Signals) => {
+      if (child.pid) {
+        child.kill(signal);
+      }
+    };
+
+    process.on("SIGINT", forwardSignal);
+    process.on("SIGTERM", forwardSignal);
+
+    child.on("close", (code, signal) => {
+      process.removeListener("SIGINT", forwardSignal);
+      process.removeListener("SIGTERM", forwardSignal);
+
+      if (signal) {
+        log.info(`Child killed by signal ${signal}`);
+        resolve(1);
+      } else {
+        resolve(code ?? 1);
+      }
+    });
+  });
+}
+
+/**
+ * Run a command in a restart loop. The child is restarted whenever it exits
+ * with code {@link RESTART_EXIT_CODE} (75). Any other exit code stops the loop
+ * and is forwarded as this process's exit code.
+ */
+export async function runWithRestart(command: string, args: string[]): Promise<never> {
+  log.info(`Starting: ${command} ${args.join(" ")}`);
+
+  while (true) {
+    const exitCode = await spawnChild(command, args);
+
+    if (exitCode === RESTART_EXIT_CODE) {
+      log.info("Child exited with code 75 — restarting…");
+      continue;
+    }
+
+    log.info(`Child exited with code ${exitCode} — stopping.`);
+    process.exit(exitCode);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+// Usage: tsx src/daemon/wrapper.ts -- <command> [args...]
+// Everything after "--" is treated as the command + arguments to wrap.
+
+function main(): void {
+  const separatorIndex = process.argv.indexOf("--");
+  if (separatorIndex === -1 || separatorIndex === process.argv.length - 1) {
+    console.error("Usage: wrapper.ts -- <command> [args...]");
+    process.exit(1);
+  }
+
+  const [command, ...args] = process.argv.slice(separatorIndex + 1);
+  void runWithRestart(command, args);
+}
+
+main();


### PR DESCRIPTION
Add POST /api/restart (localhost-only) that exits with code 75 to signal the wrapper to restart the child process. Add wrapper.ts that monitors exit codes, restarts on 75, and forwards SIGINT/SIGTERM.

Also adds `dev:watch` npm script for development with auto-restart.