### PR TITLE
refactor(pi-mono): refine system-prompt override pattern

### DIFF
--- a/src/core/pi-mono.test.ts
+++ b/src/core/pi-mono.test.ts
@@ -26,7 +26,8 @@ vi.mock("@mariozechner/pi-ai", () => ({
 }));
 
 import { getModel } from "@mariozechner/pi-ai";
-import { PiMonoCore, resolveModel } from "./pi-mono.js";
+import type { AgentSession } from "@mariozechner/pi-coding-agent";
+import { applySystemPromptOverrideToSession, PiMonoCore, resolveModel } from "./pi-mono.js";
 import { ToolRegistry } from "./tools.js";
 
 // ---------------------------------------------------------------------------
@@ -173,5 +174,41 @@ describe("PiMonoCore", () => {
 
     const cache = core.createServiceCache(makeConfig({ id: "agent-a" }));
     expect(cache.customTools).toHaveLength(0);
+  });
+});
+
+describe("applySystemPromptOverrideToSession", () => {
+  type MutableSession = {
+    _baseSystemPrompt?: string;
+    _rebuildSystemPrompt?: (toolNames: string[]) => string;
+    agent: { state: { systemPrompt?: string } };
+  };
+
+  function makeMockSession(): MutableSession {
+    return { agent: { state: {} } };
+  }
+
+  it("sets state.systemPrompt and _baseSystemPrompt to the override", () => {
+    const session = makeMockSession();
+    applySystemPromptOverrideToSession(session as unknown as AgentSession, "you are a helpful agent");
+
+    expect(session.agent.state.systemPrompt).toBe("you are a helpful agent");
+    expect(session._baseSystemPrompt).toBe("you are a helpful agent");
+  });
+
+  it("trims surrounding whitespace from the override", () => {
+    const session = makeMockSession();
+    applySystemPromptOverrideToSession(session as unknown as AgentSession, "  padded  ");
+
+    expect(session.agent.state.systemPrompt).toBe("padded");
+    expect(session._baseSystemPrompt).toBe("padded");
+  });
+
+  it("installs a _rebuildSystemPrompt that ignores tool list and returns the override", () => {
+    const session = makeMockSession();
+    applySystemPromptOverrideToSession(session as unknown as AgentSession, "stable identity");
+
+    expect(session._rebuildSystemPrompt?.(["t1", "t2"])).toBe("stable identity");
+    expect(session._rebuildSystemPrompt?.([])).toBe("stable identity");
   });
 });

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -10,7 +10,6 @@ import {
   type AgentSession,
   AuthStorage,
   createAgentSession,
-  DefaultResourceLoader,
   ModelRegistry,
   type SessionManager,
   SettingsManager,
@@ -122,6 +121,41 @@ function toToolDefinition(tool: Tool, handler: (args: unknown) => Promise<string
 }
 
 // ---------------------------------------------------------------------------
+// System prompt override
+// ---------------------------------------------------------------------------
+
+/**
+ * Force a system prompt onto an existing AgentSession by patching the SDK's
+ * private fields. Mirrors openclaw's pi-embedded-runner/system-prompt.ts.
+ *
+ * Three fields must be set together:
+ *  - `state.systemPrompt`: what the LLM sees on the next turn
+ *  - `_baseSystemPrompt`: SDK's prompt() handler resets state.systemPrompt
+ *    to this value on every call when an extensionRunner exists
+ *  - `_rebuildSystemPrompt`: SDK calls this when the tool list changes; we
+ *    return the override so a rebuild does not overwrite our prompt
+ *
+ * The `as unknown as { ... }` cast is required because `_baseSystemPrompt`
+ * and `_rebuildSystemPrompt` are private to the SDK's AgentSession class.
+ * If the SDK renames these fields, this will fail loudly at the access site
+ * (TypeScript will not catch it because of the cast — but the LLM will
+ * immediately revert to its default identity, which is a visible regression).
+ */
+export function applySystemPromptOverrideToSession(
+  session: AgentSession,
+  override: string,
+): void {
+  const prompt = override.trim();
+  session.agent.state.systemPrompt = prompt;
+  const mutableSession = session as unknown as {
+    _baseSystemPrompt?: string;
+    _rebuildSystemPrompt?: (toolNames: string[]) => string;
+  };
+  mutableSession._baseSystemPrompt = prompt;
+  mutableSession._rebuildSystemPrompt = () => prompt;
+}
+
+// ---------------------------------------------------------------------------
 // AgentServiceCache — cached per-agent SDK dependencies
 // ---------------------------------------------------------------------------
 
@@ -196,27 +230,19 @@ export class AgentServiceCache {
       compaction: compactionSettings,
     });
 
