### PR TITLE
feat(core): add steering support for TUI and Chat API

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -11,7 +11,8 @@ import { addRoute } from "./routes.js";
 import { sendJson, sendError } from "./middleware.js";
 import { createLogger } from "../core/logger.js";
 import { randomUUID } from "node:crypto";
-import { runAgentLoop } from "../core/agent-runner.js";
+import { runAgentLoop, abortAgentSession } from "../core/agent-runner.js";
+import { userMessage as mkUserMsg } from "../core/messages.js";
 import { agentEventBus } from "../core/agent-event-bus.js";
 import type { DefaultSessionStore } from "../core/session-store.js";
 import type { Session } from "../core/types.js";
@@ -28,6 +29,7 @@ interface ActiveSession {
   agentId: string;
   lastActivity: number;
   abortController?: AbortController;
+  pendingMessages: Array<{ content: string; timestamp: number }>;
 }
 
 const activeSessions = new Map<string, ActiveSession>();
@@ -260,7 +262,7 @@ addRoute("POST", "/api/sessions/:agentId", async (req, res, deps) => {
   }
 
   evictStaleSessions();
-  activeSessions.set(sessionKey, { sessionKey, sessionId, agentId, lastActivity: Date.now() });
+  activeSessions.set(sessionKey, { sessionKey, sessionId, agentId, lastActivity: Date.now(), pendingMessages: [] });
 
   log.info(`Session ${resumed ? "resumed" : "created"}: ${sessionKey} (agent: ${agentId})`);
   sendJson(res, resumed ? 200 : 201, { key: urlKey, agentId, resumed });
@@ -344,6 +346,16 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
       log,
       hooks: deps.hooks,
       agentId,
+      onToolComplete: async () => {
+        const pending = active.pendingMessages;
+        if (pending.length === 0) return null;
+        const drained = pending.splice(0);
+        for (const m of drained) {
+          await store.addMessage(sessionId, mkUserMsg(m.content, m.timestamp));
+        }
+        const formatted = drained.map((m) => m.content).join("\n");
+        return `[Messages arrived while you were working]\n${formatted}`;
+      },
     });
 
     if (result.errorMessage) {
@@ -360,6 +372,30 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
 });
 
 // ---------------------------------------------------------------------------
+// POST /api/sessions/:agentId/:key/steer — inject a message mid-run
+// ---------------------------------------------------------------------------
+
+addRoute("POST", "/api/sessions/:agentId/:key/steer", async (req, res, _deps) => {
+  const sessionKey = `${req.params.agentId}:${req.params.key}`;
+  const active = activeSessions.get(sessionKey);
+  if (!active) {
+    sendError(res, 404, `Active session not found`);
+    return;
+  }
+
+  const body = req.body as { message?: string } | undefined;
+  if (!body?.message) {
+    sendError(res, 400, "Request body must include 'message'");
+    return;
+  }
+
+  active.pendingMessages.push({ content: body.message, timestamp: Date.now() });
+  active.lastActivity = Date.now();
+  log.debug(`Steer message queued for session ${sessionKey}`);
+  sendJson(res, 200, { ok: true, queued: active.pendingMessages.length });
+});
+
+// ---------------------------------------------------------------------------
 // POST /api/sessions/:agentId/:key/abort — abort current response
 // ---------------------------------------------------------------------------
 
@@ -371,7 +407,8 @@ addRoute("POST", "/api/sessions/:agentId/:key/abort", (req, res) => {
     return;
   }
 
-  session.abortController?.abort();
+  abortAgentSession(session.sessionId);
+  session.pendingMessages.length = 0;
   sendJson(res, 200, { ok: true });
 });
 

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -329,6 +329,8 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
       writeEvent("tool_call", { toolCallId: e.toolCallId, toolName: e.toolName, args: e.args });
     } else if (e.type === "tool_execution_end") {
       writeEvent("tool_result", { toolCallId: e.toolCallId, toolName: e.toolName, result: e.result, isError: e.isError });
+    } else if (e.type === "turn_end") {
+      writeEvent("turn_end", {});
     }
   });
 

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -12,7 +12,7 @@ import { sendJson, sendError } from "./middleware.js";
 import { createLogger } from "../core/logger.js";
 import { randomUUID } from "node:crypto";
 import { runAgentLoop, abortAgentSession } from "../core/agent-runner.js";
