### PR TITLE
fix(commands): pass agent systemPrompt to /compact session

### DIFF
--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -225,7 +225,7 @@ export class SlashCommandHandler {
 
       const session = await ctx.agentCache.createSession({
         sessionManager,
-        systemPrompt: "",
+        systemPrompt: ctx.agentManager.getSystemPrompt(ctx.agentId) ?? "",
       });
 
       try {


### PR DESCRIPTION
## Summary
- `/compact` was creating a session with an empty `systemPrompt`, so post-#598 the compaction LLM call lost agent identity (SOUL.md persona, etc.).
- Resolve the prompt via `ctx.agentManager.getSystemPrompt(ctx.agentId)`, matching the pattern in `src/core/runtime.ts:208,281`.

Closes #600

## Test plan
- [x] `pnpm typecheck`
- [x] `npx vitest run src/commands/` (30 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)