-    // Pass the system prompt via DefaultResourceLoader so it becomes
-    // `_baseSystemPrompt` inside the SDK. Mutating
-    // `session.agent.state.systemPrompt` after creation is unreliable —
-    // the SDK's prompt() handler resets state.systemPrompt back to
-    // _baseSystemPrompt on every call when an extensionRunner exists
-    // (which it always does when customTools are passed). See
-    // pi-coding-agent agent-session.js:768-772.
+    // The SDK's prompt() handler resets `state.systemPrompt` back to
+    // `_baseSystemPrompt` on every call when an extensionRunner exists
+    // (always true with customTools). It may also call `_rebuildSystemPrompt`
+    // when the tool list changes. To make the override stick, we patch all
+    // three fields directly on the session after creation. Mirrors openclaw's
+    // applySystemPromptOverrideToSession (system-prompt.ts:99-111).
     //
-    // IMPORTANT: when we provide our own resourceLoader, the SDK does
-    // NOT call reload() for us (sdk.js only auto-reloads its own
-    // default-constructed loader). Without reload(), `systemPrompt`
-    // stays undefined and the LLM falls back to the SDK's default
-    // identity ("I'm pi...").
+    // We do NOT pass an explicit DefaultResourceLoader: the SDK's built-in
+    // default loader handles tool/extension wiring fine, and routing the
+    // prompt through the loader couples us to the loader's auto-discovery
+    // side effects (e.g. AGENTS.md/CLAUDE.md leak — issue #590). Patching
+    // the session directly keeps prompt injection isolated from loader behavior.
     const cwd = opts.cwd ?? process.cwd();
-    const resourceLoader = new DefaultResourceLoader({
-      cwd,
-      agentDir: this.agentDir,
-      systemPrompt: opts.systemPrompt,
-      settingsManager,
-    });
-    await resourceLoader.reload();
 
     const { session } = await createAgentSession({
       cwd,
@@ -228,8 +254,9 @@ export class AgentServiceCache {
       customTools: this.customTools,
       sessionManager: opts.sessionManager,
       settingsManager,
-      resourceLoader,
     });
+
+    applySystemPromptOverrideToSession(session, opts.systemPrompt);
 
     return session;
   }


### PR DESCRIPTION
## Summary
- Refine PR #581's `DefaultResourceLoader({ systemPrompt }) + reload()` injection
- After `createAgentSession`, call `applySystemPromptOverrideToSession()` which patches three SDK fields together: `state.systemPrompt`, `_baseSystemPrompt`, and `_rebuildSystemPrompt`. This survives both the per-prompt reset and the per-tool-list rebuild that the SDK performs internally.
- Drop the explicit `DefaultResourceLoader` — the SDK's built-in default loader handles tool/extension wiring fine.

## Why
The previous loader-based approach coupled prompt injection to the loader's auto-discovery side effects: `DefaultResourceLoader({ cwd, agentDir })` scans for `AGENTS.md`/`CLAUDE.md` and prepends them as `# Project Context`. That is exactly the leak tracked in #590 (subagent inherits the daemon's `process.cwd()` project files).

## Trade-off
We now depend on the SDK's private field names (`_baseSystemPrompt`, `_rebuildSystemPrompt`) staying stable across `@mariozechner/pi-coding-agent` upgrades. The failure mode if a name changes is loud and immediate (LLM reverts to default identity, e.g. \"I'm pi...\") — much easier to catch than the silent project-context leak.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 1264/1264 pass; 3 new tests for `applySystemPromptOverrideToSession`
- [ ] Manual: start a fresh TUI session, ask \"who are you\" — first response should reflect SOUL.md persona, not SDK default identity
- [ ] Manual (#590): with daemon launched from the isotopes repo, `spawn_agent(agent=\"subagent\", task=\"who are you\")` — subagent response should NOT reference \"Isotopes\" / repo CLAUDE.md content

## Related
- #581 — the loader-based fix this replaces
- #590 — the project-context leak this avoids by removing the custom loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)