### PR TITLE
feat(agents): named-agent spawn mode with full identity load

### DIFF
--- a/src/agents/builtin/system-prompt.ts
+++ b/src/agents/builtin/system-prompt.ts
@@ -9,11 +9,7 @@ export function buildSpawnAgentSystemPrompt(options: BuildPromptOptions): string
 
   sections.push(
     "You are a subagent in the Isotopes framework — a generic helper " +
-      "spawned by another agent to handle one focused task. You are not " +
-      "Claude, ChatGPT, or any branded assistant; you have no name, no " +
-      "personality, and no continuity across calls. Your underlying model " +
-      "may vary; do not infer your identity from it. If asked who you " +
-      "are, say you're a subagent doing the task you were given.",
+      "spawned by another agent to handle one focused task.",
   );
 
   sections.push(

--- a/src/agents/builtin/system-prompt.ts
+++ b/src/agents/builtin/system-prompt.ts
@@ -8,7 +8,12 @@ export function buildSpawnAgentSystemPrompt(options: BuildPromptOptions): string
   const sections: string[] = [];
 
   sections.push(
-    "You are a focused agent spawned to complete a single task and then exit.",
+    "You are a subagent in the Isotopes framework — a generic helper " +
+      "spawned by another agent to handle one focused task. You are not " +
+      "Claude, ChatGPT, or any branded assistant; you have no name, no " +
+      "personality, and no continuity across calls. Your underlying model " +
+      "may vary; do not infer your identity from it. If asked who you " +
+      "are, say you're a subagent doing the task you were given.",
   );
 
   sections.push(
@@ -19,7 +24,7 @@ export function buildSpawnAgentSystemPrompt(options: BuildPromptOptions): string
 
   sections.push(
     "Be terse. Report findings or completion in plain text. Do not narrate plans before acting; " +
-      "just act and then summarize the result.",
+      "just act and then summarize the result. Do not greet, sign off, or refer to your model.",
   );
 
   sections.push("---");

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -3,7 +3,7 @@ export type {
   RunEvent,
   RunResult,
   RunOptions,
-  InProcessOptions,
+  BuiltinOptions,
   RunTask,
   OnCompleteCallback,
 } from "./types.js";

--- a/src/agents/runners/builtin.test.ts
+++ b/src/agents/runners/builtin.test.ts
@@ -337,4 +337,57 @@ describe("BuiltinRunner", () => {
       { type: "run:done", exitCode: 0 },
     ]);
   });
+
+  it("named mode: forwards abort signal to the underlying session", async () => {
+    interface FakeNamedSession {
+      _cb: ((event: { type: string }) => void) | null;
+      subscribe: ReturnType<typeof vi.fn>;
+      prompt: ReturnType<typeof vi.fn>;
+      abort: ReturnType<typeof vi.fn>;
+      dispose: ReturnType<typeof vi.fn>;
+      agent: { state: { systemPrompt: string } };
+    }
+    const namedSession: FakeNamedSession = {
+      _cb: null,
+      subscribe: vi.fn((cb: (event: { type: string }) => void) => {
+        namedSession._cb = cb;
+        return () => {};
+      }),
+      prompt: vi.fn(async () => {
+        // Emit agent_end so bridgeSessionToRunEvents terminates
+        if (namedSession._cb) namedSession._cb({ type: "agent_end", messages: [] } as never);
+      }),
+      abort: vi.fn(),
+      dispose: vi.fn(),
+      agent: { state: { systemPrompt: "" } },
+    };
+    const namedCache = {
+      createSession: vi.fn().mockResolvedValue(namedSession),
+    } as unknown as AgentServiceCache;
+    const core = {
+      setToolRegistry: vi.fn(),
+      clearToolRegistry: vi.fn(),
+      createServiceCache: vi.fn(),
+    } as unknown as PiMonoCore;
+    const runner = new BuiltinRunner(core);
+
+    const ac = new AbortController();
+    ac.abort();
+
+    await collect(
+      runner.run(
+        "task-named-abort",
+        {
+          agentId: "eous",
+          prompt: "p",
+          cwd: "/eous-workspace",
+          builtin: { mode: "named", cache: namedCache, systemPrompt: "I am eous." },
+        },
+        { abort: ac.signal },
+      ),
+    );
+
+    expect(namedSession.abort).toHaveBeenCalled();
+    expect(namedSession.dispose).toHaveBeenCalled();
+  });
 });

--- a/src/agents/runners/builtin.test.ts
+++ b/src/agents/runners/builtin.test.ts
@@ -272,15 +272,23 @@ describe("BuiltinRunner", () => {
       { type: "turn_end", message: {} as never, toolResults: [] } as AgentEvent,
       { type: "agent_end", messages: [] } as AgentEvent,
     ];
+    interface FakeNamedSession {
+      _cb: ((event: { type: string }) => void) | null;
+      subscribe: ReturnType<typeof vi.fn>;
+      prompt: ReturnType<typeof vi.fn>;
+      abort: ReturnType<typeof vi.fn>;
+      dispose: ReturnType<typeof vi.fn>;
+      agent: { state: { systemPrompt: string } };
+    }
     let capturedSystemPrompt: string | undefined;
-    const namedSession = {
+    const namedSession: FakeNamedSession = {
+      _cb: null,
       subscribe: vi.fn((cb: (event: { type: string }) => void) => {
-        (namedSession as unknown as Record<string, unknown>)._cb = cb;
+        namedSession._cb = cb;
         return () => {};
       }),
       prompt: vi.fn(async () => {
-        const cb = (namedSession as unknown as Record<string, (event: { type: string }) => void>)._cb;
-        if (cb) for (const e of events) cb(e);
+        if (namedSession._cb) for (const e of events) namedSession._cb(e);
       }),
       abort: vi.fn(),
       dispose: vi.fn(),

--- a/src/agents/runners/builtin.test.ts
+++ b/src/agents/runners/builtin.test.ts
@@ -86,7 +86,7 @@ async function collect(gen: AsyncGenerator<RunEvent>): Promise<RunEvent[]> {
 }
 
 describe("BuiltinRunner", () => {
-  it("yields error+done(1) when options.inProcess is missing", async () => {
+  it("yields error+done(1) when options.builtin is missing", async () => {
     const harness = makeCore([]);
     const runner = new BuiltinRunner(harness.core);
     const out = await collect(
@@ -117,14 +117,14 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "do thing",
           cwd: "/tmp",
-          inProcess: { mode: "ephemeral", provider: fakeProvider(), tools },
+          builtin: { mode: "ephemeral", provider: fakeProvider(), tools },
         },
         { abort: new AbortController().signal },
       ),
     );
 
     expect(harness.setIds).toHaveLength(1);
-    expect(harness.setIds[0]).toMatch(/^agent-inproc-task-2-/);
+    expect(harness.setIds[0]).toMatch(/^agent-builtin-task-2-/);
     expect(harness.clearedIds).toEqual(harness.setIds);
 
     expect(harness.capturedConfig?.compaction).toEqual({ mode: "off" });
@@ -152,7 +152,7 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "p",
           cwd: "/tmp",
-          inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+          builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
         },
         { abort: ac.signal },
       ),
@@ -172,7 +172,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-skip", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+        builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out).toEqual([{ type: "run:done", exitCode: 0 }]);
@@ -187,7 +187,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-tool", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+        builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out[0]).toEqual({ type: "run:tool_use", toolName: "shell", toolInput: { cmd: "ls" } });
@@ -203,7 +203,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-tresult", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+        builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out[0]).toEqual({ type: "run:tool_result", toolName: "test", toolResult: "ok" });
@@ -218,7 +218,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-err", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+        builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out).toEqual([
@@ -254,7 +254,7 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "p",
           cwd: "/tmp",
-          inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+          builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
         },
         { abort: new AbortController().signal },
       ),
@@ -313,7 +313,7 @@ describe("BuiltinRunner", () => {
           agentId: "eous",
           prompt: "who are you?",
           cwd: "/eous-workspace",
-          inProcess: { mode: "named", cache: namedCache, systemPrompt: "I am eous." },
+          builtin: { mode: "named", cache: namedCache, systemPrompt: "I am eous." },
         },
         { abort: new AbortController().signal },
       ),

--- a/src/agents/runners/builtin.test.ts
+++ b/src/agents/runners/builtin.test.ts
@@ -117,7 +117,7 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "do thing",
           cwd: "/tmp",
-          inProcess: { provider: fakeProvider(), tools },
+          inProcess: { mode: "ephemeral", provider: fakeProvider(), tools },
         },
         { abort: new AbortController().signal },
       ),
@@ -152,7 +152,7 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "p",
           cwd: "/tmp",
-          inProcess: { provider: fakeProvider(), tools: makeRegistry([]) },
+          inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
         },
         { abort: ac.signal },
       ),
