### PR TITLE
refactor(vnext): step 2 — relocate dedupe + debounce to transport/

### DIFF
--- a/src/plugins/discord/discord.ts
+++ b/src/plugins/discord/discord.ts
@@ -33,8 +33,8 @@ import { createReplyResolver, type ReplyToMode } from "./reply-directive.js";
 import type { UsageTracker } from "../../core/usage-tracker.js";
 import { buildSessionKey } from "../../core/session-keys.js";
 import { ChannelHistoryBuffer, buildHistoryContext } from "../../core/channel-history.js";
-import { DedupeCache } from "../../core/dedupe.js";
-import { InboundDebouncer } from "../../core/debounce.js";
+import { DedupeCache } from "../../vnext/transport/dedupe.js";
+import { InboundDebouncer } from "../../vnext/transport/debounce.js";
 import { SlashCommandHandler } from "../../commands/slash-commands.js";
 
 const log = loggers.discord;

--- a/src/vnext/transport/debounce.test.ts
+++ b/src/vnext/transport/debounce.test.ts
@@ -1,4 +1,4 @@
-// src/core/debounce.test.ts — Tests for inbound message debouncer
+// src/vnext/transport/debounce.test.ts — Tests for inbound message debouncer
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { InboundDebouncer } from "./debounce.js";

--- a/src/vnext/transport/debounce.ts
+++ b/src/vnext/transport/debounce.ts
@@ -1,4 +1,4 @@
-// src/core/debounce.ts — Combine rapid-fire messages from the same user
+// src/vnext/transport/debounce.ts — Combine rapid-fire messages from the same user
 // into a single prompt. Opt-in feature (default disabled in config).
 
 // ---------------------------------------------------------------------------

--- a/src/vnext/transport/dedupe.test.ts
+++ b/src/vnext/transport/dedupe.test.ts
@@ -1,4 +1,4 @@
-// src/core/dedupe.test.ts — Tests for deduplication cache
+// src/vnext/transport/dedupe.test.ts — Tests for deduplication cache
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { DedupeCache } from "./dedupe.js";

--- a/src/vnext/transport/dedupe.ts
+++ b/src/vnext/transport/dedupe.ts
@@ -1,4 +1,4 @@
-// src/core/dedupe.ts — TTL-based message deduplication cache.
+// src/vnext/transport/dedupe.ts — TTL-based message deduplication cache.
 // Lazy eviction (no timers) — cleanup runs on insertion.
 
 export interface DedupeCacheOptions {


### PR DESCRIPTION
Step 2 of #623. PRD: \`.claude/prd/core-cleanup-vnext.md\`.

## Layout decision

Both modules are used **only** by the Discord plugin and are conceptually transport-layer:
- \`dedupe\` — TTL message dedup cache
- \`debounce\` — coalesce rapid-fire user messages into one prompt

→ both go to \`src/vnext/transport/\`. \`utils/\` continues to be deferred (no real generic utility has appeared yet).

## Scope (pure relocate, no logic)

- \`git mv src/core/{dedupe,debounce}.{ts,test.ts}\` → \`src/vnext/transport/\`
- One importer (\`src/plugins/discord/discord.ts\`)
- Sync header comments

## Verification

- \`tsc --noEmit\` clean
- \`vitest run src/vnext/transport/\` — 14/14 pass

## Reviewability

5 files, 6/6 line diff. Pure mechanical move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)