### PR TITLE
chore(spawn-agent): log costUsd and durationMs on completion

### DIFF
--- a/src/tools/spawn-agent.ts
+++ b/src/tools/spawn-agent.ts
@@ -194,6 +194,8 @@ export async function spawnAgent(
     }
   }
 
+  const startedAt = Date.now();
+
   try {
     const events = backend.spawn(taskId, {
       agentId,
@@ -214,11 +216,16 @@ export async function spawnAgent(
     }
 
     const result = summarizeEvents(collected);
+    const doneEvent = collected.find(
+      (e): e is Extract<RunEvent, { type: "run:done" }> => e.type === "run:done",
+    );
 
     log.info("Agent completed", {
       taskId,
       success: result.success,
       exitCode: result.exitCode,
+      durationMs: Date.now() - startedAt,
+      ...(doneEvent?.costUsd !== undefined ? { costUsd: doneEvent.costUsd } : {}),
     });
 
     taskRegistry.unregister(taskId);
@@ -232,7 +239,7 @@ export async function spawnAgent(
     };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
-    log.error("Agent spawn failed", { taskId, error });
+    log.error("Agent spawn failed", { taskId, error, durationMs: Date.now() - startedAt });
 
     taskRegistry.unregister(taskId);
 


### PR DESCRIPTION
## Summary
Follow-up to #599. After RunRecorder was removed, cost/duration only existed at runtime in the collected events — they were no longer surfaced anywhere observable. Add both to the existing \`Agent completed\` / \`Agent spawn failed\` INFO log lines so daemon logs remain the answer to \"what did this spawn cost / how long did it take\".

Net: 1 file, +8 / -1.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (1249 passing)
- [ ] Tail daemon log during a spawn → confirm \`durationMs\` and (for builtin) \`costUsd\` show up

🤖 Generated with [Claude Code](https://claude.com/claude-code)