### PR TITLE
fix(core): log warning on event listener errors

### DIFF
--- a/src/core/agent-event-bus.ts
+++ b/src/core/agent-event-bus.ts
@@ -1,4 +1,7 @@
 import type { AgentEvent } from "./types.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("event-bus");
 
 type Listener = (event: AgentEvent) => void;
 
@@ -14,8 +17,8 @@ export class SessionEventEmitter {
     for (const fn of this.listeners) {
       try {
         fn(event);
-      } catch {
-        // error isolation: one listener must not break others
+      } catch (err) {
+        log.warn("Event listener threw", err);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace silent `catch {}` in `SessionEventEmitter.emit()` with `log.warn()` so listener exceptions are visible in logs instead of being swallowed.

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] Verify warn logs appear when a listener throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)