### PR TITLE
refactor(vnext): step 5 — finish gateway/ (channel-history)

### DIFF
--- a/src/plugins/discord/discord.ts
+++ b/src/plugins/discord/discord.ts
@@ -32,7 +32,7 @@ import { extractDiscordMetadata, formatInboundMeta } from "./message-metadata.js
 import { createReplyResolver, type ReplyToMode } from "./reply-directive.js";
 import type { UsageTracker } from "../../core/usage-tracker.js";
 import { buildSessionKey } from "../../vnext/gateway/session-keys.js";
-import { ChannelHistoryBuffer, buildHistoryContext } from "../../core/channel-history.js";
+import { ChannelHistoryBuffer, buildHistoryContext } from "../../vnext/gateway/channel-history.js";
 import { DedupeCache } from "../../vnext/gateway/dedupe.js";
 import { InboundDebouncer } from "../../vnext/gateway/debounce.js";
 import { SlashCommandHandler } from "../../commands/slash-commands.js";

--- a/src/vnext/gateway/channel-history.test.ts
+++ b/src/vnext/gateway/channel-history.test.ts
@@ -1,4 +1,4 @@
-// src/core/channel-history.test.ts — Tests for channel history buffer
+// src/vnext/gateway/channel-history.test.ts — Tests for channel history buffer
 
 import { describe, it, expect } from "vitest";
 import { ChannelHistoryBuffer, buildHistoryContext, type HistoryEntry } from "./channel-history.js";

--- a/src/vnext/gateway/channel-history.ts
+++ b/src/vnext/gateway/channel-history.ts
@@ -1,4 +1,4 @@
-// src/core/channel-history.ts — Transport-agnostic channel history buffer.
+// src/vnext/gateway/channel-history.ts — Transport-agnostic channel history buffer.
 // Records messages the bot observes but doesn't respond to, then injects
 // them as context when the bot IS triggered.
 


### PR DESCRIPTION
Step 5 of #623. Adds the last \"clean\" inbound piece to the L2 \`gateway/\` layer.

## Scope (pure relocate, no logic)

From \`src/core/\` → \`src/vnext/gateway/\`:
- \`channel-history.{ts,test.ts}\` (118+137 LOC) — LRU history buffer per (transport, channel)

External importer updated: \`plugins/discord/discord.ts\`.

## Deferred

Three modules originally planned for this PR were pulled back to \`src/core/\`:

- **tool-result-truncation** — controls what fits in the agent's context window. Agent concern, not gateway.
- **assistant-output-directives** — pure system-prompt fragment. The actual tag parser is \`plugins/discord/reply-directive.ts\`. Belongs with system-prompt assembly (\`core/workspace.ts\`).
- **silent-reply** — behavior is questionable; needs a separate look before deciding home.

All three will be tackled in the \`agent/\` layer step (or, for silent-reply, after the design pass).

## Final gateway/ shape

6 modules:

| Group | Files |
|---|---|
| Routing decisions | \`bindings\`, \`mention\`, \`session-keys\` |
| Inbound primitives | \`dedupe\`, \`debounce\` |
| Channel state | \`channel-history\` |

## Verification

- \`tsc --noEmit\` clean
- \`vitest run src/vnext/gateway/\` — 73/73 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)