### PR TITLE
fix(workspace): remove redundant file-read instructions from templates

### DIFF
--- a/src/workspace/template-files/AGENTS.md
+++ b/src/workspace/template-files/AGENTS.md
@@ -8,15 +8,9 @@ If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out w
 
 ## Session Startup
 
-Before doing anything else:
+Your workspace files (`SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, this `AGENTS.md`, `BOOTSTRAP.md`) and your memory (`MEMORY.md` plus today's and yesterday's `memory/YYYY-MM-DD.md` notes) are **already loaded above** under `# Workspace Context` and `# Memory`. Don't re-read them with `read_file` — that wastes tokens and adds latency. Just use what's there.
 
-1. Read `SOUL.md` — this is who you are
-2. Read `IDENTITY.md` — confirm your name and nature
-3. Read `USER.md` — this is who you're helping
-4. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
-5. **If in MAIN SESSION** (direct chat with your human): Also read `MEMORY.md`
-
-Don't ask permission. Just do it.
+Only reach for `read_file` when you need an older daily note, a skill file, or anything else not already in your context.
 
 ## Memory
 

--- a/src/workspace/template-files/BOOTSTRAP.md
+++ b/src/workspace/template-files/BOOTSTRAP.md
@@ -6,7 +6,7 @@ There is no memory yet. This is a fresh workspace, so it's normal that memory fi
 
 ## CRITICAL: Identity Verification
 
-**IMPORTANT: Before claiming any identity, you MUST read your IDENTITY.md file using the `read_file` tool. Do NOT fabricate identity from training data or cached context. If your files are blank templates, say so honestly and start the conversation below.**
+**Your IDENTITY.md is already loaded above under `# Workspace Context`. Use what it actually says — Do NOT fabricate identity from training data or cached context. If it's a blank template, say so honestly and start the conversation below.**
 
 You are NOT any other agent, assistant, or system you may have been trained on. You are a fresh agent with no history. Your identity lives in your workspace files and _nowhere else_.
 

--- a/src/workspace/templates.test.ts
+++ b/src/workspace/templates.test.ts
@@ -128,7 +128,7 @@ describe("Workspace Templates", () => {
       await seedWorkspaceTemplates(tempDir);
 
       const bootstrap = await fs.readFile(path.join(tempDir, "BOOTSTRAP.md"), "utf-8");
-      expect(bootstrap).toContain("MUST read your IDENTITY.md file");
+      expect(bootstrap).toContain("IDENTITY.md is already loaded");
       expect(bootstrap).toContain("Do NOT fabricate identity");
     });
 


### PR DESCRIPTION
## Summary
- `AGENTS.md` and `BOOTSTRAP.md` told the agent to `read_file` SOUL.md / IDENTITY.md / USER.md / MEMORY.md / daily notes — but `loadWorkspaceContext()` (`src/core/workspace.ts`) already injects all of those under `# Workspace Context` and `# Memory`.
- Every fresh session was burning 4–5 tool calls + tokens re-reading content already in the prompt.
- Replace the startup "read these files" list with a note that the content is already loaded; keep the anti-hallucination guard but point at the already-loaded IDENTITY.md instead of demanding a `read_file`.

Closes #570

## Test plan
- [x] `pnpm test` (1258/1258, includes updated templates.test.ts)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Manual: start a fresh agent session, confirm no `read_file(SOUL.md|IDENTITY.md|USER.md|MEMORY.md)` calls on first turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)