### PR TITLE
refactor(vnext): step 3 — relocate config to src/vnext/config.ts

### DIFF
--- a/src/agents/runners/claude.ts
+++ b/src/agents/runners/claude.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_SPAWN_ALLOWED_TOOLS,
   type SettingSource,
   type SpawnPermissionMode,
-} from "../../core/config.js";
+} from "../../vnext/config.js";
 import type { SendMessageRequest } from "../types.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import fs from "node:fs/promises";
 import { VERSION } from "./version.js";
-import { loadConfig } from "./core/config.js";
+import { loadConfig } from "./vnext/config.js";
 import { logger } from "./vnext/logging/logger.js";
 import { createRuntime } from "./core/runtime.js";
 import {

--- a/src/core/agent-init.test.ts
+++ b/src/core/agent-init.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { initializeAgent } from "./agent-init.js";
-import type { AgentConfigFile } from "./config.js";
+import type { AgentConfigFile } from "../vnext/config.js";
 import { PiMonoCore } from "./pi-mono.js";
 import { DefaultAgentManager } from "./agent-manager.js";
 import { createMockAgentCache } from "./test-helpers.js";

--- a/src/core/agent-init.ts
+++ b/src/core/agent-init.ts
@@ -11,7 +11,7 @@ import {
   type AgentToolsConfigFile,
   type ProviderConfigFile,
   type SpawningConfigFile,
-} from "./config.js";
+} from "../vnext/config.js";
 import {
   ensureExplicitWorkspaceDir,
   ensureWorkspaceDir,

--- a/src/core/bindings.test.ts
+++ b/src/core/bindings.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect } from "vitest";
 import { resolveBinding } from "./bindings.js";
 import type { Binding } from "./types.js";
-import { toBindings } from "./config.js";
+import { toBindings } from "../vnext/config.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -7,7 +7,7 @@ import {
   resolveSpawningConfig,
   resolveSandboxConfigFromFile,
   type IsotopesConfigFile,
-} from "./config.js";
+} from "../vnext/config.js";
 import path from "node:path";
 import { PiMonoCore } from "./pi-mono.js";
 import { DefaultAgentManager } from "./agent-manager.js";

--- a/src/init/wizard.tsx
+++ b/src/init/wizard.tsx
@@ -33,7 +33,7 @@ export interface DiscordAnswers {
   groupAllowlist?: string[];
 }
 
-import type { SpawnPermissionMode } from "../core/config.js";
+import type { SpawnPermissionMode } from "../vnext/config.js";
 export type SubagentEnableShellChoice = "yes" | "no";
 export type SubagentTypeChoice = "claude" | "builtin" | "both";
 

--- a/src/plugins/discord/discord.ts
+++ b/src/plugins/discord/discord.ts
@@ -20,7 +20,7 @@ import {
 import type { ThreadBindingConfig } from "./types.js";
 import type { DefaultAgentManager } from "../../core/agent-manager.js";
 import { userMessage as mkUserMsg, userMessageWithImages as mkUserMsgWithImages } from "../../core/messages.js";
-import type { ContextConfigFile } from "../../core/config.js";
+import type { ContextConfigFile } from "../../vnext/config.js";
 import { shouldRespondToMessage } from "../../core/mention.js";
 import { loggers } from "../../vnext/logging/logger.js";
 import { ThreadBindingManager } from "./thread-bindings.js";

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -7,7 +7,7 @@ import type { SessionStore, Tool, Transport } from "../core/types.js";
 import type { ToolHandler } from "../core/tools.js";
 import type { DefaultAgentManager } from "../core/agent-manager.js";
 import type { SessionStoreManager } from "../core/session-store-manager.js";
-import type { IsotopesConfigFile } from "../core/config.js";
+import type { IsotopesConfigFile } from "../vnext/config.js";
 import type { UsageTracker } from "../core/usage-tracker.js";
 import type { LazyTransportContext } from "../tools/react.js";
 import type { AgentRuntime } from "../agents/runtime.js";

--- a/src/vnext/config.test.ts
+++ b/src/vnext/config.test.ts
@@ -1,4 +1,4 @@
-// src/core/config.test.ts — Unit tests for config loading
+// src/vnext/config.test.ts — Unit tests for config loading
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs/promises";

--- a/src/vnext/config.ts
+++ b/src/vnext/config.ts
@@ -1,4 +1,4 @@
-// src/core/config.ts — Configuration loading for Isotopes
+// src/vnext/config.ts — Configuration loading for Isotopes
 // Loads agent and runtime configuration from YAML/JSON files.
 
 import fs from "node:fs/promises";
@@ -16,7 +16,7 @@ import type {
   PeerKind,
   ProviderConfig,
   SessionConfig,
-} from "./types.js";
+} from "../core/types.js";
 import { resolveSandboxConfig, type SandboxConfig } from "../sandbox/config.js";
 import type { PluginConfigEntry } from "../plugins/types.js";
 import { createLogger } from "../vnext/logging/logger.js";

--- a/src/workspace/config-reloader.test.ts
+++ b/src/workspace/config-reloader.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import os from "node:os";
 import YAML from "yaml";
 import { ConfigReloader } from "./config-reloader.js";
-import type { IsotopesConfigFile } from "../core/config.js";
+import type { IsotopesConfigFile } from "../vnext/config.js";
 
 describe("ConfigReloader", () => {
   let tempDir: string;

--- a/src/workspace/config-reloader.ts
+++ b/src/workspace/config-reloader.ts
@@ -2,7 +2,7 @@
 // Watches the Isotopes config file and reloads it when modified.
 
 import { createLogger } from "../vnext/logging/logger.js";
-import { loadConfig, type IsotopesConfigFile } from "../core/config.js";
+import { loadConfig, type IsotopesConfigFile } from "../vnext/config.js";
 import { WorkspaceWatcher, type FileChange } from "./watcher.js";
 
 const log = createLogger("config-reloader");


### PR DESCRIPTION
Step 3 of #623.

## Layout decision

Decided against the per-domain split (agent/binding/sandbox/spawning/...). At 677 LOC the file is small enough that splitting now would be premature — openclaw's 140-file \`config/\` tree is the result of years of accretion, not initial design. Defer splitting until a specific domain actually grows past a useful threshold.

## Scope (pure relocate, no logic)

- \`git mv src/core/config.{ts,test.ts}\` → \`src/vnext/\`
- 7 external importers + 4 core-internal imports rewritten
- One sibling import (\`./types.js\`) temporarily routed to \`../core/types.js\` until \`types\` is migrated in a later step
- Sync header comments

## Verification

- \`tsc --noEmit\` clean
- \`vitest run src/vnext/config.test.ts\` — 59/59 pass

## Reviewability

13 files, 14/14 line diff. The 2 renames preserve git history (99% similarity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)