@@ -172,7 +172,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-skip", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        inProcess: { provider: fakeProvider(), tools: makeRegistry([]) },
+        inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out).toEqual([{ type: "run:done", exitCode: 0 }]);
@@ -187,7 +187,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-tool", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        inProcess: { provider: fakeProvider(), tools: makeRegistry([]) },
+        inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out[0]).toEqual({ type: "run:tool_use", toolName: "shell", toolInput: { cmd: "ls" } });
@@ -203,7 +203,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-tresult", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        inProcess: { provider: fakeProvider(), tools: makeRegistry([]) },
+        inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out[0]).toEqual({ type: "run:tool_result", toolName: "test", toolResult: "ok" });
@@ -218,7 +218,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-err", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        inProcess: { provider: fakeProvider(), tools: makeRegistry([]) },
+        inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out).toEqual([
@@ -254,7 +254,7 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "p",
           cwd: "/tmp",
-          inProcess: { provider: fakeProvider(), tools: makeRegistry([]) },
+          inProcess: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
         },
         { abort: new AbortController().signal },
       ),
@@ -263,5 +263,70 @@ describe("BuiltinRunner", () => {
     expect(out.some((e) => e.type === "run:error")).toBe(true);
     expect(out.at(-1)).toEqual({ type: "run:done", exitCode: 1 });
     expect(clearedIds).toEqual(setIds);
+  });
+
+  it("named mode: uses the provided cache+systemPrompt and skips setToolRegistry", async () => {
+    const events: AgentEvent[] = [
+      { type: "turn_start" } as AgentEvent,
+      { type: "message_update", message: {} as never, assistantMessageEvent: { type: "text_delta", delta: "named-ok" } as never } as AgentEvent,
+      { type: "turn_end", message: {} as never, toolResults: [] } as AgentEvent,
+      { type: "agent_end", messages: [] } as AgentEvent,
+    ];
+    let capturedSystemPrompt: string | undefined;
+    const namedSession = {
+      subscribe: vi.fn((cb: (event: { type: string }) => void) => {
+        (namedSession as unknown as Record<string, unknown>)._cb = cb;
+        return () => {};
+      }),
+      prompt: vi.fn(async () => {
+        const cb = (namedSession as unknown as Record<string, (event: { type: string }) => void>)._cb;
+        if (cb) for (const e of events) cb(e);
+      }),
+      abort: vi.fn(),
+      dispose: vi.fn(),
+      agent: { state: { systemPrompt: "" } },
+    };
+    const namedCache = {
+      createSession: vi.fn().mockImplementation(async (opts: { systemPrompt: string }) => {
+        capturedSystemPrompt = opts.systemPrompt;
+        return namedSession;
+      }),
+    } as unknown as AgentServiceCache;
+
+    const setIds: string[] = [];
+    const clearedIds: string[] = [];
+    let createdServiceCache = false;
+    const core = {
+      setToolRegistry: (id: string) => setIds.push(id),
+      clearToolRegistry: (id: string) => clearedIds.push(id),
+      createServiceCache: () => {
+        createdServiceCache = true;
+        return {} as unknown as AgentServiceCache;
+      },
+    } as unknown as PiMonoCore;
+    const runner = new BuiltinRunner(core);
+
+    const out = await collect(
+      runner.run(
+        "task-named",
+        {
+          agentId: "eous",
+          prompt: "who are you?",
+          cwd: "/eous-workspace",
+          inProcess: { mode: "named", cache: namedCache, systemPrompt: "I am eous." },
+        },
+        { abort: new AbortController().signal },
+      ),
+    );
+
+    expect(capturedSystemPrompt).toBe("I am eous.");
+    expect(setIds).toEqual([]);
+    expect(clearedIds).toEqual([]);
+    expect(createdServiceCache).toBe(false);
+    expect(namedSession.dispose).toHaveBeenCalled();
+    expect(out).toEqual([
+      { type: "run:message", content: "named-ok" },
+      { type: "run:done", exitCode: 0 },
+    ]);
   });
 });

--- a/src/agents/runners/builtin.test.ts
+++ b/src/agents/runners/builtin.test.ts
@@ -117,7 +117,7 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "do thing",
           cwd: "/tmp",
-          builtin: { mode: "ephemeral", provider: fakeProvider(), tools },
+          builtin: { mode: "subagent", provider: fakeProvider(), tools },
         },
         { abort: new AbortController().signal },
       ),
@@ -152,7 +152,7 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "p",
           cwd: "/tmp",
-          builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+          builtin: { mode: "subagent", provider: fakeProvider(), tools: makeRegistry([]) },
         },
         { abort: ac.signal },
       ),
