### PR TITLE
refactor(core): merge startAgentLoop into runAgentLoop with session registry

### DIFF
--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -11,10 +11,6 @@ import type { HookRegistry } from "../plugins/hooks.js";
 import { isAgentEvent } from "./agent-events.js";
 import { agentEventBus } from "./agent-event-bus.js";
 
-// ---------------------------------------------------------------------------
-// Active session registry — allows external abort/steer by sessionId
-// ---------------------------------------------------------------------------
-
 const activeSessions = new Map<string, AgentSession>();
 
 export function abortAgentSession(sessionId: string): boolean {
@@ -24,20 +20,9 @@ export function abortAgentSession(sessionId: string): boolean {
   return true;
 }
 
-export function steerAgentSession(sessionId: string, text: string): boolean {
-  const session = activeSessions.get(sessionId);
-  if (!session) return false;
-  void session.steer(text);
-  return true;
-}
-
 export function isAgentSessionActive(sessionId: string): boolean {
   return activeSessions.has(sessionId);
 }
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
 
 export interface AgentRunResult {
   responseText: string;

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -11,6 +11,34 @@ import type { HookRegistry } from "../plugins/hooks.js";
 import { isAgentEvent } from "./agent-events.js";
 import { agentEventBus } from "./agent-event-bus.js";
 
+// ---------------------------------------------------------------------------
+// Active session registry — allows external abort/steer by sessionId
+// ---------------------------------------------------------------------------
+
+const activeSessions = new Map<string, AgentSession>();
+
+export function abortAgentSession(sessionId: string): boolean {
+  const session = activeSessions.get(sessionId);
+  if (!session) return false;
+  session.abort();
+  return true;
+}
+
+export function steerAgentSession(sessionId: string, text: string): boolean {
+  const session = activeSessions.get(sessionId);
+  if (!session) return false;
+  void session.steer(text);
+  return true;
+}
+
+export function isAgentSessionActive(sessionId: string): boolean {
+  return activeSessions.has(sessionId);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 export interface AgentRunResult {
   responseText: string;
   errorMessage: string | null;
@@ -29,7 +57,6 @@ export interface RunAgentOptions {
   agentId?: string;
   hooks?: HookRegistry;
 }
-
 
 export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResult> {
   const { cache, sessionStore, sessionId, systemPrompt, cwd, textInput, log, usageTracker, onToolComplete, agentId, hooks } = opts;
@@ -53,9 +80,7 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
     cwd,
   });
 
-  let responseText = "";
-  let errorMessage: string | null = null;
-  let activeSession: AgentSession | undefined = session;
+  activeSessions.set(sessionId, session);
 
   try {
     const result = await runSessionEvents(session, {
@@ -65,64 +90,7 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<AgentRunResul
       sessionId,
       onToolComplete,
     });
-    responseText = result.responseText;
-    errorMessage = result.errorMessage;
 
-    if (hooks && agentId && responseText) {
-      await hooks.emit("message_sending", {
-        agentId,
-        sessionId,
-        message: assistantMessage(responseText),
-      });
-    }
-
-    if (hooks && agentId) {
-      await hooks.emit("agent_end", { agentId, stopReason: errorMessage ? "error" : "end" });
-    }
-  } finally {
-    activeSession?.dispose();
-    activeSession = undefined;
-  }
-
-  return { responseText, errorMessage };
-}
-
-/** Returned handle for callers that need to steer/abort a running session */
-export interface ActiveAgentHandle {
-  session: AgentSession;
-  done: Promise<AgentRunResult>;
-  abort(): void;
-}
-
-/**
- * Start an agent loop and return a handle for mid-run control (steer, abort).
- * The session is NOT disposed automatically — caller must dispose.
- */
-export async function startAgentLoop(opts: RunAgentOptions): Promise<ActiveAgentHandle> {
-  const { cache, sessionStore, sessionId, systemPrompt, cwd, textInput, log, usageTracker, onToolComplete, agentId, hooks } = opts;
-
-  if (hooks && agentId && textInput) {
-    await hooks.emit("message_received", {
-      agentId,
-      sessionId,
-      message: userMessage(textInput),
-    });
-  }
-
-  const sessionManager = await sessionStore.getSessionManager(sessionId);
-  if (!sessionManager) {
-    throw new Error(`Session "${sessionId}" not found or has no SessionManager`);
-  }
-
-  const session = await cache.createSession({ sessionManager, systemPrompt, cwd });
-
-  const done = runSessionEvents(session, {
-    textInput,
-    log,
-    usageTracker,
-    sessionId,
-    onToolComplete,
-  }).then(async (result) => {
     if (hooks && agentId && result.responseText) {
       await hooks.emit("message_sending", {
         agentId,
@@ -130,17 +98,16 @@ export async function startAgentLoop(opts: RunAgentOptions): Promise<ActiveAgent
         message: assistantMessage(result.responseText),
       });
     }
+
     if (hooks && agentId) {
       await hooks.emit("agent_end", { agentId, stopReason: result.errorMessage ? "error" : "end" });
     }
-    return result;
-  });
 
-  return {
-    session,
-    done,
-    abort: () => session.abort(),
-  };
+    return result;
+  } finally {
+    activeSessions.delete(sessionId);
+    session.dispose();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -26,7 +26,7 @@ import type { ContextConfigFile } from "../core/config.js";
 import { shouldRespondToMessage } from "../core/mention.js";
 import { loggers } from "../core/logger.js";
 import { ThreadBindingManager } from "../core/thread-bindings.js";
-import { startAgentLoop, type ActiveAgentHandle } from "../core/agent-runner.js";
+import { runAgentLoop, abortAgentSession, isAgentSessionActive } from "../core/agent-runner.js";
 import { agentEventBus } from "../core/agent-event-bus.js";
 import { isSilentReply } from "./silent-reply.js";
 import { extractDiscordMetadata, formatInboundMeta } from "./message-metadata.js";
@@ -219,8 +219,8 @@ export class DiscordTransport implements Transport {
   private debouncer: InboundDebouncer;
   private commandHandler: SlashCommandHandler;
 
-  // Track which sessions are currently in a prompt turn
-  private activeHandles = new Map<string, ActiveAgentHandle>();
+  // Track which sessions are currently in a prompt turn (for /stop and pending message buffering)
+  private activeSessions = new Set<string>();
   // Buffer messages that arrive while a session is prompting
   private pendingMessages = new Map<string, Array<{ content: string; sender: string; timestamp: number }>>();
 
@@ -409,15 +409,12 @@ export class DiscordTransport implements Transport {
       const sessionStore = this.getSessionStore(agentId);
       const sessionKey = this.getSessionKey(msg, agentId);
       const session = await sessionStore.findByKey(sessionKey);
-      if (session && this.activeHandles.has(session.id)) {
-        const handle = this.activeHandles.get(session.id);
-        if (handle) {
-          log.info(`Main-agent /stop`, { sessionId: session.id, agentId });
-          handle.abort();
-          this.pendingMessages.delete(session.id);
-          await (msg.channel as SendableChannel).send("🛑 Stopped.");
-          return;
-        }
+      if (session && isAgentSessionActive(session.id)) {
+        log.info(`Main-agent /stop`, { sessionId: session.id, agentId });
+        abortAgentSession(session.id);
+        this.pendingMessages.delete(session.id);
+        await (msg.channel as SendableChannel).send("🛑 Stopped.");
+        return;
       }
       return;
     }
@@ -514,7 +511,7 @@ export class DiscordTransport implements Transport {
     // 6.5. If session is currently active (in a prompt turn), buffer this message instead.
     // The buffer is drained at turn_end via onToolComplete, where each message is
     // also persisted to SessionStore so future prompt() invocations replay them.
-    if (this.activeHandles.has(session.id)) {
+    if (this.activeSessions.has(session.id)) {
       log.debug(`Session ${session.id} is active, buffering message from ${msg.author.username}`);
       const pending = this.pendingMessages.get(session.id) ?? [];
       pending.push({
@@ -855,8 +852,9 @@ export class DiscordTransport implements Transport {
       });
 
       // Create the agent loop runner function
-      const runLoop = async () => {
-        const handle = await startAgentLoop({
+      const runLoop = () => {
+        this.activeSessions.add(sessionId);
+        return runAgentLoop({
           cache,
           sessionStore,
           sessionId,
@@ -883,12 +881,6 @@ export class DiscordTransport implements Transport {
             return `[Messages arrived while you were working]\n${formatted}`;
           },
         });
-        this.activeHandles.set(sessionId, handle);
-        try {
-          return await handle.done;
-        } finally {
-          handle.session.dispose();
-        }
       };
 
       // Run with or without subagent context based on config
@@ -940,7 +932,7 @@ export class DiscordTransport implements Transport {
       unsubBus();
       agentEventBus.removeSession(sessionId);
       typing.stop();
-      this.activeHandles.delete(sessionId);
+      this.activeSessions.delete(sessionId);
       this.pendingMessages.delete(sessionId);
     }
   }

--- a/src/transports/discord.ts
+++ b/src/transports/discord.ts
@@ -219,8 +219,6 @@ export class DiscordTransport implements Transport {
   private debouncer: InboundDebouncer;
   private commandHandler: SlashCommandHandler;
 
-  // Track which sessions are currently in a prompt turn (for /stop and pending message buffering)
-  private activeSessions = new Set<string>();
   // Buffer messages that arrive while a session is prompting
   private pendingMessages = new Map<string, Array<{ content: string; sender: string; timestamp: number }>>();
 
@@ -511,7 +509,7 @@ export class DiscordTransport implements Transport {
     // 6.5. If session is currently active (in a prompt turn), buffer this message instead.
     // The buffer is drained at turn_end via onToolComplete, where each message is
     // also persisted to SessionStore so future prompt() invocations replay them.
-    if (this.activeSessions.has(session.id)) {
+    if (isAgentSessionActive(session.id)) {
       log.debug(`Session ${session.id} is active, buffering message from ${msg.author.username}`);
       const pending = this.pendingMessages.get(session.id) ?? [];
       pending.push({
@@ -853,7 +851,6 @@ export class DiscordTransport implements Transport {
 
       // Create the agent loop runner function
       const runLoop = () => {
-        this.activeSessions.add(sessionId);
         return runAgentLoop({
           cache,
           sessionStore,
@@ -932,7 +929,6 @@ export class DiscordTransport implements Transport {
       unsubBus();
       agentEventBus.removeSession(sessionId);
       typing.stop();
-      this.activeSessions.delete(sessionId);
       this.pendingMessages.delete(sessionId);
     }
   }


### PR DESCRIPTION
## Summary

- Merge `startAgentLoop` and `runAgentLoop` into a single `runAgentLoop` function, eliminating ~60 lines of duplicated code
- Add a module-level `activeSessions` registry (`Map<sessionId, AgentSession>`) with exported `abortAgentSession()`, `steerAgentSession()`, and `isAgentSessionActive()` helpers
- Discord transport no longer holds `ActiveAgentHandle` references — `/stop` uses `abortAgentSession(sessionId)` instead
- Session dispose is now always handled internally by `runAgentLoop` (no caller responsibility)

Follows the openclaw pattern: single entry point + global registry for external control by sessionId.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 1278 tests pass
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)