-import { userMessage as mkUserMsg } from "../core/messages.js";
+import { userMessage } from "../core/messages.js";
 import { agentEventBus } from "../core/agent-event-bus.js";
 import type { DefaultSessionStore } from "../core/session-store.js";
 import type { Session } from "../core/types.js";
@@ -35,6 +35,8 @@ interface ActiveSession {
 const activeSessions = new Map<string, ActiveSession>();
 const SESSION_TTL_MS = 30 * 60 * 1000;
 const MAX_SESSIONS = 100;
+const MAX_PENDING_MESSAGES = 50;
+const MAX_STEER_MESSAGE_LEN = 10_000;
 
 function evictStaleSessions() {
   const now = Date.now();
@@ -353,7 +355,7 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
         if (pending.length === 0) return null;
         const drained = pending.splice(0);
         for (const m of drained) {
-          await store.addMessage(sessionId, mkUserMsg(m.content, m.timestamp));
+          await store.addMessage(sessionId, userMessage(m.content, m.timestamp));
         }
         const formatted = drained.map((m) => m.content).join("\n");
         return `[Messages arrived while you were working]\n${formatted}`;
@@ -388,6 +390,14 @@ addRoute("POST", "/api/sessions/:agentId/:key/steer", async (req, res, _deps) =>
   const body = req.body as { message?: string } | undefined;
   if (!body?.message) {
     sendError(res, 400, "Request body must include 'message'");
+    return;
+  }
+  if (body.message.length > MAX_STEER_MESSAGE_LEN) {
+    sendError(res, 400, `Message exceeds max length of ${MAX_STEER_MESSAGE_LEN}`);
+    return;
+  }
+  if (active.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+    sendError(res, 429, `Steer queue full (max ${MAX_PENDING_MESSAGES})`);
     return;
   }
 

--- a/src/tui/ChatScreen.test.ts
+++ b/src/tui/ChatScreen.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { historyToChatMessages, extractResultText } from "./ChatScreen.js";
+
+describe("extractResultText", () => {
+  it("returns string as-is", () => {
+    expect(extractResultText("hello")).toBe("hello");
+  });
+
+  it("joins text blocks from array", () => {
+    const blocks = [
+      { type: "text", text: "line1" },
+      { type: "text", text: "line2" },
+    ];
+    expect(extractResultText(blocks)).toBe("line1\nline2");
+  });
+
+  it("unwraps content property", () => {
+    expect(extractResultText({ content: "nested" })).toBe("nested");
+  });
+
+  it("JSON stringifies unknown shapes", () => {
+    expect(extractResultText(42)).toBe("42");
+  });
+});
+
+describe("historyToChatMessages", () => {
+  it("converts user and assistant messages", () => {
+    const items = [
+      { role: "user", content: "hi", timestamp: 1000 },
+      { role: "assistant", content: [{ type: "text", text: "hello" }], timestamp: 2000 },
+    ];
+    const result = historyToChatMessages(items);
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe("user");
+    expect(result[0].content).toBe("hi");
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].content).toBe("hello");
+  });
+
+  it("skips empty user messages", () => {
+    const items = [
+      { role: "user", content: [] },
+      { role: "assistant", content: [{ type: "text", text: "response" }] },
+    ];
+    const result = historyToChatMessages(items);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("assistant");
+  });
+
+  it("strips steer prefix from user messages", () => {
+    const items = [
+      { role: "user", content: "[Messages arrived while you were working]\nactual message" },
+    ];
+    const result = historyToChatMessages(items);
+    expect(result[0].content).toBe("actual message");
+  });
+
+  it("marks toolResult by toolCallId before flush", () => {
+    const items = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "t1", name: "echo", arguments: "{}" },
+          { type: "toolCall", id: "t2", name: "time", arguments: "{}" },
+        ],
+      },
+      { role: "toolResult", toolCallId: "t2" },
+      { role: "toolResult", toolCallId: "t1" },
+    ];
+    const result = historyToChatMessages(items);
+    expect(result).toHaveLength(1);
+    const blocks = result[0].blocks!;
+    // Both are marked ✓ (flush marks remaining, but t2 was marked first by toolCallId)
+    expect(blocks[0].type === "tool" && blocks[0].result).toBe("✓");
+    expect(blocks[1].type === "tool" && blocks[1].result).toBe("✓");
+  });
+
+  it("falls back to first-unresolved when no toolCallId", () => {
+    const items = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "t1", name: "echo", arguments: "{}" },
+        ],
+      },
+      { role: "toolResult" },
+    ];
+    const result = historyToChatMessages(items);
+    const blocks = result[0].blocks!;
+    expect(blocks[0].type === "tool" && blocks[0].result).toBe("✓");
+  });
+
+  it("splits consecutive assistant messages into separate entries", () => {
+    const items = [
+      { role: "assistant", content: [{ type: "text", text: "first" }] },
+      { role: "assistant", content: [{ type: "text", text: "second" }] },
+    ];
+    const result = historyToChatMessages(items);
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe("first");
+    expect(result[1].content).toBe("second");
+  });
+
+  it("handles user content as array of text blocks", () => {
+    const items = [
+      { role: "user", content: [{ type: "text", text: "hello " }, { type: "text", text: "world" }] },
+    ];
+    const result = historyToChatMessages(items);
+    expect(result[0].content).toBe("hello world");
+  });
+});

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -214,6 +214,16 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     const text = input.trim();
     if (!text) return;
     setInput("");