@@ -172,7 +172,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-skip", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+        builtin: { mode: "subagent", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out).toEqual([{ type: "run:done", exitCode: 0 }]);
@@ -187,7 +187,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-tool", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+        builtin: { mode: "subagent", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out[0]).toEqual({ type: "run:tool_use", toolName: "shell", toolInput: { cmd: "ls" } });
@@ -203,7 +203,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-tresult", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+        builtin: { mode: "subagent", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out[0]).toEqual({ type: "run:tool_result", toolName: "test", toolResult: "ok" });
@@ -218,7 +218,7 @@ describe("BuiltinRunner", () => {
     const out = await collect(
       runner.run("task-err", {
         agentId: "test-agent", prompt: "p", cwd: "/tmp",
-        builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+        builtin: { mode: "subagent", provider: fakeProvider(), tools: makeRegistry([]) },
       }, { abort: new AbortController().signal }),
     );
     expect(out).toEqual([
@@ -254,7 +254,7 @@ describe("BuiltinRunner", () => {
           agentId: "test-agent",
           prompt: "p",
           cwd: "/tmp",
-          builtin: { mode: "ephemeral", provider: fakeProvider(), tools: makeRegistry([]) },
+          builtin: { mode: "subagent", provider: fakeProvider(), tools: makeRegistry([]) },
         },
         { abort: new AbortController().signal },
       ),

--- a/src/agents/runners/builtin.ts
+++ b/src/agents/runners/builtin.ts
@@ -38,31 +38,31 @@ export class BuiltinRunner implements Runner {
     options: RunOptions,
     signals: RunnerSignals,
   ): AsyncGenerator<RunEvent> {
-    if (!options.inProcess) {
-      yield { type: "run:error", error: "builtin runner requires options.inProcess" };
+    if (!options.builtin) {
+      yield { type: "run:error", error: "builtin runner requires options.builtin" };
       yield { type: "run:done", exitCode: 1 };
       return;
     }
 
-    if (options.inProcess.mode === "named") {
-      yield* this.runNamed(runId, options, signals, options.inProcess);
+    if (options.builtin.mode === "named") {
+      yield* this.runNamed(runId, options, signals, options.builtin);
       return;
     }
 
-    yield* this.runEphemeral(runId, options, signals, options.inProcess);
+    yield* this.runEphemeral(runId, options, signals, options.builtin);
   }
 
   private async *runEphemeral(
     runId: string,
     options: RunOptions,
     signals: RunnerSignals,
-    inProcess: Extract<NonNullable<RunOptions["inProcess"]>, { mode: "ephemeral" }>,
+    builtin: Extract<NonNullable<RunOptions["builtin"]>, { mode: "ephemeral" }>,
   ): AsyncGenerator<RunEvent> {
-    const agentId = `agent-inproc-${runId}-${randomUUID().slice(0, 8)}`;
-    const tools = filterTools(inProcess.tools, agentId);
+    const agentId = `agent-builtin-${runId}-${randomUUID().slice(0, 8)}`;
+    const tools = filterTools(builtin.tools, agentId);
     const systemPrompt = buildSpawnAgentSystemPrompt({
       task: options.prompt,
-      extraSystemPrompt: inProcess.extraSystemPrompt,
+      extraSystemPrompt: builtin.extraSystemPrompt,
     });
 
     log.info("BuiltinRunner.run (ephemeral)", { runId, agentId, toolCount: tools.list().length });
@@ -71,7 +71,7 @@ export class BuiltinRunner implements Runner {
 
     const cache = this.core.createServiceCache({
       id: agentId,
-      provider: inProcess.provider,
+      provider: builtin.provider,
       compaction: { mode: "off" },
     });
 
@@ -98,14 +98,14 @@ export class BuiltinRunner implements Runner {
     runId: string,
     options: RunOptions,
     signals: RunnerSignals,
-    inProcess: Extract<NonNullable<RunOptions["inProcess"]>, { mode: "named" }>,
+    builtin: Extract<NonNullable<RunOptions["builtin"]>, { mode: "named" }>,
   ): AsyncGenerator<RunEvent> {
     log.info("BuiltinRunner.run (named)", { runId, agentId: options.agentId });
 
     const sessionManager = SessionManager.inMemory();
-    const session = await inProcess.cache.createSession({
+    const session = await builtin.cache.createSession({
       sessionManager,
-      systemPrompt: inProcess.systemPrompt,
+      systemPrompt: builtin.systemPrompt,
     });
 
     const onAbort = () => session.abort();

--- a/src/agents/runners/builtin.ts
+++ b/src/agents/runners/builtin.ts
@@ -44,20 +44,34 @@ export class BuiltinRunner implements Runner {
       return;
     }
 
+    if (options.inProcess.mode === "named") {
+      yield* this.runNamed(runId, options, signals, options.inProcess);
+      return;
+    }
+
+    yield* this.runEphemeral(runId, options, signals, options.inProcess);
+  }
+
+  private async *runEphemeral(
+    runId: string,
+    options: RunOptions,
+    signals: RunnerSignals,
+    inProcess: Extract<NonNullable<RunOptions["inProcess"]>, { mode: "ephemeral" }>,
+  ): AsyncGenerator<RunEvent> {
     const agentId = `agent-inproc-${runId}-${randomUUID().slice(0, 8)}`;
-    const tools = filterTools(options.inProcess.tools, agentId);
+    const tools = filterTools(inProcess.tools, agentId);
     const systemPrompt = buildSpawnAgentSystemPrompt({
       task: options.prompt,
-      extraSystemPrompt: options.inProcess.extraSystemPrompt,
+      extraSystemPrompt: inProcess.extraSystemPrompt,
     });
 
-    log.info("BuiltinRunner.run", { runId, agentId, toolCount: tools.list().length });
+    log.info("BuiltinRunner.run (ephemeral)", { runId, agentId, toolCount: tools.list().length });
 
     this.core.setToolRegistry(agentId, tools);
 
     const cache = this.core.createServiceCache({
       id: agentId,
-      provider: options.inProcess.provider,
+      provider: inProcess.provider,
       compaction: { mode: "off" },
     });
 
@@ -77,6 +91,32 @@ export class BuiltinRunner implements Runner {
       signals.abort.removeEventListener("abort", onAbort);
       session.dispose();
       this.core.clearToolRegistry(agentId);
+    }
+  }
+
+  private async *runNamed(
+    runId: string,
+    options: RunOptions,
+    signals: RunnerSignals,
+    inProcess: Extract<NonNullable<RunOptions["inProcess"]>, { mode: "named" }>,
+  ): AsyncGenerator<RunEvent> {
+    log.info("BuiltinRunner.run (named)", { runId, agentId: options.agentId });
+
+    const sessionManager = SessionManager.inMemory();
+    const session = await inProcess.cache.createSession({
+      sessionManager,
+      systemPrompt: inProcess.systemPrompt,
+    });
+
+    const onAbort = () => session.abort();
+    signals.abort.addEventListener("abort", onAbort, { once: true });
+    if (signals.abort.aborted) session.abort();
+
+    try {
+      yield* bridgeSessionToRunEvents(session, options.prompt);
+    } finally {
+      signals.abort.removeEventListener("abort", onAbort);
+      session.dispose();
     }
   }
 }

--- a/src/agents/runners/builtin.ts
+++ b/src/agents/runners/builtin.ts
@@ -69,6 +69,13 @@ export class BuiltinRunner implements Runner {
 
     this.core.setToolRegistry(agentId, tools);
 
+    // Compaction is intentionally OFF for ephemeral spawns: the system
+    // prompt steers the agent toward terse single-shot tasks, there's no
+    // SOUL/MEMORY identity worth preserving across compactions, and
+    // compaction would add LLM-call overhead that defeats the
+    // fire-and-forget premise. Long ephemeral runs that overflow context
+    // will fail loudly — that's a signal the task should use a named
+    // agent or Claude CLI instead. See issue #585 for making this opt-in.
     const cache = this.core.createServiceCache({
       id: agentId,
       provider: builtin.provider,

--- a/src/agents/runners/builtin.ts
+++ b/src/agents/runners/builtin.ts
@@ -102,6 +102,14 @@ export class BuiltinRunner implements Runner {
   ): AsyncGenerator<RunEvent> {
     log.info("BuiltinRunner.run (named)", { runId, agentId: options.agentId });
 
+    // Reuses the named agent's existing AgentServiceCache. The cache is
+    // immutable after construction (model/authStorage/modelRegistry/
+    // compactionConfig/customTools are set once), and `createSession`
+    // builds a fresh settingsManager per call — so concurrent spawns of
+    // the same named agent (or a spawn racing with direct user chat) are
+    // session-isolated. Compaction and provider settings deliberately
+    // inherit from the target agent's config (named = full identity);
+    // do NOT force `compaction: { mode: "off" }` here as ephemeral does.
     const sessionManager = SessionManager.inMemory();
     const session = await builtin.cache.createSession({
       sessionManager,

--- a/src/agents/runners/builtin.ts
+++ b/src/agents/runners/builtin.ts
@@ -82,7 +82,7 @@ export class BuiltinRunner implements Runner {
       compaction: { mode: "off" },
     });
 
-    const sessionManager = SessionManager.inMemory();
+    const sessionManager = builtin.sessionManager ?? SessionManager.inMemory();
     const session = await cache.createSession({
       sessionManager,
       systemPrompt,
@@ -117,7 +117,7 @@ export class BuiltinRunner implements Runner {
     // session-isolated. Compaction and provider settings deliberately
     // inherit from the target agent's config (named = full identity);
     // do NOT force `compaction: { mode: "off" }` here as ephemeral does.
-    const sessionManager = SessionManager.inMemory();
+    const sessionManager = builtin.sessionManager ?? SessionManager.inMemory();
     const session = await builtin.cache.createSession({
       sessionManager,
       systemPrompt: builtin.systemPrompt,

--- a/src/agents/runners/builtin.ts
+++ b/src/agents/runners/builtin.ts
@@ -49,14 +49,14 @@ export class BuiltinRunner implements Runner {
       return;
     }
 
-    yield* this.runEphemeral(runId, options, signals, options.builtin);
+    yield* this.runSubagent(runId, options, signals, options.builtin);
   }
 
-  private async *runEphemeral(
+  private async *runSubagent(
     runId: string,
     options: RunOptions,
     signals: RunnerSignals,
-    builtin: Extract<NonNullable<RunOptions["builtin"]>, { mode: "ephemeral" }>,
+    builtin: Extract<NonNullable<RunOptions["builtin"]>, { mode: "subagent" }>,
   ): AsyncGenerator<RunEvent> {
     const agentId = `agent-builtin-${runId}-${randomUUID().slice(0, 8)}`;
     const tools = filterTools(builtin.tools, agentId);
@@ -65,15 +65,15 @@ export class BuiltinRunner implements Runner {
       extraSystemPrompt: builtin.extraSystemPrompt,
     });
 
-    log.info("BuiltinRunner.run (ephemeral)", { runId, agentId, toolCount: tools.list().length });
+    log.info("BuiltinRunner.run (subagent)", { runId, agentId, toolCount: tools.list().length });
 
     this.core.setToolRegistry(agentId, tools);
 
-    // Compaction is intentionally OFF for ephemeral spawns: the system
+    // Compaction is intentionally OFF for subagent spawns: the system
     // prompt steers the agent toward terse single-shot tasks, there's no
     // SOUL/MEMORY identity worth preserving across compactions, and
     // compaction would add LLM-call overhead that defeats the
-    // fire-and-forget premise. Long ephemeral runs that overflow context
+    // fire-and-forget premise. Long subagent runs that overflow context
     // will fail loudly — that's a signal the task should use a named
     // agent or Claude CLI instead. See issue #585 for making this opt-in.
     const cache = this.core.createServiceCache({
@@ -116,7 +116,7 @@ export class BuiltinRunner implements Runner {
     // the same named agent (or a spawn racing with direct user chat) are
     // session-isolated. Compaction and provider settings deliberately
     // inherit from the target agent's config (named = full identity);
-    // do NOT force `compaction: { mode: "off" }` here as ephemeral does.
+    // do NOT force `compaction: { mode: "off" }` here as subagent does.
     const sessionManager = builtin.sessionManager ?? SessionManager.inMemory();
     const session = await builtin.cache.createSession({
       sessionManager,

--- a/src/agents/runners/builtin.ts
+++ b/src/agents/runners/builtin.ts
@@ -117,6 +117,13 @@ export class BuiltinRunner implements Runner {
     // session-isolated. Compaction and provider settings deliberately
     // inherit from the target agent's config (named = full identity);
     // do NOT force `compaction: { mode: "off" }` here as subagent does.
+    //
+    // Note: a long spawn run that exceeds the target's context window
+    // will trigger that target's compaction policy (extra LLM call,
+    // adds cost+latency mid-spawn, leaves a summary message in the
+    // persisted session). Behavior matches a long chat session for the
+    // same target — low risk in practice (most spawns end in a few
+    // turns) but worth knowing if cost / latency spikes are observed.
     const sessionManager = builtin.sessionManager ?? SessionManager.inMemory();
     const session = await builtin.cache.createSession({
       sessionManager,

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,6 +1,7 @@
 import type { ProviderConfig } from "../core/types.js";
 import type { ToolRegistry } from "../core/tools.js";
 import type { SpawnPermissionMode } from "../core/config.js";
+import type { AgentServiceCache } from "../core/pi-mono.js";
 
 export type RunStatus = "created" | "running" | "awaiting" | "completed" | "failed" | "cancelled";
 
@@ -22,11 +23,31 @@ export interface RunResult {
   durationMs?: number;
 }
 
-export interface InProcessOptions {
-  provider: ProviderConfig;
-  tools: ToolRegistry;
-  extraSystemPrompt?: string;
-}
+/**
+ * Builtin runner payload. Two modes:
+ *
+ * - "ephemeral": fire-and-forget agent with no identity. Uses the parent's
+ *   provider and a filtered subset of the parent's tools. The session is
+ *   in-memory and discarded; the system prompt is the generic
+ *   `buildSpawnAgentSystemPrompt()` preamble + task.
+ *
+ * - "named": spawn into an existing named agent's full identity. Uses the
+ *   target agent's `AgentServiceCache` (which already owns its provider
+ *   and tool registry) and the target's already-assembled system prompt
+ *   (SOUL.md/MEMORY.md/TOOLS.md/tool guards merged at init time).
+ */
+export type InProcessOptions =
+  | {
+      mode: "ephemeral";
+      provider: ProviderConfig;
+      tools: ToolRegistry;
+      extraSystemPrompt?: string;
+    }
+  | {
+      mode: "named";
+      cache: AgentServiceCache;
+      systemPrompt: string;
+    };
 
 export type OnCompleteCallback = (result: RunResult) => void | Promise<void>;
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -27,7 +27,7 @@ export interface RunResult {
 /**
  * Builtin runner payload. Two modes:
  *
- * - "ephemeral": fire-and-forget agent. Uses the parent's provider and
+ * - "subagent": fire-and-forget agent. Uses the parent's provider and
  *   a filtered subset of the parent's tools. The system prompt is the
  *   generic `buildSpawnAgentSystemPrompt()` preamble + task. By
  *   convention spawned via the magic agent id "subagent" so its run
@@ -47,7 +47,7 @@ export interface RunResult {
  */
 export type BuiltinOptions =
   | {
-      mode: "ephemeral";
+      mode: "subagent";
       provider: ProviderConfig;
       tools: ToolRegistry;
       extraSystemPrompt?: string;

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -36,7 +36,7 @@ export interface RunResult {
  *   and tool registry) and the target's already-assembled system prompt
  *   (SOUL.md/MEMORY.md/TOOLS.md/tool guards merged at init time).
  */
-export type InProcessOptions =
+export type BuiltinOptions =
   | {
       mode: "ephemeral";
       provider: ProviderConfig;
@@ -64,7 +64,7 @@ export interface RunOptions {
   depth?: number;
   /** Maximum allowed nesting depth. Spawn is rejected when depth >= maxDepth. */
   maxDepth?: number;
-  inProcess?: InProcessOptions;
+  builtin?: BuiltinOptions;
   onComplete?: OnCompleteCallback;
 }
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -2,6 +2,7 @@ import type { ProviderConfig } from "../core/types.js";
 import type { ToolRegistry } from "../core/tools.js";
 import type { SpawnPermissionMode } from "../core/config.js";
 import type { AgentServiceCache } from "../core/pi-mono.js";
+import type { SessionManager } from "@mariozechner/pi-coding-agent";
 
 export type RunStatus = "created" | "running" | "awaiting" | "completed" | "failed" | "cancelled";
 
@@ -26,15 +27,23 @@ export interface RunResult {
 /**
  * Builtin runner payload. Two modes:
  *
- * - "ephemeral": fire-and-forget agent with no identity. Uses the parent's
- *   provider and a filtered subset of the parent's tools. The session is
- *   in-memory and discarded; the system prompt is the generic
- *   `buildSpawnAgentSystemPrompt()` preamble + task.
+ * - "ephemeral": fire-and-forget agent. Uses the parent's provider and
+ *   a filtered subset of the parent's tools. The system prompt is the
+ *   generic `buildSpawnAgentSystemPrompt()` preamble + task. By
+ *   convention spawned via the magic agent id "subagent" so its run
+ *   sessions land in `~/.isotopes/agents/subagent/sessions/`.
  *
- * - "named": spawn into an existing named agent's full identity. Uses the
- *   target agent's `AgentServiceCache` (which already owns its provider
- *   and tool registry) and the target's already-assembled system prompt
- *   (SOUL.md/MEMORY.md/TOOLS.md/tool guards merged at init time).
+ * - "named": spawn into an existing named agent's full identity. Uses
+ *   the target agent's `AgentServiceCache` (which already owns its
+ *   provider and tool registry) and the target's already-assembled
+ *   system prompt (SOUL.md/MEMORY.md/TOOLS.md/tool guards merged at
+ *   init time). Run sessions land in the target agent's own
+ *   `sessions/` directory alongside its chat sessions.
+ *
+ * Both modes accept an optional `sessionManager`: when provided, the
+ * SDK persists the conversation through it (structured messages,
+ * resumable in principle); when omitted, the runner falls back to
+ * `SessionManager.inMemory()` (transient).
  */
 export type BuiltinOptions =
   | {
@@ -42,11 +51,13 @@ export type BuiltinOptions =
       provider: ProviderConfig;
       tools: ToolRegistry;
       extraSystemPrompt?: string;
+      sessionManager?: SessionManager;
     }
   | {
       mode: "named";
       cache: AgentServiceCache;
       systemPrompt: string;
+      sessionManager?: SessionManager;
     };
 
 export type OnCompleteCallback = (result: RunResult) => void | Promise<void>;

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -10,6 +10,7 @@ import {
   type AgentSession,
   AuthStorage,
   createAgentSession,
+  DefaultResourceLoader,
   ModelRegistry,
   type SessionManager,
   SettingsManager,
@@ -195,8 +196,23 @@ export class AgentServiceCache {
       compaction: compactionSettings,
     });
 
+    // Pass the system prompt via DefaultResourceLoader so it becomes
+    // `_baseSystemPrompt` inside the SDK. Mutating
+    // `session.agent.state.systemPrompt` after creation is unreliable —
+    // the SDK's prompt() handler resets state.systemPrompt back to
+    // _baseSystemPrompt on every call when an extensionRunner exists
+    // (which it always does when customTools are passed). See
+    // pi-coding-agent agent-session.js:768-772.
+    const cwd = opts.cwd ?? process.cwd();
+    const resourceLoader = new DefaultResourceLoader({
+      cwd,
+      agentDir: this.agentDir,
+      systemPrompt: opts.systemPrompt,
+      settingsManager,
+    });
+
     const { session } = await createAgentSession({
-      cwd: opts.cwd ?? process.cwd(),
+      cwd,
       agentDir: this.agentDir,
       authStorage: this.authStorage,
       modelRegistry: this.modelRegistry,
@@ -205,9 +221,8 @@ export class AgentServiceCache {
       customTools: this.customTools,
       sessionManager: opts.sessionManager,
       settingsManager,
+      resourceLoader,
     });
-
-    session.agent.state.systemPrompt = opts.systemPrompt;
 
     return session;
   }

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -203,6 +203,12 @@ export class AgentServiceCache {
     // _baseSystemPrompt on every call when an extensionRunner exists
     // (which it always does when customTools are passed). See
     // pi-coding-agent agent-session.js:768-772.
+    //
+    // IMPORTANT: when we provide our own resourceLoader, the SDK does
+    // NOT call reload() for us (sdk.js only auto-reloads its own
+    // default-constructed loader). Without reload(), `systemPrompt`
+    // stays undefined and the LLM falls back to the SDK's default
+    // identity ("I'm pi...").
     const cwd = opts.cwd ?? process.cwd();
     const resourceLoader = new DefaultResourceLoader({
       cwd,
@@ -210,6 +216,7 @@ export class AgentServiceCache {
       systemPrompt: opts.systemPrompt,
       settingsManager,
     });
+    await resourceLoader.reload();
 
     const { session } = await createAgentSession({
       cwd,

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -7,7 +7,7 @@ import type { HookRegistry } from "../plugins/hooks.js";
 import type { FsLike } from "../sandbox/fs-bridge.js";
 import { spawnAgent, getSupportedAgents } from "../tools/spawn-agent.js";
 import { createWebFetchTool, createWebSearchTool } from "../tools/web.js";
-import type { RunEvent, InProcessOptions } from "../agents/types.js";
+import type { RunEvent, BuiltinOptions } from "../agents/types.js";
 import { getSpawnAgentContext, type SpawnAgentStreamContext } from "./spawn-agent-context.js";
 import { failureTracker } from "../agents/failure-tracker.js";
 import { createLogger } from "./logger.js";
@@ -283,7 +283,7 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
         const namedWorkspace = agentManager?.getWorkspacePath?.(agent);
         const isNamed = namedCache !== undefined && namedSystemPrompt !== undefined && namedSystemPrompt.length > 0;
 
-        let builtin: InProcessOptions | undefined;
+        let builtin: BuiltinOptions | undefined;
         let targetAgentId: string | undefined;
         let effectiveCwd = cwd;
         let effectiveAllowedWorkspaces = allAllowedWorkspaces;
@@ -335,7 +335,7 @@ async function runSpawnAgentPlain(
   allowedWorkspaces: string[],
   maxTurns?: number,
   parentAgentId?: string,
-  builtin?: InProcessOptions,
+  builtin?: BuiltinOptions,
   targetAgentId?: string,
 ): Promise<string> {
   const result = await spawnAgent(task, {
@@ -367,7 +367,7 @@ async function runSpawnAgentWithStreaming(
   context: SpawnAgentStreamContext,
   maxTurns?: number,
   parentAgentId?: string,
-  builtin?: InProcessOptions,
+  builtin?: BuiltinOptions,
   targetAgentId?: string,
 ): Promise<string> {
   const { channelId, showToolCalls = true, onComplete } = context;

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -292,10 +292,15 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
           builtin = { mode: "named", cache: namedCache, systemPrompt: namedSystemPrompt };
           targetAgentId = agent;
           if (namedWorkspace) {
+            // Named agents run in their OWN workspace, not the parent's.
+            // The parent cannot scope a named-agent spawn to the parent's
+            // filesystem — by design, the named agent retains its full
+            // identity including cwd. We append the target's workspace
+            // to allowedWorkspaces so AgentRuntime.validateCwd accepts it.
             effectiveCwd = namedWorkspace;
             effectiveAllowedWorkspaces = [...allAllowedWorkspaces, namedWorkspace];
           }
-          log.info("Spawning named agent", { agent, cwd: effectiveCwd });
+          log.info("Spawning named agent", { agent, parentAgentId, cwd: effectiveCwd });
         } else if (parentProvider && parentTools) {
           builtin = { mode: "ephemeral", provider: parentProvider, tools: parentTools };
         }

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -7,10 +7,11 @@ import type { HookRegistry } from "../plugins/hooks.js";
 import type { FsLike } from "../sandbox/fs-bridge.js";
 import { spawnAgent, getSupportedAgents } from "../tools/spawn-agent.js";
 import { createWebFetchTool, createWebSearchTool } from "../tools/web.js";
-import type { RunEvent } from "../agents/types.js";
+import type { RunEvent, InProcessOptions } from "../agents/types.js";
 import { getSpawnAgentContext, type SpawnAgentStreamContext } from "./spawn-agent-context.js";
 import { failureTracker } from "../agents/failure-tracker.js";
 import { createLogger } from "./logger.js";
+import type { AgentServiceCache } from "./pi-mono.js";
 const log = createLogger("tools:spawn-agent");
 /** Function that executes a tool call and returns a string result. */
 export type ToolHandler = (args: unknown) => Promise<string>;
@@ -168,8 +169,16 @@ export interface SpawnAgentToolOptions {
   allowedWorkspaces?: string[];
   /** Allowed agents (defaults to all available) */
   allowedAgents?: string[];
-  /** Agent manager — used to discover available in-process agents */
-  agentManager?: { list(): { id: string; spawnable?: boolean }[] };
+  /** Agent manager — used to discover available in-process agents and to
+   * resolve named-agent identity (cache, system prompt, workspace path) for
+   * named-mode spawn. `get`/`getSystemPrompt`/`getWorkspacePath` are optional
+   * so test fixtures can pass a minimal `{ list }` shim. */
+  agentManager?: {
+    list(): { id: string; spawnable?: boolean }[];
+    get?(id: string): AgentServiceCache | undefined;
+    getSystemPrompt?(id: string): string | undefined;
+    getWorkspacePath?(id: string): string | undefined;
+  };
   /** Pre-computed list of spawnable agent IDs (avoids init order issues) */
   spawnableAgentIds?: string[];
   /** Default timeout in seconds (default: 300) */
@@ -198,7 +207,7 @@ export interface SpawnAgentToolOptions {
  * posted to the main channel when complete.
  */
 export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: Tool; handler: ToolHandler } {
-  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns, parentAgentId, parentProvider, parentTools, spawnableAgentIds } = options;
+  const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns, parentAgentId, parentProvider, parentTools, spawnableAgentIds, agentManager } = options;
   const availableAgents: string[] = [...getSupportedAgents()];
   if (spawnableAgentIds) {
     for (const id of spawnableAgentIds) {
@@ -264,14 +273,38 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
       }
 
       try {
-        const builtin = parentProvider && parentTools
-          ? { provider: parentProvider, tools: parentTools }
-          : undefined;
+        // Resolve spawn mode: if `agent` matches a registered named agent
+        // (with full identity in agentManager), use named mode — load its
+        // own system prompt, AgentServiceCache (provider+tools wired at
+        // init), and workspace as cwd. Otherwise fall back to ephemeral
+        // mode using the parent agent's provider/tools.
+        const namedCache = agentManager?.get?.(agent);
+        const namedSystemPrompt = agentManager?.getSystemPrompt?.(agent);
+        const namedWorkspace = agentManager?.getWorkspacePath?.(agent);
+        const isNamed = namedCache !== undefined && namedSystemPrompt !== undefined && namedSystemPrompt.length > 0;
+
+        let builtin: InProcessOptions | undefined;
+        let targetAgentId: string | undefined;
+        let effectiveCwd = cwd;
+        let effectiveAllowedWorkspaces = allAllowedWorkspaces;
+
+        if (isNamed) {
+          builtin = { mode: "named", cache: namedCache, systemPrompt: namedSystemPrompt };
+          targetAgentId = agent;
+          if (namedWorkspace) {
+            effectiveCwd = namedWorkspace;
+            effectiveAllowedWorkspaces = [...allAllowedWorkspaces, namedWorkspace];
+          }
+          log.info("Spawning named agent", { agent, cwd: effectiveCwd });
+        } else if (parentProvider && parentTools) {
+          builtin = { mode: "ephemeral", provider: parentProvider, tools: parentTools };
+        }
+
         let result: string;
         if (discordContext) {
-          result = await runSpawnAgentWithStreaming(task, agent, cwd, timeout, allAllowedWorkspaces, discordContext, maxTurns, parentAgentId, builtin);
+          result = await runSpawnAgentWithStreaming(task, agent, effectiveCwd, timeout, effectiveAllowedWorkspaces, discordContext, maxTurns, parentAgentId, builtin, targetAgentId);
         } else {
-          result = await runSpawnAgentPlain(task, agent, cwd, timeout, allAllowedWorkspaces, maxTurns, parentAgentId, builtin);
+          result = await runSpawnAgentPlain(task, agent, effectiveCwd, timeout, effectiveAllowedWorkspaces, maxTurns, parentAgentId, builtin, targetAgentId);
         }
 
         // Record failure if result indicates failure
@@ -302,7 +335,8 @@ async function runSpawnAgentPlain(
   allowedWorkspaces: string[],
   maxTurns?: number,
   parentAgentId?: string,
-  builtin?: { provider: ProviderConfig; tools: ToolRegistry },
+  builtin?: InProcessOptions,
+  targetAgentId?: string,
 ): Promise<string> {
   const result = await spawnAgent(task, {
     agent,
@@ -311,6 +345,7 @@ async function runSpawnAgentPlain(
     allowedWorkspaces,
     maxTurns,
     parentAgentId,
+    ...(targetAgentId ? { targetAgentId } : {}),
     ...(builtin ? { builtin } : {}),
   });
   if (result.success) {
@@ -332,7 +367,8 @@ async function runSpawnAgentWithStreaming(
   context: SpawnAgentStreamContext,
   maxTurns?: number,
   parentAgentId?: string,
-  builtin?: { provider: ProviderConfig; tools: ToolRegistry },
+  builtin?: InProcessOptions,
+  targetAgentId?: string,
 ): Promise<string> {
   const { channelId, showToolCalls = true, onComplete } = context;
   const sink = context.createSink(channelId, { showToolCalls, useThread: true });
@@ -354,6 +390,7 @@ async function runSpawnAgentWithStreaming(
       channelId,
       threadId,
       parentAgentId,
+      ...(targetAgentId ? { targetAgentId } : {}),
       ...(builtin ? { builtin } : {}),
       onEvent: async (event) => {
         events.push(event);
@@ -756,7 +793,12 @@ export function createWorkspaceToolsWithGuards(
   parentAgentId?: string,
   parentProvider?: ProviderConfig,
   parentTools?: ToolRegistry,
-  agentManager?: { list(): { id: string; spawnable?: boolean }[] },
+  agentManager?: {
+    list(): { id: string; spawnable?: boolean }[];
+    get?(id: string): AgentServiceCache | undefined;
+    getSystemPrompt?(id: string): string | undefined;
+    getWorkspacePath?(id: string): string | undefined;
+  },
   spawnableAgentIds?: string[],
 ): { tool: Tool; handler: ToolHandler }[] {
   const fileOpts: FileToolOptions = { workspacePath, fsImpl };
@@ -768,7 +810,7 @@ export function createWorkspaceToolsWithGuards(
     createTimeTool(),
   ];
   if (spawnAgentEnabled) {
-    tools.push(createSpawnAgentTool({ workspacePath, allowedWorkspaces, maxTurns: spawnAgentMaxTurns, parentAgentId, parentProvider, parentTools, spawnableAgentIds }));
+    tools.push(createSpawnAgentTool({ workspacePath, allowedWorkspaces, maxTurns: spawnAgentMaxTurns, parentAgentId, parentProvider, parentTools, spawnableAgentIds, agentManager }));
   }
   if (settings?.web) {
     tools.push(createWebFetchTool());

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -321,9 +321,16 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
             effectiveAllowedWorkspaces = [...allAllowedWorkspaces, namedWorkspace];
           }
           log.info("Spawning named agent", { agent, parentAgentId, cwd: effectiveCwd });
-        } else if (parentProvider && parentTools) {
-          builtin = { mode: "subagent", provider: parentProvider, tools: parentTools };
+        } else if (!isSubagent && namedCache !== undefined && (namedSystemPrompt === undefined || namedSystemPrompt.length === 0)) {
+          // The agent is registered in agentManager but its assembled
+          // systemPrompt is empty (init race / hot-reload mid-flight).
+          // Don't silently fall through to the external-runner path —
+          // surface it so the user sees a misroute instead of a
+          // confusing "agent not found" from ClaudeRunner.
+          log.warn("Named agent has empty systemPrompt; spawn will route to external runner and likely fail", { agent });
         }
+        // Other agent ids (e.g. "claude") don't get a builtin payload —
+        // they go to the external runner registered for that id.
 
         let result: string;
         if (discordContext) {

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -207,7 +207,7 @@ export interface SpawnAgentToolOptions {
  * posted to the main channel when complete.
  */
 /**
- * Magic agent id that triggers ephemeral builtin spawn (parent's
+ * Magic agent id that triggers subagent builtin spawn (parent's
  * provider + filtered tools + generic system prompt + task). Run
  * sessions land in `~/.isotopes/agents/subagent/sessions/` regardless
  * of which agent triggered the spawn — keeps real agents' session
@@ -218,7 +218,7 @@ export const SUBAGENT_AGENT_ID = "subagent";
 export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: Tool; handler: ToolHandler } {
   const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns, parentAgentId, parentProvider, parentTools, spawnableAgentIds, agentManager } = options;
   const availableAgents: string[] = [...getSupportedAgents()];
-  // Always expose the ephemeral magic id, gated by parent having
+  // Always expose the subagent magic id, gated by parent having
   // provider+tools to lend (always true for real agents).
   if (parentProvider && parentTools && !availableAgents.includes(SUBAGENT_AGENT_ID)) {
     availableAgents.push(SUBAGENT_AGENT_ID);
@@ -288,7 +288,7 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
 
       try {
         // Resolve spawn mode:
-        //  - magic id "subagent" → ephemeral builtin (parent's provider+tools,
+        //  - magic id "subagent" → subagent builtin (parent's provider+tools,
         //    generic preamble, run session lands in subagent/ store)
         //  - registered named agent (in agentManager) → named builtin (full
         //    identity, run session lands in target's own sessions/)
@@ -305,9 +305,9 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
         let effectiveAllowedWorkspaces = allAllowedWorkspaces;
 
         if (isSubagent && parentProvider && parentTools) {
-          builtin = { mode: "ephemeral", provider: parentProvider, tools: parentTools };
+          builtin = { mode: "subagent", provider: parentProvider, tools: parentTools };
           targetAgentId = SUBAGENT_AGENT_ID;
-          log.info("Spawning ephemeral subagent", { parentAgentId, cwd: effectiveCwd });
+          log.info("Spawning subagent", { parentAgentId, cwd: effectiveCwd });
         } else if (isNamed) {
           builtin = { mode: "named", cache: namedCache, systemPrompt: namedSystemPrompt };
           targetAgentId = agent;
@@ -322,7 +322,7 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
           }
           log.info("Spawning named agent", { agent, parentAgentId, cwd: effectiveCwd });
         } else if (parentProvider && parentTools) {
-          builtin = { mode: "ephemeral", provider: parentProvider, tools: parentTools };
+          builtin = { mode: "subagent", provider: parentProvider, tools: parentTools };
         }
 
         let result: string;

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -206,9 +206,23 @@ export interface SpawnAgentToolOptions {
  * spawn agent output will be streamed to a Discord thread and a summary will be
  * posted to the main channel when complete.
  */
+/**
+ * Magic agent id that triggers ephemeral builtin spawn (parent's
+ * provider + filtered tools + generic system prompt + task). Run
+ * sessions land in `~/.isotopes/agents/subagent/sessions/` regardless
+ * of which agent triggered the spawn — keeps real agents' session
+ * directories clean while preserving structured run history.
+ */
+export const SUBAGENT_AGENT_ID = "subagent";
+
 export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: Tool; handler: ToolHandler } {
   const { workspacePath, allowedWorkspaces = [], allowedAgents, timeout, maxTurns, parentAgentId, parentProvider, parentTools, spawnableAgentIds, agentManager } = options;
   const availableAgents: string[] = [...getSupportedAgents()];
+  // Always expose the ephemeral magic id, gated by parent having
+  // provider+tools to lend (always true for real agents).
+  if (parentProvider && parentTools && !availableAgents.includes(SUBAGENT_AGENT_ID)) {
+    availableAgents.push(SUBAGENT_AGENT_ID);
+  }
   if (spawnableAgentIds) {
     for (const id of spawnableAgentIds) {
       if (!availableAgents.includes(id)) {
@@ -273,14 +287,16 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
       }
 
       try {
-        // Resolve spawn mode: if `agent` matches a registered named agent
-        // (with full identity in agentManager), use named mode — load its
-        // own system prompt, AgentServiceCache (provider+tools wired at
-        // init), and workspace as cwd. Otherwise fall back to ephemeral
-        // mode using the parent agent's provider/tools.
-        const namedCache = agentManager?.get?.(agent);
-        const namedSystemPrompt = agentManager?.getSystemPrompt?.(agent);
-        const namedWorkspace = agentManager?.getWorkspacePath?.(agent);
+        // Resolve spawn mode:
+        //  - magic id "subagent" → ephemeral builtin (parent's provider+tools,
+        //    generic preamble, run session lands in subagent/ store)
+        //  - registered named agent (in agentManager) → named builtin (full
+        //    identity, run session lands in target's own sessions/)
+        //  - otherwise → external runner ("claude") via ClaudeRunner
+        const isSubagent = agent === SUBAGENT_AGENT_ID;
+        const namedCache = !isSubagent ? agentManager?.get?.(agent) : undefined;
+        const namedSystemPrompt = !isSubagent ? agentManager?.getSystemPrompt?.(agent) : undefined;
+        const namedWorkspace = !isSubagent ? agentManager?.getWorkspacePath?.(agent) : undefined;
         const isNamed = namedCache !== undefined && namedSystemPrompt !== undefined && namedSystemPrompt.length > 0;
 
         let builtin: BuiltinOptions | undefined;
@@ -288,7 +304,11 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): { tool: To
         let effectiveCwd = cwd;
         let effectiveAllowedWorkspaces = allAllowedWorkspaces;
 
-        if (isNamed) {
+        if (isSubagent && parentProvider && parentTools) {
+          builtin = { mode: "ephemeral", provider: parentProvider, tools: parentTools };
+          targetAgentId = SUBAGENT_AGENT_ID;
+          log.info("Spawning ephemeral subagent", { parentAgentId, cwd: effectiveCwd });
+        } else if (isNamed) {
           builtin = { mode: "named", cache: namedCache, systemPrompt: namedSystemPrompt };
           targetAgentId = agent;
           if (namedWorkspace) {

--- a/src/tools/spawn-agent.test.ts
+++ b/src/tools/spawn-agent.test.ts
@@ -116,6 +116,54 @@ describe("spawnAgent", () => {
     expect(events).toHaveLength(3);
     expect(events[1]).toEqual({ type: "run:tool_use", toolName: "Read" });
   });
+
+  it("skips per-event recorder when builtin SDK persists via injected SessionManager", async () => {
+    vi.resetModules();
+    const { initSpawnBackend, spawnAgent, setSpawnSessionStoreFactory } = await import("./spawn-agent.js");
+    initSpawnBackend({ config: { claude: { permissionMode: "allowlist", allowedTools: [] }, useThread: true, showToolCalls: true } });
+
+    const addMessage = vi.fn();
+    const setMetadata = vi.fn();
+    const fakeStore = {
+      create: vi.fn(async () => ({ id: "sess-1" })),
+      addMessage,
+      setMetadata,
+      get: vi.fn(async () => ({ id: "sess-1", metadata: {} })),
+      getSessionManager: vi.fn(async () => ({ /* fake SessionManager */ })),
+    };
+    setSpawnSessionStoreFactory(() => fakeStore as never);
+
+    spawnMock.mockReturnValue(
+      eventGen(
+        { type: "run:start" },
+        { type: "run:message", content: "hello" },
+        { type: "run:tool_use", toolName: "Read" },
+        { type: "run:tool_result", toolName: "Read", toolResult: "ok" },
+        { type: "run:done", exitCode: 0 },
+      ),
+    );
+
+    await spawnAgent("t", {
+      agent: "subagent",
+      cwd: process.cwd(),
+      parentAgentId: "main",
+      targetAgentId: "subagent",
+      builtin: {
+        mode: "subagent",
+        provider: { type: "anthropic", model: "claude-sonnet-4-5" } as never,
+        tools: { list: () => [] } as never,
+      },
+    });
+
+    // SDK persisted path → per-event recorder should NOT have written messages
+    expect(addMessage).not.toHaveBeenCalled();
+    // patchMetadata still runs at completion
+    expect(setMetadata).toHaveBeenCalled();
+    // Verify SessionManager was requested
+    expect(fakeStore.getSessionManager).toHaveBeenCalledWith("sess-1");
+
+    setSpawnSessionStoreFactory(undefined);
+  });
 });
 
 describe("getSupportedAgents", () => {

--- a/src/tools/spawn-agent.ts
+++ b/src/tools/spawn-agent.ts
@@ -6,7 +6,7 @@ import {
   summarizeEvents,
   type RunEvent,
 } from "../agents/index.js";
-import type { InProcessOptions } from "../agents/types.js";
+import type { BuiltinOptions } from "../agents/types.js";
 import type { PiMonoCore } from "../core/pi-mono.js";
 import { taskRegistry } from "../agents/task-registry.js";
 import { createRunRecorder } from "../agents/persistence.js";
@@ -55,8 +55,8 @@ export interface SpawnAgentOptions {
    * unset and the recorder falls back to `parentAgentId`.
    */
   targetAgentId?: string;
-  /** In-process backend options. Required when agent is not an external runner. */
-  builtin?: InProcessOptions;
+  /** Builtin runner payload. Required when agent is not an external runner. */
+  builtin?: BuiltinOptions;
 }
 
 export interface SpawnAgentResult {
@@ -188,7 +188,7 @@ export async function spawnAgent(
       maxTurns: options.maxTurns ?? 50,
       depth: options.depth,
       maxDepth: backendConfig.config?.maxDepth,
-      ...(options.builtin ? { inProcess: options.builtin } : {}),
+      ...(options.builtin ? { builtin: options.builtin } : {}),
     });
 
     const collected: RunEvent[] = [];

--- a/src/tools/spawn-agent.ts
+++ b/src/tools/spawn-agent.ts
@@ -65,6 +65,9 @@ export interface SpawnAgentResult {
   error?: string;
   exitCode: number;
   eventCount: number;
+  /** Session id of the recorded run under the target agent's session store.
+   * Undefined when persistence is unavailable (no store / NOOP recorder). */
+  sessionId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -221,6 +224,7 @@ export async function spawnAgent(
       error: result.error,
       exitCode: result.exitCode,
       eventCount: collected.length,
+      ...(recorder.sessionId ? { sessionId: recorder.sessionId } : {}),
     };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
@@ -239,6 +243,7 @@ export async function spawnAgent(
       error,
       exitCode: 1,
       eventCount: 0,
+      ...(recorder.sessionId ? { sessionId: recorder.sessionId } : {}),
     };
   }
 }

--- a/src/tools/spawn-agent.ts
+++ b/src/tools/spawn-agent.ts
@@ -179,7 +179,7 @@ export async function spawnAgent(
     threadId: options.threadId,
   });
 
-  // For builtin runs (named + ephemeral) the SDK can persist the real
+  // For builtin runs (named + subagent) the SDK can persist the real
   // structured conversation directly into the run's session. Hand the
   // SessionManager backing this session into the BuiltinOptions so the
   // SDK writes there. We then skip per-event recorder.record() to avoid

--- a/src/tools/spawn-agent.ts
+++ b/src/tools/spawn-agent.ts
@@ -187,9 +187,17 @@ export async function spawnAgent(
   // runs at the end to capture exitCode/costUsd/durationMs.
   let builtin = options.builtin;
   if (builtin && store && recorder.sessionId) {
-    const sessionManager = await store.getSessionManager(recorder.sessionId);
-    if (sessionManager) {
-      builtin = { ...builtin, sessionManager };
+    try {
+      const sessionManager = await store.getSessionManager(recorder.sessionId);
+      if (sessionManager) {
+        builtin = { ...builtin, sessionManager };
+      }
+    } catch (err) {
+      log.warn("Failed to obtain SessionManager for builtin spawn; falling back to per-event recorder", {
+        taskId,
+        sessionId: recorder.sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
   const sdkPersists = builtin?.sessionManager !== undefined;

--- a/src/tools/spawn-agent.ts
+++ b/src/tools/spawn-agent.ts
@@ -179,6 +179,21 @@ export async function spawnAgent(
     threadId: options.threadId,
   });
 
+  // For builtin runs (named + ephemeral) the SDK can persist the real
+  // structured conversation directly into the run's session. Hand the
+  // SessionManager backing this session into the BuiltinOptions so the
+  // SDK writes there. We then skip per-event recorder.record() to avoid
+  // double-writing the same session — recorder.patchMetadata() still
+  // runs at the end to capture exitCode/costUsd/durationMs.
+  let builtin = options.builtin;
+  if (builtin && store && recorder.sessionId) {
+    const sessionManager = await store.getSessionManager(recorder.sessionId);
+    if (sessionManager) {
+      builtin = { ...builtin, sessionManager };
+    }
+  }
+  const sdkPersists = builtin?.sessionManager !== undefined;
+
   const startedAt = Date.now();
 
   try {
@@ -191,14 +206,16 @@ export async function spawnAgent(
       maxTurns: options.maxTurns ?? 50,
       depth: options.depth,
       maxDepth: backendConfig.config?.maxDepth,
-      ...(options.builtin ? { builtin: options.builtin } : {}),
+      ...(builtin ? { builtin } : {}),
     });
 
     const collected: RunEvent[] = [];
     for await (const event of events) {
       collected.push(event);
       options.onEvent?.(event);
-      await recorder.record(event);
+      if (!sdkPersists) {
+        await recorder.record(event);
+      }
     }
 
     const result = summarizeEvents(collected);


### PR DESCRIPTION
## Summary

Splits `BuiltinRunner`'s `inProcess` payload into a discriminated union: `mode: "subagent"` (fire-and-forget with parent's identity) and `mode: "named"` (full identity load — target's `AgentServiceCache` + assembled SOUL/MEMORY/TOOLS/tool-guard prompt + own provider/tools, runs in target's workspace).

Both builtin modes now persist conversations via the SDK directly into a SessionStore-backed `SessionManager` (no more `SessionManager.inMemory()`):
- **Named** runs land in the target agent's own `~/.isotopes/agents/<id>/sessions/` alongside its chat sessions
- **Subagent** runs land in `~/.isotopes/agents/subagent/sessions/` (a dedicated magic-id store)

Side fixes uncovered:
- `pi-mono.ts` was setting `state.systemPrompt` after session creation, which the SDK's `prompt()` handler resets back to `_baseSystemPrompt` on every call when `customTools` are present. Switched to passing systemPrompt via `DefaultResourceLoader` (with explicit `reload()`), so the prompt actually reaches the LLM. Without this fix, named-mode would have looked correct in code but the LLM would default to the underlying model's identity ("I am pi", etc).
- Subagent system prompt now identifies as "a subagent in the Isotopes framework" so the underlying model doesn't introduce itself as Claude/Anthropic.

Closes #575

## Test plan

- [x] `pnpm run ci` — lint + typecheck + 1248 unit tests pass (added 2 new tests for named-mode abort + builtin SDK-persistence path)
- [x] Manual: `spawn_agent(agent="<named>", task="who are you")` → response reflects target SOUL.md persona (verified eous returns its own persona, not "I am pi" / "I am Claude")
- [x] Manual: `spawn_agent(agent="subagent", ...)` → response identifies as "a subagent in the Isotopes framework"
- [x] Manual: run JSONL lands in target agent's `sessions/` (verified eous spawn writes to `~/.isotopes/agents/eous/sessions/`)
- [x] Manual: subagent runs land in `~/.isotopes/agents/subagent/sessions/`
- [x] Regression: `spawn_agent(agent="claude", ...)` still routes through ClaudeRunner unchanged
- [ ] Tool-guard verification: named agent with `tool_settings.codingMode: "spawn-agent"` rejects direct write_file (deferred — no real agent currently configured this way; pre-existing tool-guard tests cover the general path)

## Known caveats / follow-ups (issues opened)

- **#589** [P0]: Concurrent spawns with differing `allowedWorkspaces` abort each other (named mode adds target's workspace per-call → cache key mismatch in `getBackend()`). Workaround until fixed: spawn serially. Plan: switch `allowedRoots` to per-spawn validation.
- **#590**: `DefaultResourceLoader` scans `cwd`/`agentDir` for `AGENTS.md`/`CLAUDE.md` and prepends them to system prompt; subagent inherits parent workspace's project context (or daemon's `process.cwd()` when `cwd` omitted). Plan: pass an isolated `ResourceLoader` for subagent mode.
- **#587**: Audit JSONL pattern (`RunRecorder`) is mostly redundant with SDK persistence + daemon log; openclaw uses a single `subagents/runs.json` registry instead. Plan: drop per-run audit JSONL, adopt openclaw model.
- **#585**: Subagent compaction is hardcoded `off`; consider opt-in inheritance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)