### PR TITLE
refactor(vnext): step 1 — relocate logger to logging/, paths to top-level

### DIFF
--- a/src/agents/failure-tracker.ts
+++ b/src/agents/failure-tracker.ts
@@ -1,4 +1,4 @@
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("failure-tracker");
 

--- a/src/agents/runners/builtin.ts
+++ b/src/agents/runners/builtin.ts
@@ -2,7 +2,7 @@
 // and leaf (ephemeral cache + parent's filtered tools).
 
 import { randomUUID } from "node:crypto";
-import { createLogger } from "../../core/logger.js";
+import { createLogger } from "../../vnext/logging/logger.js";
 import { PiMonoCore } from "../../core/pi-mono.js";
 import { ToolRegistry, type ToolHandler } from "../../core/tools.js";
 import { buildSpawnAgentSystemPrompt } from "../builtin/system-prompt.js";

--- a/src/agents/runners/claude.ts
+++ b/src/agents/runners/claude.ts
@@ -2,7 +2,7 @@
 // see one event taxonomy.
 
 import { query, type Options, type PermissionMode, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
-import { createLogger } from "../../core/logger.js";
+import { createLogger } from "../../vnext/logging/logger.js";
 import {
   DEFAULT_SPAWN_ALLOWED_TOOLS,
   type SettingSource,

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -4,7 +4,7 @@
 import { existsSync, statSync, realpathSync } from "node:fs";
 import { resolve, normalize } from "node:path";
 import { randomUUID } from "node:crypto";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type {
   AgentSessionKind,
   AgentSessionPolicy,

--- a/src/automation/cron-config.test.ts
+++ b/src/automation/cron-config.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CronScheduler, type CronJob } from "./cron-job.js";
 
 // Suppress log output in tests
-vi.mock("../core/logger.js", () => ({
+vi.mock("../vnext/logging/logger.js", () => ({
   createLogger: () => ({
     debug: vi.fn(),
     info: vi.fn(),

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -2,7 +2,7 @@
 // Manages cron-based scheduled tasks for agents and channels.
 
 import { Cron } from "croner";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("cron");
 

--- a/src/automation/heartbeat.test.ts
+++ b/src/automation/heartbeat.test.ts
@@ -29,7 +29,7 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 // Suppress log output in tests
-vi.mock("../core/logger.js", () => ({
+vi.mock("../vnext/logging/logger.js", () => ({
   createLogger: () => ({
     debug: vi.fn(),
     info: vi.fn(),

--- a/src/automation/heartbeat.ts
+++ b/src/automation/heartbeat.ts
@@ -4,7 +4,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createLogger, type Logger } from "../core/logger.js";
+import { createLogger, type Logger } from "../vnext/logging/logger.js";
 import { isSilentReply } from "../core/silent-reply.js";
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,13 +8,13 @@ import { fileURLToPath } from "node:url";
 import fs from "node:fs/promises";
 import { VERSION } from "./version.js";
 import { loadConfig } from "./core/config.js";
-import { logger } from "./core/logger.js";
+import { logger } from "./vnext/logging/logger.js";
 import { createRuntime } from "./core/runtime.js";
 import {
   getConfigPath,
   getIsotopesHome,
   getLogsDir,
-} from "./core/paths.js";
+} from "./vnext/paths.js";
 import { DaemonProcess } from "./daemon/process.js";
 import { ServiceManager, getPlatform, type ServiceConfig } from "./daemon/service.js";
 

--- a/src/commands/slash-commands.ts
+++ b/src/commands/slash-commands.ts
@@ -4,7 +4,7 @@
 import type { SessionStore } from "../core/types.js";
 import type { AgentServiceCache } from "../core/pi-mono.js";
 import type { DefaultAgentManager } from "../core/agent-manager.js";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import { failureTracker } from "../agents/failure-tracker.js";
 
 const log = createLogger("commands");

--- a/src/core/agent-event-bus.ts
+++ b/src/core/agent-event-bus.ts
@@ -1,5 +1,5 @@
 import type { AgentEvent } from "./types.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("event-bus");
 

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -16,7 +16,7 @@ import {
   ensureExplicitWorkspaceDir,
   ensureWorkspaceDir,
   resolveExplicitWorkspacePath,
-} from "./paths.js";
+} from "../vnext/paths.js";
 import {
   loadWorkspaceContext,
   buildSystemPrompt,
@@ -37,7 +37,7 @@ import * as nodeFs from "node:fs/promises";
 import { PiMonoCore, type AgentServiceCache } from "./pi-mono.js";
 import type { DefaultAgentManager } from "./agent-manager.js";
 import type { AgentConfig } from "./types.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { HookRegistry } from "../plugins/hooks.js";
 
 const log = createLogger("agent-init");

--- a/src/core/agent-run.test.ts
+++ b/src/core/agent-run.test.ts
@@ -6,7 +6,7 @@ import { AgentRuntime } from "../agents/runtime.js";
 import type { RegisteredAgent, SendMessageRequest } from "../agents/types.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { agentEventBus } from "./agent-event-bus.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("test:agent-run");
 

--- a/src/core/agent-run.ts
+++ b/src/core/agent-run.ts
@@ -5,7 +5,7 @@
 import type { AgentRuntime } from "../agents/runtime.js";
 import { agentEventBus } from "./agent-event-bus.js";
 import { userMessage, assistantMessage, getAgentEndMeta, getUsage } from "./messages.js";
-import type { Logger } from "./logger.js";
+import type { Logger } from "../vnext/logging/logger.js";
 import type { UsageTracker } from "./usage-tracker.js";
 import type { HookRegistry } from "../plugins/hooks.js";
 import { runWithMessageContext } from "../transport/context.js";

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -19,7 +19,7 @@ import type {
 } from "./types.js";
 import { resolveSandboxConfig, type SandboxConfig } from "../sandbox/config.js";
 import type { PluginConfigEntry } from "../plugins/types.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("config");
 

--- a/src/core/pi-mono.ts
+++ b/src/core/pi-mono.ts
@@ -23,7 +23,7 @@ import {
 } from "./types.js";
 import type { ToolRegistry } from "./tools.js";
 import { resolveCompactionConfig } from "./compaction.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import * as path from "node:path";
 
 // ---------------------------------------------------------------------------

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -12,7 +12,7 @@ import path from "node:path";
 import { PiMonoCore } from "./pi-mono.js";
 import { DefaultAgentManager } from "./agent-manager.js";
 import { SessionStoreManager } from "./session-store-manager.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import { LazyTransportContext } from "../tools/react.js";
 import { ProcessRegistry } from "../tools/exec.js";
 import { ToolRegistry } from "./tools.js";
@@ -20,14 +20,14 @@ import { ContainerManager, SandboxExecutor } from "../sandbox/index.js";
 import { initializeAgent } from "./agent-init.js";
 import {
   ensureDirectories,
-} from "./paths.js";
+} from "../vnext/paths.js";
 import { HotReloadManager } from "../workspace/index.js";
 import { ApiServer } from "../plugins/http/server.js";
 import { CronScheduler } from "../automation/cron-job.js";
 import { HeartbeatManager } from "../automation/heartbeat.js";
 import { UsageTracker } from "./usage-tracker.js";
 import { PluginManager } from "../plugins/manager.js";
-import { getIsotopesHome } from "./paths.js";
+import { getIsotopesHome } from "../vnext/paths.js";
 import { AgentRuntime } from "../agents/runtime.js";
 import { consumeRootRun } from "./agent-run.js";
 

--- a/src/core/session-store-manager.test.ts
+++ b/src/core/session-store-manager.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import fs from "node:fs/promises";
 
 import { SessionStoreManager } from "./session-store-manager.js";
-import { getAgentSessionsDir, normalizeAgentId } from "./paths.js";
+import { getAgentSessionsDir, normalizeAgentId } from "../vnext/paths.js";
 
 let tmpRoot: string;
 let originalHome: string | undefined;

--- a/src/core/session-store-manager.ts
+++ b/src/core/session-store-manager.ts
@@ -5,9 +5,9 @@ import {
   ensureAgentSessionsDir,
   getAgentSessionsDir,
   normalizeAgentId,
-} from "./paths.js";
+} from "../vnext/paths.js";
 import type { SessionConfig } from "./types.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { HookRegistry } from "../plugins/hooks.js";
 
 const log = createLogger("session-store-manager");

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -15,7 +15,7 @@ import type {
   SessionStoreConfig,
   SessionConfig,
 } from "./types.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("session-store");
 

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -14,7 +14,7 @@ import { getDiscordSubagentStreamContext } from "../plugins/discord/subagent-str
 import { DiscordSubagentSink } from "../plugins/discord/discord-subagent-sink.js";
 import { failureTracker } from "../agents/failure-tracker.js";
 import { getAgentEndMeta } from "./messages.js";
-import { createLogger } from "./logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 const log = createLogger("tools:send-message");
 /** Function that executes a tool call and returns a string result. */
 export type ToolHandler = (args: unknown) => Promise<string>;

--- a/src/daemon/process.ts
+++ b/src/daemon/process.ts
@@ -6,7 +6,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("daemon:process");
 

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import os from "node:os";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const execAsync = promisify(exec);
 const log = createLogger("daemon:service");

--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -1,7 +1,7 @@
 // src/plugins/api.ts — Scoped plugin API factory
 
 import path from "node:path";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { HookRegistry } from "./hooks.js";
 import type { UIRegistry } from "./ui-registry.js";
 import type { ToolPluginRegistry } from "./tool-registry.js";

--- a/src/plugins/discord/discord-manager.ts
+++ b/src/plugins/discord/discord-manager.ts
@@ -12,7 +12,7 @@ import { DiscordTransport } from "./discord.js";
 import { ThreadBindingManager } from "./thread-bindings.js";
 import type { ReplyToMode } from "./reply-directive.js";
 import type { UsageTracker } from "../../core/usage-tracker.js";
-import { createLogger } from "../../core/logger.js";
+import { createLogger } from "../../vnext/logging/logger.js";
 
 const log = createLogger("discord-manager");
 

--- a/src/plugins/discord/discord-subagent-sink.ts
+++ b/src/plugins/discord/discord-subagent-sink.ts
@@ -12,7 +12,7 @@
 //                      AgentEvent types.
 //   3. finish(result)→ posts a summary, unregisters the thread.
 
-import { createLogger } from "../../core/logger.js";
+import { createLogger } from "../../vnext/logging/logger.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { DiscordSubagentStreamContext } from "./subagent-stream-context.js";
 

--- a/src/plugins/discord/discord.ts
+++ b/src/plugins/discord/discord.ts
@@ -22,7 +22,7 @@ import type { DefaultAgentManager } from "../../core/agent-manager.js";
 import { userMessage as mkUserMsg, userMessageWithImages as mkUserMsgWithImages } from "../../core/messages.js";
 import type { ContextConfigFile } from "../../core/config.js";
 import { shouldRespondToMessage } from "../../core/mention.js";
-import { loggers } from "../../core/logger.js";
+import { loggers } from "../../vnext/logging/logger.js";
 import { ThreadBindingManager } from "./thread-bindings.js";
 import { consumeRootRun, cancelRunBySessionId, isRootRunActive } from "../../core/agent-run.js";
 import { runWithDiscordSubagentStream, type DiscordSubagentStreamContext } from "./subagent-stream-context.js";

--- a/src/plugins/discord/index.ts
+++ b/src/plugins/discord/index.ts
@@ -6,7 +6,7 @@ import type { Transport, SessionStore } from "../../core/types.js";
 import { DiscordTransportManager } from "./discord-manager.js";
 import { ThreadBindingManager } from "./thread-bindings.js";
 import type { DiscordChannelsConfig } from "./types.js";
-import { createLogger } from "../../core/logger.js";
+import { createLogger } from "../../vnext/logging/logger.js";
 import path from "node:path";
 
 const log = createLogger("plugin:discord");

--- a/src/plugins/discord/thread-bindings.ts
+++ b/src/plugins/discord/thread-bindings.ts
@@ -4,7 +4,7 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { ThreadBinding } from "./types.js";
-import { logger } from "../../core/logger.js";
+import { logger } from "../../vnext/logging/logger.js";
 
 /** Callback invoked when a new thread binding is created */
 export type ThreadBindingCallback = (binding: ThreadBinding) => void;

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -2,7 +2,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { PluginManifest } from "./types.js";
 
 const log = createLogger("plugins:discovery");

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -1,7 +1,7 @@
 // src/plugins/hooks.ts — Typed hook registry for plugin lifecycle events
 
 import type { HookName, HookPayloads } from "./types.js";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 type HookHandler<H extends HookName> = (payload: HookPayloads[H]) => void | Promise<void>;
 

--- a/src/plugins/http/logs.ts
+++ b/src/plugins/http/logs.ts
@@ -5,7 +5,7 @@ import { access, constants } from "node:fs/promises";
 import path from "node:path";
 import { addRoute } from "./routes.js";
 import { sendJson, handleRouteError } from "./middleware.js";
-import { getIsotopesHome, getLogsDir } from "../../core/paths.js";
+import { getIsotopesHome, getLogsDir } from "../../vnext/paths.js";
 
 const LOG_CANDIDATES = [
   () => path.join(getLogsDir(), "isotopes.log"),

--- a/src/plugins/http/middleware.ts
+++ b/src/plugins/http/middleware.ts
@@ -2,7 +2,7 @@
 // CORS, JSON body parsing, error handling, and request logging.
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { createLogger } from "../../core/logger.js";
+import { createLogger } from "../../vnext/logging/logger.js";
 
 const log = createLogger("api");
 

--- a/src/plugins/http/server.ts
+++ b/src/plugins/http/server.ts
@@ -3,7 +3,7 @@
 
 import http from "node:http";
 import path from "node:path";
-import { createLogger } from "../../core/logger.js";
+import { createLogger } from "../../vnext/logging/logger.js";
 import type { CronScheduler } from "../../automation/cron-job.js";
 import type { ConfigReloader } from "../../workspace/config-reloader.js";
 import type { DefaultAgentManager } from "../../core/agent-manager.js";

--- a/src/plugins/http/sessions.ts
+++ b/src/plugins/http/sessions.ts
@@ -9,7 +9,7 @@
 
 import { addRoute } from "./routes.js";
 import { sendJson, sendError } from "./middleware.js";
-import { createLogger } from "../../core/logger.js";
+import { createLogger } from "../../vnext/logging/logger.js";
 import { randomUUID } from "node:crypto";
 import { consumeRootRun, cancelRunBySessionId } from "../../core/agent-run.js";
 import { userMessage } from "../../core/messages.js";

--- a/src/plugins/manager.ts
+++ b/src/plugins/manager.ts
@@ -2,7 +2,7 @@
 
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import { HookRegistry } from "./hooks.js";
 import { UIRegistry } from "./ui-registry.js";
 import { ToolPluginRegistry } from "./tool-registry.js";

--- a/src/plugins/tool-registry.ts
+++ b/src/plugins/tool-registry.ts
@@ -2,7 +2,7 @@
 
 import type { ToolEntry } from "../core/tools.js";
 import type { PluginToolContext, PluginToolFactory } from "./types.js";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("plugins:tools");
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,7 +1,7 @@
 // src/plugins/types.ts — Plugin system interfaces
 // Defines the manifest, lifecycle, hooks, and API surface for Isotopes plugins.
 
-import type { Logger } from "../core/logger.js";
+import type { Logger } from "../vnext/logging/logger.js";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionStore, Tool, Transport } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -2,7 +2,7 @@
 // Manages the lifecycle of sandbox containers per-agent and routes
 // command execution through them.
 
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { ContainerInfo, ContainerManager, ExecResult } from "./container.js";
 import { shouldSandbox, type SandboxConfig, type WorkspaceAccess } from "./config.js";
 

--- a/src/sandbox/fs-bridge.ts
+++ b/src/sandbox/fs-bridge.ts
@@ -12,7 +12,7 @@
 
 import { spawn } from "node:child_process";
 import * as nodeFs from "node:fs/promises";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { SandboxExecutor } from "./executor.js";
 
 const log = createLogger("sandbox:fs-bridge");

--- a/src/skills/discovery.ts
+++ b/src/skills/discovery.ts
@@ -3,7 +3,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import { getIsotopesHome } from "../core/paths.js";
+import { getIsotopesHome } from "../vnext/paths.js";
 
 // Directories to skip during recursive scanning
 const IGNORED_DIRS = new Set([

--- a/src/tools/exec.test.ts
+++ b/src/tools/exec.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import type { ChildProcess } from "node:child_process";
 
-vi.mock("../core/logger.js", () => ({
+vi.mock("../vnext/logging/logger.js", () => ({
   createLogger: () => ({
     info: vi.fn(),
     warn: vi.fn(),

--- a/src/tools/exec.ts
+++ b/src/tools/exec.ts
@@ -4,7 +4,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { Tool } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";
 import type { SandboxExecutor } from "../sandbox/executor.js";

--- a/src/tools/react.ts
+++ b/src/tools/react.ts
@@ -1,6 +1,6 @@
 // src/tools/react.ts — message_react tool
 
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { Tool, Transport } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";
 

--- a/src/vnext/logging/logger.test.ts
+++ b/src/vnext/logging/logger.test.ts
@@ -1,4 +1,4 @@
-// src/core/logger.test.ts — Unit tests for logger
+// src/vnext/logging/logger.test.ts — Unit tests for logger
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createLogger, logger, loggers } from "./logger.js";

--- a/src/vnext/logging/logger.ts
+++ b/src/vnext/logging/logger.ts
@@ -1,4 +1,4 @@
-// src/core/logger.ts — Logging system for Isotopes
+// src/vnext/logging/logger.ts — Logging system for Isotopes
 // Provides structured logging with levels, timestamps, and tags.
 
 /** Log severity level. */

--- a/src/vnext/paths.test.ts
+++ b/src/vnext/paths.test.ts
@@ -1,4 +1,4 @@
-// src/core/paths.test.ts — Unit tests for paths module
+// src/vnext/paths.test.ts — Unit tests for paths module
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import path from "node:path";

--- a/src/vnext/paths.ts
+++ b/src/vnext/paths.ts
@@ -1,4 +1,4 @@
-// src/core/paths.ts — Directory and path management for Isotopes
+// src/vnext/paths.ts — Directory and path management for Isotopes
 // Centralizes all path logic for consistent directory structure.
 
 import os from "node:os";

--- a/src/workspace/config-reloader.ts
+++ b/src/workspace/config-reloader.ts
@@ -1,7 +1,7 @@
 // src/workspace/config-reloader.ts — Auto-reload config on file changes
 // Watches the Isotopes config file and reloads it when modified.
 
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import { loadConfig, type IsotopesConfigFile } from "../core/config.js";
 import { WorkspaceWatcher, type FileChange } from "./watcher.js";
 

--- a/src/workspace/hot-reload.ts
+++ b/src/workspace/hot-reload.ts
@@ -2,7 +2,7 @@
 // Watches workspace files and triggers agent reload when they change.
 
 import path from "node:path";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import type { DefaultAgentManager } from '../core/agent-manager.js';;
 import { WorkspaceWatcher } from "./watcher.js";
 

--- a/src/workspace/state.ts
+++ b/src/workspace/state.ts
@@ -3,7 +3,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 import { isBrandNewWorkspace } from "./templates.js";
 
 const log = createLogger("workspace:state");

--- a/src/workspace/templates.ts
+++ b/src/workspace/templates.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("workspace:templates");
 

--- a/src/workspace/watcher.ts
+++ b/src/workspace/watcher.ts
@@ -3,7 +3,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { createLogger } from "../core/logger.js";
+import { createLogger } from "../vnext/logging/logger.js";
 
 const log = createLogger("watcher");
 


### PR DESCRIPTION
First step in #623: bottom-up rebuild of `src/core/` under `src/vnext/`.

PRD: `.claude/prd/core-cleanup-vnext.md` (local, gitignored)

## Layout decision

`logger` is cross-cutting (every layer uses it) → own folder `src/vnext/logging/`, peer to future `routing/`, `transport/`, `sessions/`, etc. — mirrors openclaw's `src/logging/`.

`paths` is project-specific (`~/.isotopes` conventions), not a generic util → top-level `src/vnext/paths.ts`.

`utils/` deferred — won't be created until a real generic utility lands (step 2: `dedupe` / `debounce`).

## Scope (pure relocate, no logic)

- `git mv src/core/logger.{ts,test.ts}` → `src/vnext/logging/`
- `git mv src/core/paths.{ts,test.ts}` → `src/vnext/`
- Update 49 importer files (single-line path changes)
- Sync header comments

## Verification

- `tsc --noEmit` clean
- `vitest run src/vnext/` — 31/31 pass

## Reviewability

53 files changed, 58/58 line diff. Every non-rename change is a single import-path rewrite. The 4 renames preserve git history (>=98% similarity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)