+
+    if (isStreaming) {
+      const userMsg: ChatMessage = { role: "user", content: text, timestamp: new Date() };
+      setMessages((prev) => [...prev, userMsg]);
+      void api.steerMessage(agentId, sessionKeyRef.current!, text).catch((err) => {
+        setMessages((prev) => [...prev, { role: "system", content: `Steer failed: ${err instanceof Error ? err.message : String(err)}`, timestamp: new Date() }]);
+      });
+      return;
+    }
+
     const slash = parseSlashCommand(text);
     if (slash) {
       const handled = dispatch(slash.command, slash.args, {
@@ -250,13 +260,20 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
   };
 
   useInput((ch, key) => {
-    if (isStreaming) return;
     if (key.return) {
       handleSubmit();
+    } else if (key.escape && isStreaming) {
+      abortRef.current?.abort();
+      void api.abortMessage(agentId, sessionKeyRef.current!).catch(() => {});
     } else if (key.backspace || key.delete) {
       setInput((prev) => prev.slice(0, -1));
     } else if (key.ctrl && ch === "c") {
-      exit();
+      if (isStreaming) {
+        abortRef.current?.abort();
+        void api.abortMessage(agentId, sessionKeyRef.current!).catch(() => {});
+      } else {
+        exit();
+      }
     } else if (ch && !key.ctrl && !key.meta) {
       setInput((prev) => prev + ch);
     }
@@ -339,8 +356,11 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
 
       <Box borderStyle="single" paddingX={1} height={3}>
         <Text color="green">&gt; </Text>
-        <Text wrap="truncate">{input}</Text>
+        <Text wrap="truncate">{input || (isStreaming ? "" : "")}</Text>
         <Text color="gray">█</Text>
+        {isStreaming && !input && (
+          <Text color="gray" dimColor> type to steer · esc to stop</Text>
+        )}
       </Box>
     </Box>
   );

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Box, Text, Static, useInput, useApp } from "ink";
+import { randomUUID } from "node:crypto";
 import { parseSlashCommand, dispatch, HELP_TEXT } from "./commands.js";
 import type { ChatMessage, ContentBlock, TuiOptions, Screen, SSEEvent } from "./types.js";
 import * as api from "./api.js";
@@ -7,7 +8,7 @@ import * as api from "./api.js";
 const MAX_VISIBLE_MESSAGES = 50;
 const MAX_HISTORY_MESSAGES = 20;
 
-function extractResultText(result: unknown): string {
+export function extractResultText(result: unknown): string {
   if (typeof result === "string") return result;
   if (Array.isArray(result)) {
     const texts: string[] = [];
@@ -22,7 +23,7 @@ function extractResultText(result: unknown): string {
   return JSON.stringify(result);
 }
 
-function historyToChatMessages(items: Array<{ role: string; type?: string; content?: unknown; timestamp?: number }>): ChatMessage[] {
+export function historyToChatMessages(items: Array<{ role: string; type?: string; content?: unknown; timestamp?: number; toolCallId?: string }>): ChatMessage[] {
   const result: ChatMessage[] = [];
   let current: { text: string; blocks: ContentBlock[]; timestamp: Date } | null = null;
 
@@ -56,8 +57,10 @@ function historyToChatMessages(items: Array<{ role: string; type?: string; conte
       flushAssistant();
       result.push({ role: "user", content: text, timestamp: ts });
     } else if (role === "toolResult") {
-      // Mark matching tool calls as completed
-      if (current) {
+      if (current && m.toolCallId) {
+        const tc = current.blocks.find((b) => b.type === "tool" && b.id === m.toolCallId);
+        if (tc && tc.type === "tool" && !tc.result) tc.result = "✓";
+      } else if (current) {
         for (const b of current.blocks) {
           if (b.type === "tool" && !b.result) { b.result = "✓"; break; }
         }
@@ -105,6 +108,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
   const sessionKeyRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const pendingSteerRef = useRef<ChatMessage[]>([]);
+  const settledRef = useRef<ChatMessage[]>([]);
   const autoMessageSent = useRef(false);
 
   const initAgent = useCallback(async (requestedAgent?: string) => {
@@ -173,7 +177,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     let blocks: ContentBlock[] = [];
     const abort = new AbortController();
     abortRef.current = abort;
-    let streamMsgId = `stream-${Date.now()}`;
+    let streamMsgId = randomUUID();
     pendingSteerRef.current = [];
 
     const updateAssistant = () => {
@@ -216,7 +220,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
           setMessages((prev) => [...prev, ...flushed]);
         }
         blocks = [];
-        streamMsgId = `stream-${Date.now()}`;
+        streamMsgId = randomUUID();
       } else if (e.type === "error") {
         setMessages((prev) => [...prev, { role: "system", content: `Error: ${e.message}`, timestamp: new Date() }]);
       }
@@ -258,6 +262,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
       const handled = dispatch(slash.command, slash.args, {
         onNewChat: () => {
           setMessages([]);
+          settledRef.current = [];
           setIsStreaming(true);
           (async () => {
             try {
@@ -308,7 +313,6 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     }
   });
 
-  const visible = messages.slice(-MAX_VISIBLE_MESSAGES);
   const contentWidth = (process.stdout.columns || 80) - 2;
 
   const renderMessage = (msg: ChatMessage, i: number) => {
@@ -367,9 +371,15 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     return <Box key={msg.id ?? i} flexDirection="column" width={contentWidth} marginTop={i > 0 ? 1 : 0}>{elements}</Box>;
   };
 
-  // Split: settled messages go to Static (terminal scrollback), active message stays dynamic
-  const settledMessages = isStreaming ? visible.slice(0, -1) : visible;
-  const activeMessage = isStreaming ? visible[visible.length - 1] : null;
+  // Split: settled messages go to Static (terminal scrollback), active message stays dynamic.
+  // settledRef is append-only so Static gets a stable reference and doesn't re-render old items.
+  const visible = messages.slice(-MAX_VISIBLE_MESSAGES);
+  const settledCount = isStreaming ? Math.max(visible.length - 1, 0) : visible.length;
+  if (settledCount > settledRef.current.length) {
+    const newSettled = visible.slice(settledRef.current.length, settledCount);
+    settledRef.current = [...settledRef.current, ...newSettled];
+  }
+  const activeMessage = isStreaming && visible.length > 0 ? visible[visible.length - 1] : null;
 
   return (
     <Box flexDirection="column">
@@ -380,17 +390,17 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         {isStreaming && <Text color="yellow"> (streaming...)</Text>}
       </Box>
 
-      <Static items={settledMessages.map((msg, i) => ({ ...msg, _idx: i }))}>
+      <Static items={settledRef.current.map((msg, i) => ({ ...msg, _idx: i }))}>
         {(item) => renderMessage(item, item._idx)}
       </Static>
 
       {error && <Box paddingX={1}><Text color="red">{error}</Text></Box>}
       {!agentReady && !error && <Box paddingX={1}><Text color="gray">Loading agent...</Text></Box>}
-      {activeMessage && <Box paddingX={1} flexDirection="column">{renderMessage(activeMessage, settledMessages.length)}</Box>}
+      {activeMessage && <Box paddingX={1} flexDirection="column">{renderMessage(activeMessage, settledRef.current.length)}</Box>}
 
       <Box borderStyle="single" paddingX={1} flexShrink={0} flexGrow={0}>
         <Text color="green">&gt; </Text>
-        <Text wrap="truncate">{input || (isStreaming ? "" : "")}</Text>
+        <Text wrap="truncate">{input}</Text>
         <Text color="gray">█</Text>
         {isStreaming && !input && (
           <Text color="gray" dimColor> type to steer · esc to stop</Text>

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -313,7 +313,8 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         {isStreaming && <Text color="yellow"> (streaming...)</Text>}
       </Box>
 
-      <Box flexDirection="column" paddingX={1} height={messageHeight} overflow="hidden">
+      <Box flexDirection="column-reverse" paddingX={1} height={messageHeight} overflow="hidden">
+        <Box flexDirection="column">
         {error && <Text color="red">{error}</Text>}
         {!agentReady && !error && <Text color="gray">Loading agent...</Text>}
         {visible.map((msg, i) => {
@@ -371,6 +372,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
 
           return <Box key={i} flexDirection="column" width={contentWidth} marginTop={i > 0 ? 1 : 0}>{elements}</Box>;
         })}
+        </Box>
       </Box>
 
       <Box borderStyle="single" paddingX={1} height={3}>

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { Box, Text, useInput, useApp } from "ink";
+import { Box, Text, Static, useInput, useApp } from "ink";
 import { parseSlashCommand, dispatch, HELP_TEXT } from "./commands.js";
 import type { ChatMessage, ContentBlock, TuiOptions, Screen, SSEEvent } from "./types.js";
 import * as api from "./api.js";
@@ -310,82 +310,85 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
 
   const visible = messages.slice(-MAX_VISIBLE_MESSAGES);
   const contentWidth = (process.stdout.columns || 80) - 2;
-  const headerHeight = 3;
-  const inputHeight = 3;
-  const messageHeight = (process.stdout.rows || 24) - headerHeight - inputHeight;
+
+  const renderMessage = (msg: ChatMessage, i: number) => {
+    const roleLabel = msg.role === "user" ? "You" : msg.role === "assistant" ? "Agent" : "System";
+    const roleColor = msg.role === "user" ? "green" : msg.role === "assistant" ? "blue" : "gray";
+
+    if (!msg.blocks) {
+      return (
+        <Box key={msg.id ?? i} flexDirection="column" width={contentWidth} marginTop={i > 0 ? 1 : 0}>
+          <Text wrap="wrap">
+            <Text color={roleColor} bold>{roleLabel}</Text>
+            <Text>: {msg.content}</Text>
+          </Text>
+        </Box>
+      );
+    }
+
+    const elements: React.ReactNode[] = [];
+    let labelRendered = false;
+    for (let j = 0; j < msg.blocks.length; j++) {
+      const block = msg.blocks[j];
+      if (block.type === "text") {
+        if (!labelRendered) {
+          labelRendered = true;
+          elements.push(
+            <Box key={j}>
+              <Text wrap="wrap">
+                <Text color={roleColor} bold>{roleLabel}</Text>
+                <Text>: {block.text}</Text>
+              </Text>
+            </Box>
+          );
+        } else {
+          elements.push(<Box key={j}><Text wrap="wrap">{block.text}</Text></Box>);
+        }
+      } else {
+        if (!labelRendered) {
+          labelRendered = true;
+          elements.push(
+            <Box key={`label`}>
+              <Text color={roleColor} bold>{roleLabel}</Text>
+              <Text>:</Text>
+            </Box>
+          );
+        }
+        elements.push(
+          <Box key={j}>
+            <Text color="gray" dimColor wrap="truncate-end">
+              {"  "}{block.name}({block.args.length > 60 ? block.args.slice(0, 60) + "…" : block.args}){block.isError ? " ✗" : block.result ? " ✓" : " …"}
+            </Text>
+          </Box>
+        );
+      }
+    }
+
+    return <Box key={msg.id ?? i} flexDirection="column" width={contentWidth} marginTop={i > 0 ? 1 : 0}>{elements}</Box>;
+  };
+
+  // Split: settled messages go to Static (terminal scrollback), active message stays dynamic
+  const settledMessages = isStreaming ? visible.slice(0, -1) : visible;
+  const activeMessage = isStreaming ? visible[visible.length - 1] : null;
 
   return (
-    <Box flexDirection="column" height={process.stdout.rows}>
-      <Box borderStyle="single" paddingX={1} height={headerHeight}>
+    <Box flexDirection="column">
+      <Box borderStyle="single" paddingX={1} flexShrink={0} flexGrow={0}>
         <Text bold>isotopes</Text>
         <Text> — agent: </Text>
         <Text color="cyan">{agentId || "loading..."}</Text>
         {isStreaming && <Text color="yellow"> (streaming...)</Text>}
       </Box>
 
-      <Box flexDirection="column-reverse" paddingX={1} height={messageHeight} overflow="hidden">
-        <Box flexDirection="column">
-        {error && <Text color="red">{error}</Text>}
-        {!agentReady && !error && <Text color="gray">Loading agent...</Text>}
-        {visible.map((msg, i) => {
-          const roleLabel = msg.role === "user" ? "You" : msg.role === "assistant" ? "Agent" : "System";
-          const roleColor = msg.role === "user" ? "green" : msg.role === "assistant" ? "blue" : "gray";
+      <Static items={settledMessages.map((msg, i) => ({ ...msg, _idx: i }))}>
+        {(item) => renderMessage(item, item._idx)}
+      </Static>
 
-          if (!msg.blocks) {
-            return (
-              <Box key={i} flexDirection="column" width={contentWidth} marginTop={i > 0 ? 1 : 0}>
-                <Text wrap="wrap">
-                  <Text color={roleColor} bold>{roleLabel}</Text>
-                  <Text>: {msg.content}</Text>
-                </Text>
-              </Box>
-            );
-          }
+      {error && <Box paddingX={1}><Text color="red">{error}</Text></Box>}
+      {!agentReady && !error && <Box paddingX={1}><Text color="gray">Loading agent...</Text></Box>}
+      {activeMessage && <Box paddingX={1} flexDirection="column">{renderMessage(activeMessage, settledMessages.length)}</Box>}
 
-          const elements: React.ReactNode[] = [];
-          let labelRendered = false;
-          for (let j = 0; j < msg.blocks.length; j++) {
-            const block = msg.blocks[j];
-            if (block.type === "text") {
-              if (!labelRendered) {
-                labelRendered = true;
-                elements.push(
-                  <Box key={j}>
-                    <Text wrap="wrap">
-                      <Text color={roleColor} bold>{roleLabel}</Text>
-                      <Text>: {block.text}</Text>
-                    </Text>
-                  </Box>
-                );
-              } else {
-                elements.push(<Box key={j}><Text wrap="wrap">{block.text}</Text></Box>);
-              }
-            } else {
-              if (!labelRendered) {
-                labelRendered = true;
-                elements.push(
-                  <Box key={`label`}>
-                    <Text color={roleColor} bold>{roleLabel}</Text>
-                    <Text>:</Text>
-                  </Box>
-                );
-              }
-              elements.push(
-                <Box key={j}>
-                  <Text color="gray" dimColor wrap="truncate-end">
-                    {"  "}{block.name}({block.args.length > 60 ? block.args.slice(0, 60) + "…" : block.args}){block.isError ? " ✗" : block.result ? " ✓" : " …"}
-                  </Text>
-                </Box>
-              );
-            }
-          }
-
-          return <Box key={i} flexDirection="column" width={contentWidth} marginTop={i > 0 ? 1 : 0}>{elements}</Box>;
-        })}
-        </Box>
-      </Box>
-
-      <Box borderStyle="single" paddingX={1} height={3}>
+      <Box borderStyle="single" paddingX={1} flexShrink={0} flexGrow={0}>
         <Text color="green">&gt; </Text>
         <Text wrap="truncate">{input || (isStreaming ? "" : "")}</Text>
         <Text color="gray">█</Text>

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -169,15 +169,19 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     const blocks: ContentBlock[] = [];
     const abort = new AbortController();
     abortRef.current = abort;
+    const streamMsgId = `stream-${Date.now()}`;
 
     const updateAssistant = () => {
       const fullText = blocks.filter((b) => b.type === "text").map((b) => b.text).join("");
+      const assistantMsg: ChatMessage = { role: "assistant", content: fullText, blocks: [...blocks], timestamp: new Date(), id: streamMsgId };
       setMessages((prev) => {
-        const last = prev[prev.length - 1];
-        if (last?.role === "assistant") {
-          return [...prev.slice(0, -1), { ...last, content: fullText, blocks: [...blocks] }];
+        const idx = prev.findIndex((m) => m.id === streamMsgId);
+        if (idx >= 0) {
+          const updated = [...prev];
+          updated[idx] = assistantMsg;
+          return updated;
         }
-        return [...prev, { role: "assistant", content: fullText, blocks: [...blocks], timestamp: new Date() }];
+        return [...prev, assistantMsg];
       });
     };
 

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -42,7 +42,6 @@ function historyToChatMessages(items: Array<{ role: string; type?: string; conte
     const ts = typeof m.timestamp === "number" ? new Date(m.timestamp) : new Date();
 
     if (role === "user") {
-      flushAssistant();
       let text = "";
       if (typeof m.content === "string") {
         text = m.content;
@@ -51,6 +50,10 @@ function historyToChatMessages(items: Array<{ role: string; type?: string; conte
           if (b.type === "text" && typeof b.text === "string") text += b.text;
         }
       }
+      if (!text) continue;
+      const steerPrefix = "[Messages arrived while you were working]\n";
+      if (text.startsWith(steerPrefix)) text = text.slice(steerPrefix.length);
+      flushAssistant();
       result.push({ role: "user", content: text, timestamp: ts });
     } else if (role === "toolResult") {
       // Mark matching tool calls as completed

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -52,8 +52,16 @@ function historyToChatMessages(items: Array<{ role: string; type?: string; conte
         }
       }
       result.push({ role: "user", content: text, timestamp: ts });
+    } else if (role === "toolResult") {
+      // Mark matching tool calls as completed
+      if (current) {
+        for (const b of current.blocks) {
+          if (b.type === "tool" && !b.result) { b.result = "✓"; break; }
+        }
+      }
     } else if (role === "assistant") {
-      if (!current) current = { text: "", blocks: [], timestamp: ts };
+      flushAssistant();
+      current = { text: "", blocks: [], timestamp: ts };
       if (Array.isArray(m.content)) {
         for (const b of m.content as Array<Record<string, unknown>>) {
           if (b.type === "text" && typeof b.text === "string") {

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -169,16 +169,17 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     setIsStreaming(true);
 
     const sessionKey = sessionKeyRef.current;
-    const blocks: ContentBlock[] = [];
+    let blocks: ContentBlock[] = [];
     const abort = new AbortController();
     abortRef.current = abort;
-    const streamMsgId = `stream-${Date.now()}`;
+    let streamMsgId = `stream-${Date.now()}`;
 
     const updateAssistant = () => {
       const fullText = blocks.filter((b) => b.type === "text").map((b) => b.text).join("");
-      const assistantMsg: ChatMessage = { role: "assistant", content: fullText, blocks: [...blocks], timestamp: new Date(), id: streamMsgId };
+      const msgId = streamMsgId;
+      const assistantMsg: ChatMessage = { role: "assistant", content: fullText, blocks: [...blocks], timestamp: new Date(), id: msgId };
       setMessages((prev) => {
-        const idx = prev.findIndex((m) => m.id === streamMsgId);
+        const idx = prev.findIndex((m) => m.id === msgId);
         if (idx >= 0) {
           const updated = [...prev];
           updated[idx] = assistantMsg;
@@ -207,6 +208,9 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
           tc.isError = e.isError;
         }
         updateAssistant();
+      } else if (e.type === "turn_end") {
+        blocks = [];
+        streamMsgId = `stream-${Date.now()}`;
       } else if (e.type === "error") {
         setMessages((prev) => [...prev, { role: "system", content: `Error: ${e.message}`, timestamp: new Date() }]);
       }

--- a/src/tui/ChatScreen.tsx
+++ b/src/tui/ChatScreen.tsx
@@ -104,6 +104,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
   const [error, setError] = useState<string | null>(null);
   const sessionKeyRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const pendingSteerRef = useRef<ChatMessage[]>([]);
   const autoMessageSent = useRef(false);
 
   const initAgent = useCallback(async (requestedAgent?: string) => {
@@ -173,6 +174,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     const abort = new AbortController();
     abortRef.current = abort;
     let streamMsgId = `stream-${Date.now()}`;
+    pendingSteerRef.current = [];
 
     const updateAssistant = () => {
       const fullText = blocks.filter((b) => b.type === "text").map((b) => b.text).join("");
@@ -209,6 +211,10 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         }
         updateAssistant();
       } else if (e.type === "turn_end") {
+        if (pendingSteerRef.current.length > 0) {
+          const flushed = pendingSteerRef.current.splice(0);
+          setMessages((prev) => [...prev, ...flushed]);
+        }
         blocks = [];
         streamMsgId = `stream-${Date.now()}`;
       } else if (e.type === "error") {
@@ -224,6 +230,10 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         setMessages((prev) => [...prev, { role: "system", content: `Error: ${msg}`, timestamp: new Date() }]);
       }
     } finally {
+      if (pendingSteerRef.current.length > 0) {
+        const flushed = pendingSteerRef.current.splice(0);
+        setMessages((prev) => [...prev, ...flushed]);
+      }
       abortRef.current = null;
       setIsStreaming(false);
     }
@@ -236,7 +246,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
 
     if (isStreaming) {
       const userMsg: ChatMessage = { role: "user", content: text, timestamp: new Date() };
-      setMessages((prev) => [...prev, userMsg]);
+      pendingSteerRef.current.push(userMsg);
       void api.steerMessage(agentId, sessionKeyRef.current!, text).catch((err) => {
         setMessages((prev) => [...prev, { role: "system", content: `Steer failed: ${err instanceof Error ? err.message : String(err)}`, timestamp: new Date() }]);
       });

--- a/src/tui/api.test.ts
+++ b/src/tui/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fetchStatus, fetchSessions, fetchUsage, isDaemonRunning, createSession, getHistory, abortMessage, deleteSession, parseSSELine } from "./api.js";
+import { fetchStatus, fetchSessions, fetchUsage, isDaemonRunning, createSession, getHistory, abortMessage, deleteSession, steerMessage, parseSSELine } from "./api.js";
 
 const mockFetch = vi.fn();
 
@@ -105,6 +105,20 @@ describe("deleteSession", () => {
   });
 });
 
+describe("steerMessage", () => {
+  it("posts steer message", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true, queued: 1 }) });
+    await steerMessage("bot", "s1", "hello");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:2712/api/sessions/bot/s1/steer",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ message: "hello" }),
+      }),
+    );
+  });
+});
+
 describe("parseSSELine", () => {
   it("parses text_delta", () => {
     const event = parseSSELine("text_delta", '{"text":"hello"}');
@@ -119,6 +133,11 @@ describe("parseSSELine", () => {
   it("parses tool_result", () => {
     const event = parseSSELine("tool_result", '{"toolCallId":"t1","toolName":"echo","result":"hi","isError":false}');
     expect(event).toEqual({ type: "tool_result", toolCallId: "t1", toolName: "echo", result: "hi", isError: false });
+  });
+
+  it("parses turn_end", () => {
+    const event = parseSSELine("turn_end", '{}');
+    expect(event).toEqual({ type: "turn_end" });
   });
 
   it("parses error", () => {

--- a/src/tui/api.ts
+++ b/src/tui/api.ts
@@ -76,6 +76,10 @@ export async function abortMessage(agentId: string, sessionKey: string): Promise
   await postJson(`${sessionPath(agentId, sessionKey)}/abort`);
 }
 
+export async function steerMessage(agentId: string, sessionKey: string, message: string): Promise<void> {
+  await postJson(`${sessionPath(agentId, sessionKey)}/steer`, { message });
+}
+
 export async function deleteSession(agentId: string, sessionKey: string): Promise<void> {
   await deleteJson(sessionPath(agentId, sessionKey));
 }

--- a/src/tui/api.ts
+++ b/src/tui/api.ts
@@ -97,6 +97,8 @@ export function parseSSELine(eventType: string, data: string): SSEEvent | null {
         return { type: "tool_call", toolCallId: parsed.toolCallId, toolName: parsed.toolName, args: parsed.args };
       case "tool_result":
         return { type: "tool_result", toolCallId: parsed.toolCallId, toolName: parsed.toolName, result: parsed.result, isError: parsed.isError };
+      case "turn_end":
+        return { type: "turn_end" };
       case "error":
         return { type: "error", message: parsed.message };
       case "agent_end":

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -51,6 +51,7 @@ export type SSEEvent =
   | { type: "text_delta"; text: string }
   | { type: "tool_call"; toolCallId: string; toolName: string; args: unknown }
   | { type: "tool_result"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+  | { type: "turn_end" }
   | { type: "error"; message: string }
   | { type: "agent_end"; stopReason: string };
 

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -7,6 +7,7 @@ export interface ChatMessage {
   content: string;
   blocks?: ContentBlock[];
   timestamp: Date;
+  id?: string;
 }
 
 export interface ToolCallEntry {


### PR DESCRIPTION
## Summary
- Add `POST /api/sessions/:agentId/:key/steer` endpoint to queue messages during agent execution
- Wire `onToolComplete` callback in `/message` handler to drain pending messages and inject via `session.steer()`
- Fix `/abort` endpoint to use `abortAgentSession()` from agent-runner (was broken no-op)
- Unblock TUI input during streaming: Enter steers, Esc/Ctrl-C aborts
- Show "type to steer · esc to stop" hint in input box during streaming

Closes #560

## Test plan
- [ ] `pnpm ci` passes (lint, typecheck, 1245 tests)
- [ ] Start daemon + TUI, send message triggering tool calls, type mid-stream → message appears in chat and agent acknowledges it
- [ ] Press Esc during streaming → agent stops
- [ ] `curl -X POST localhost:2712/api/sessions/main/tui:main/steer -H 'Content-Type: application/json' -d '{"message":"test"}'` during streaming → 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)