### PR TITLE
refactor(http): move src/api/ to src/plugins/http/

### DIFF
--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -23,7 +23,7 @@ import {
   ensureDirectories,
 } from "./paths.js";
 import { HotReloadManager } from "../workspace/index.js";
-import { ApiServer } from "../api/server.js";
+import { ApiServer } from "../plugins/http/server.js";
 import { CronScheduler } from "../automation/cron-job.js";
 import { HeartbeatManager } from "../automation/heartbeat.js";
 import { UsageTracker } from "./usage-tracker.js";

--- a/src/plugins/http/chat.test.ts
+++ b/src/plugins/http/chat.test.ts
@@ -1,11 +1,11 @@
-// src/api/chat.test.ts — Unit tests for chat session creation with sessionKey
+// src/plugins/http/chat.test.ts — Unit tests for chat session creation with sessionKey
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import http from "node:http";
 import { ApiServer } from "./server.js";
-import { CronScheduler } from "../automation/cron-job.js";
-import { createMockAgentManager } from "../core/test-helpers.js";
-import { SessionStoreManager } from "../core/session-store-manager.js";
+import { CronScheduler } from "../../automation/cron-job.js";
+import { createMockAgentManager } from "../../core/test-helpers.js";
+import { SessionStoreManager } from "../../core/session-store-manager.js";
 
 function request(
   port: number,

--- a/src/plugins/http/config.ts
+++ b/src/plugins/http/config.ts
@@ -1,4 +1,4 @@
-// src/api/config.ts — Configuration routes
+// src/plugins/http/config.ts — Configuration routes
 
 import { addRoute } from "./routes.js";
 import { sendJson, sendError } from "./middleware.js";

--- a/src/plugins/http/cron.ts
+++ b/src/plugins/http/cron.ts
@@ -1,8 +1,8 @@
-// src/api/cron.ts — Cron job management routes
+// src/plugins/http/cron.ts — Cron job management routes
 
 import { addRoute } from "./routes.js";
 import { sendJson, sendError, handleRouteError } from "./middleware.js";
-import type { CronJobInput } from "../automation/cron-job.js";
+import type { CronJobInput } from "../../automation/cron-job.js";
 
 // ---------------------------------------------------------------------------
 // GET /api/cron — list cron jobs

--- a/src/plugins/http/index.ts
+++ b/src/plugins/http/index.ts
@@ -1,4 +1,4 @@
-// src/api/index.ts — Barrel exports for the API module
+// src/plugins/http/index.ts — Barrel exports for the API module
 
 export { ApiServer } from "./server.js";
 export type { ApiServerConfig } from "./server.js";

--- a/src/plugins/http/logs.ts
+++ b/src/plugins/http/logs.ts
@@ -1,11 +1,11 @@
-// src/api/logs.ts — Log tailing route
+// src/plugins/http/logs.ts — Log tailing route
 
 import { execFile } from "node:child_process";
 import { access, constants } from "node:fs/promises";
 import path from "node:path";
 import { addRoute } from "./routes.js";
 import { sendJson, handleRouteError } from "./middleware.js";
-import { getIsotopesHome, getLogsDir } from "../core/paths.js";
+import { getIsotopesHome, getLogsDir } from "../../core/paths.js";
 
 const LOG_CANDIDATES = [
   () => path.join(getLogsDir(), "isotopes.log"),

--- a/src/plugins/http/middleware.ts
+++ b/src/plugins/http/middleware.ts
@@ -1,8 +1,8 @@
-// src/api/middleware.ts — HTTP middleware for the Isotopes REST API
+// src/plugins/http/middleware.ts — HTTP middleware for the Isotopes REST API
 // CORS, JSON body parsing, error handling, and request logging.
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../../core/logger.js";
 
 const log = createLogger("api");
 

--- a/src/plugins/http/routes.test.ts
+++ b/src/plugins/http/routes.test.ts
@@ -1,9 +1,9 @@
-// src/api/routes.test.ts — Unit tests for REST route handlers
+// src/plugins/http/routes.test.ts — Unit tests for REST route handlers
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import http from "node:http";
 import { ApiServer } from "./server.js";
-import { CronScheduler } from "../automation/cron-job.js";
+import { CronScheduler } from "../../automation/cron-job.js";
 
 function request(
   port: number,

--- a/src/plugins/http/routes.ts
+++ b/src/plugins/http/routes.ts
@@ -1,13 +1,13 @@
-// src/api/routes.ts — Route registry (addRoute / matchRoute)
+// src/plugins/http/routes.ts — Route registry (addRoute / matchRoute)
 
 import type { ServerResponse } from "node:http";
 
-import type { CronScheduler } from "../automation/cron-job.js";
-import type { ConfigReloader } from "../workspace/config-reloader.js";
-import type { DefaultAgentManager } from "../core/agent-manager.js";
-import type { UsageTracker } from "../core/usage-tracker.js";
-import type { SessionStoreManager } from "../core/session-store-manager.js";
-import type { HookRegistry } from "../plugins/hooks.js";
+import type { CronScheduler } from "../../automation/cron-job.js";
+import type { ConfigReloader } from "../../workspace/config-reloader.js";
+import type { DefaultAgentManager } from "../../core/agent-manager.js";
+import type { UsageTracker } from "../../core/usage-tracker.js";
+import type { SessionStoreManager } from "../../core/session-store-manager.js";
+import type { HookRegistry } from "../../plugins/hooks.js";
 import type { ApiRequest } from "./middleware.js";
 
 // ---------------------------------------------------------------------------

--- a/src/plugins/http/server.test.ts
+++ b/src/plugins/http/server.test.ts
@@ -1,9 +1,9 @@
-// src/api/server.test.ts — Unit tests for the ApiServer
+// src/plugins/http/server.test.ts — Unit tests for the ApiServer
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import http from "node:http";
 import { ApiServer } from "./server.js";
-import { CronScheduler } from "../automation/cron-job.js";
+import { CronScheduler } from "../../automation/cron-job.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/plugins/http/server.ts
+++ b/src/plugins/http/server.ts
@@ -1,14 +1,14 @@
-// src/api/server.ts — HTTP server for the Isotopes REST API
+// src/plugins/http/server.ts — HTTP server for the Isotopes REST API
 // Minimal server built on Node.js built-in http module (no Express).
 
 import http from "node:http";
 import path from "node:path";
-import { createLogger } from "../core/logger.js";
-import type { CronScheduler } from "../automation/cron-job.js";
-import type { ConfigReloader } from "../workspace/config-reloader.js";
-import type { DefaultAgentManager } from '../core/agent-manager.js';
-import type { UsageTracker } from "../core/usage-tracker.js";
-import type { SessionStoreManager } from "../core/session-store-manager.js";
+import { createLogger } from "../../core/logger.js";
+import type { CronScheduler } from "../../automation/cron-job.js";
+import type { ConfigReloader } from "../../workspace/config-reloader.js";
+import type { DefaultAgentManager } from "../../core/agent-manager.js";
+import type { UsageTracker } from "../../core/usage-tracker.js";
+import type { SessionStoreManager } from "../../core/session-store-manager.js";
 import {
   applyCors,
   parseJsonBody,
@@ -19,8 +19,8 @@ import {
 } from "./middleware.js";
 import { matchRoute, type RouteDeps } from "./routes.js";
 import { serveStaticFile } from "./static.js";
-import type { HookRegistry } from "../plugins/hooks.js";
-import type { UIRegistry } from "../plugins/ui-registry.js";
+import type { HookRegistry } from "../../plugins/hooks.js";
+import type { UIRegistry } from "../../plugins/ui-registry.js";
 
 // Register route modules (side-effect imports)
 import "./cron.js";

--- a/src/plugins/http/sessions.ts
+++ b/src/plugins/http/sessions.ts
@@ -1,4 +1,4 @@
-// src/api/sessions.ts — Unified session endpoints (read, create, stream, abort, delete)
+// src/plugins/http/sessions.ts — Unified session endpoints (read, create, stream, abort, delete)
 //
 // /api/sessions                        — list all sessions
 // /api/sessions/:agentId               — list sessions for one agent
@@ -9,13 +9,13 @@
 
 import { addRoute } from "./routes.js";
 import { sendJson, sendError } from "./middleware.js";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../../core/logger.js";
 import { randomUUID } from "node:crypto";
-import { runAgentLoop, abortAgentSession } from "../core/agent-runner.js";
-import { userMessage } from "../core/messages.js";
-import { agentEventBus } from "../core/agent-event-bus.js";
-import type { DefaultSessionStore } from "../core/session-store.js";
-import type { Session } from "../core/types.js";
+import { runAgentLoop, abortAgentSession } from "../../core/agent-runner.js";
+import { userMessage } from "../../core/messages.js";
+import { agentEventBus } from "../../core/agent-event-bus.js";
+import type { DefaultSessionStore } from "../../core/session-store.js";
+import type { Session } from "../../core/types.js";
 
 const log = createLogger("api:sessions");
 

--- a/src/plugins/http/static.ts
+++ b/src/plugins/http/static.ts
@@ -1,4 +1,4 @@
-// src/api/static.ts — Static file server for plugin UIs
+// src/plugins/http/static.ts — Static file server for plugin UIs
 
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/src/plugins/http/status.ts
+++ b/src/plugins/http/status.ts
@@ -1,8 +1,8 @@
-// src/api/status.ts — GET /api/status
+// src/plugins/http/status.ts — GET /api/status
 
 import { addRoute } from "./routes.js";
 import { sendJson } from "./middleware.js";
-import { VERSION } from "../version.js";
+import { VERSION } from "../../version.js";
 
 addRoute("GET", "/api/status", (_req, res, deps) => {
   const cronJobCount = deps.cronScheduler.listJobs().length;

--- a/src/plugins/http/usage.ts
+++ b/src/plugins/http/usage.ts
@@ -1,4 +1,4 @@
-// src/api/usage.ts — Global usage stats route
+// src/plugins/http/usage.ts — Global usage stats route
 
 import { addRoute } from "./routes.js";
 import { sendJson } from "./middleware.js";


### PR DESCRIPTION
## Summary
- Pure rename + import-path updates ahead of the unified runtime work in #568.
- HTTP URLs unchanged; only on-disk paths and import specifiers move.
- Header comments updated to reflect new paths.

Prep step for #568 (unified AgentRuntime). Carved out as its own PR so the substantive runtime refactor lands against a stable base.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1249 tests pass
- [ ] Manual: hit a REST endpoint to confirm URLs are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)