### PR TITLE
refactor: split types.ts into per-layer files (shim)

### DIFF
--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,0 +1,65 @@
+// src/agent/types.ts — Agent-layer types (config, runtime contract)
+
+import type { SandboxConfig } from "../legacy/sandbox/config.js";
+import type { Tool, AgentToolSettings } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Provider config
+// ---------------------------------------------------------------------------
+
+/** LLM provider connection configuration (API type, base URL, credentials). */
+export interface ProviderConfig {
+  type: 'openai-proxy' | 'anthropic-proxy' | 'openai' | 'anthropic';
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+  headers?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Agent config
+// ---------------------------------------------------------------------------
+
+/** Complete configuration needed to create an agent instance. */
+export interface AgentConfig {
+  id: string;
+  tools?: Tool[];
+  toolSettings?: AgentToolSettings;
+  provider?: ProviderConfig;
+  /** Context compaction configuration */
+  compaction?: CompactionConfig;
+  /** Sandbox execution configuration */
+  sandbox?: SandboxConfig;
+  /** Heartbeat interval in milliseconds (0 or undefined = disabled) */
+  heartbeatInterval?: number;
+  /** Custom heartbeat prompt (overrides the default) */
+  heartbeatPrompt?: string;
+  /**
+   * Coding mode controls how the agent handles code modifications:
+   * - 'send-message': Force all code changes through send_message (removes write_file, edit)
+   * - 'direct': Agent can modify files directly (default behavior)
+   * - 'auto': Agent chooses based on task complexity (default)
+   */
+  codingMode?: "send-message" | "direct" | "auto";
+  /** Whether this agent can be spawned by other agents. Default: false */
+  spawnable?: boolean;
+  /** "parent-reuse" (default) | "always-new". See AgentSessionPolicy. */
+  sessionPolicy?: "always-new" | "parent-reuse";
+}
+
+// ---------------------------------------------------------------------------
+// Compaction
+// ---------------------------------------------------------------------------
+
+/** Compaction mode for managing context window size */
+export type CompactionMode = 'off' | 'safeguard' | 'aggressive';
+
+/** Configuration for context compaction */
+export interface CompactionConfig {
+  mode: CompactionMode;
+  contextWindow?: number;
+  threshold?: number;
+  preserveRecent?: number;
+  /** Absolute token reserve before compaction triggers. Overrides threshold if set. */
+  reserveTokens?: number;
+}

--- a/src/automation/types.ts
+++ b/src/automation/types.ts
@@ -1,0 +1,7 @@
+// src/automation/types.ts — Cron + heartbeat config types
+
+/** Action to perform when a config-level cron job triggers. */
+export type CronActionConfig =
+  | { type: "message"; content: string }
+  | { type: "prompt"; prompt: string }
+  | { type: "callback"; handler: string };

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -1,0 +1,51 @@
+// src/gateway/types.ts — Gateway types (routing decisions + transport contract)
+
+// ---------------------------------------------------------------------------
+// Bindings — route messages to agents by (channel, accountId, peer)
+// ---------------------------------------------------------------------------
+
+/** Peer kind: group channel, direct message, or thread */
+export type PeerKind = 'group' | 'dm' | 'thread';
+
+/** Peer identifier — a specific chat target within a channel+account */
+export interface BindingPeer {
+  kind: PeerKind;
+  id: string;
+}
+
+/** Match criteria for a binding rule */
+export interface BindingMatch {
+  /** Transport channel type (e.g. "discord") */
+  channel: string;
+  /** Account identifier within that channel */
+  accountId?: string;
+  /** Specific peer (group/dm/thread) to scope the binding */
+  peer?: BindingPeer;
+}
+
+/** A binding ties an agent to a (channel, accountId, peer) pattern */
+export interface Binding {
+  agentId: string;
+  match: BindingMatch;
+}
+
+// ---------------------------------------------------------------------------
+// Channel config — extensible per-transport
+// ---------------------------------------------------------------------------
+
+/** Channels section of the configuration — keyed by transport name */
+export type ChannelsConfig = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+/** Lifecycle interface for a message transport (Discord, etc.). */
+export interface Transport {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  /** Reply to a specific message by ID. If channelId is provided, skip O(n) channel scan. */
+  reply?(messageId: string, content: string, channelId?: string, attachments?: Array<{ buffer: Buffer; name: string }>): Promise<{ messageId: string }>;
+  /** Add a reaction emoji to a specific message by ID. If channelId is provided, skip O(n) channel scan. */
+  react?(messageId: string, emoji: string, channelId?: string): Promise<void>;
+}

--- a/src/legacy/core/types.ts
+++ b/src/legacy/core/types.ts
@@ -1,206 +1,38 @@
-// src/core/types.ts — Core interfaces for the Isotopes agent framework
+// src/legacy/core/types.ts — Re-export shim
+//
+// Types have been split across the new layered tree (#623 segment 2).
+// This file re-exports them for back-compat while legacy/ callers are
+// migrated. Once all importers point at the new locations, this file
+// can be deleted.
 
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
-
-import type { SandboxConfig } from "../sandbox/config.js";
-
-// ---------------------------------------------------------------------------
-// Re-exports from SDK
-// ---------------------------------------------------------------------------
-
+// SDK re-exports (kept here for now; agent layer ultimately owns them)
 export type { AgentMessage, AgentEvent } from "@mariozechner/pi-agent-core";
 export type { Usage, ImageContent } from "@mariozechner/pi-ai";
 
-// ---------------------------------------------------------------------------
 // Tools
-// ---------------------------------------------------------------------------
+export type { Tool, AgentToolSettings } from "../../tools/types.js";
 
-export interface Tool {
-  name: string;
-  description: string;
-  parameters: Record<string, unknown>;
-}
+// Agent layer
+export type { ProviderConfig, AgentConfig, CompactionMode, CompactionConfig } from "../../agent/types.js";
 
-export interface AgentToolSettings {
-  web?: boolean;
-  allow?: string[];
-  deny?: string[];
-}
+// Sessions
+export type {
+  Session,
+  SessionMetadata,
+  SessionConfig,
+  SessionStoreConfig,
+  SessionStore,
+} from "../../sessions/types.js";
 
-// ---------------------------------------------------------------------------
-// Provider config
-// ---------------------------------------------------------------------------
+// Gateway (routing + transport contract)
+export type {
+  PeerKind,
+  BindingPeer,
+  BindingMatch,
+  Binding,
+  ChannelsConfig,
+  Transport,
+} from "../../gateway/types.js";
 
-/** LLM provider connection configuration (API type, base URL, credentials). */
-export interface ProviderConfig {
-  type: 'openai-proxy' | 'anthropic-proxy' | 'openai' | 'anthropic';
-  baseUrl?: string;
-  apiKey?: string;
-  model?: string;
-  headers?: Record<string, string>;
-}
-
-// ---------------------------------------------------------------------------
-// Agent config & instance
-// ---------------------------------------------------------------------------
-
-/** Complete configuration needed to create an {@link AgentInstance}. */
-export interface AgentConfig {
-  id: string;
-  tools?: Tool[];
-  toolSettings?: AgentToolSettings;
-  provider?: ProviderConfig;
-  /** Context compaction configuration */
-  compaction?: CompactionConfig;
-  /** Sandbox execution configuration */
-  sandbox?: SandboxConfig;
-  /** Heartbeat interval in milliseconds (0 or undefined = disabled) */
-  heartbeatInterval?: number;
-  /** Custom heartbeat prompt (overrides the default) */
-  heartbeatPrompt?: string;
-  /**
-   * Coding mode controls how the agent handles code modifications:
-   * - 'send-message': Force all code changes through send_message (removes write_file, edit)
-   * - 'direct': Agent can modify files directly (default behavior)
-   * - 'auto': Agent chooses based on task complexity (default)
-   */
-  codingMode?: "send-message" | "direct" | "auto";
-  /** Whether this agent can be spawned by other agents. Default: false */
-  spawnable?: boolean;
-  /** "parent-reuse" (default) | "always-new". See AgentSessionPolicy. */
-  sessionPolicy?: "always-new" | "parent-reuse";
-}
-
-// ---------------------------------------------------------------------------
-
-/** A conversation session binding an agent to a transport channel. */
-export interface Session {
-  id: string;
-  agentId: string;
-  metadata?: SessionMetadata;
-  lastActiveAt: Date;
-}
-
-/**
- * Session metadata. `transport` is set for sessions originating from a chat
- * transport (discord/web).
- */
-export interface SessionMetadata {
-  key?: string;                        // Unique key for session lookup (e.g., discord:{botId}:channel:{id}:{agentId})
-  transport?: string;
-  channelId?: string;
-  channelName?: string;
-  guildName?: string;
-  threadId?: string;
-  /** If true, session is exempt from TTL-based cleanup */
-  persistent?: boolean;
-}
-
-/** Session TTL and cleanup configuration */
-export interface SessionConfig {
-  /** Session time-to-live in seconds. Default: 86400 (24 hours) */
-  ttl?: number;
-  /** Interval between cleanup sweeps in seconds. Default: 3600 (1 hour) */
-  cleanupInterval?: number;
-}
-
-/** Configuration for the session store (data directory, limits, TTL). */
-export interface SessionStoreConfig {
-  dataDir: string;
-  maxSessions?: number;       // default: 100
-  maxTotalSizeMB?: number;    // default: 100
-  session?: SessionConfig;
-}
-
-/** Persistent store for sessions and their message histories. */
-export interface SessionStore {
-  create(agentId: string, metadata?: SessionMetadata): Promise<Session>;
-  get(sessionId: string): Promise<Session | undefined>;
-  findByKey(key: string): Promise<Session | undefined>;
-  addMessage(sessionId: string, message: AgentMessage): Promise<void>;
-  getMessages(sessionId: string): Promise<AgentMessage[]>;
-  delete(sessionId: string): Promise<void>;
-  list(): Promise<Session[]>;
-  clearMessages(sessionId: string): Promise<void>;
-  setMessages(sessionId: string, messages: AgentMessage[]): Promise<void>;
-  setMetadata(sessionId: string, patch: Partial<SessionMetadata>): Promise<void>;
-  /** Get the underlying SDK SessionManager for a session (for AgentSession creation). */
-  getSessionManager(sessionId: string): Promise<import("@mariozechner/pi-coding-agent").SessionManager | undefined>;
-}
-
-// ---------------------------------------------------------------------------
-// Bindings — route messages to agents by (channel, accountId, peer)
-// ---------------------------------------------------------------------------
-
-/** Peer kind: group channel, direct message, or thread */
-export type PeerKind = 'group' | 'dm' | 'thread';
-
-/** Peer identifier — a specific chat target within a channel+account */
-export interface BindingPeer {
-  kind: PeerKind;
-  id: string;
-}
-
-/** Match criteria for a binding rule */
-export interface BindingMatch {
-  /** Transport channel type (e.g. "discord") */
-  channel: string;
-  /** Account identifier within that channel */
-  accountId?: string;
-  /** Specific peer (group/dm/thread) to scope the binding */
-  peer?: BindingPeer;
-}
-
-/** A binding ties an agent to a (channel, accountId, peer) pattern */
-export interface Binding {
-  agentId: string;
-  match: BindingMatch;
-}
-
-// ---------------------------------------------------------------------------
-// Channel config — extensible per-transport
-// ---------------------------------------------------------------------------
-
-/** Channels section of the configuration — keyed by transport name */
-export type ChannelsConfig = Record<string, unknown>;
-
-// ---------------------------------------------------------------------------
-// Compaction — context window management
-// ---------------------------------------------------------------------------
-
-/** Compaction mode for managing context window size */
-export type CompactionMode = 'off' | 'safeguard' | 'aggressive';
-
-/** Configuration for context compaction */
-export interface CompactionConfig {
-  mode: CompactionMode;
-  contextWindow?: number;
-  threshold?: number;
-  preserveRecent?: number;
-  /** Absolute token reserve before compaction triggers. Overrides threshold if set. */
-  reserveTokens?: number;
-}
-
-// ---------------------------------------------------------------------------
-// Cron action config — for config-file-level cron job definitions
-// ---------------------------------------------------------------------------
-
-/** Action to perform when a config-level cron job triggers. */
-export type CronActionConfig =
-  | { type: "message"; content: string }
-  | { type: "prompt"; prompt: string }
-  | { type: "callback"; handler: string };
-
-// ---------------------------------------------------------------------------
-// Transport
-// ---------------------------------------------------------------------------
-
-/** Lifecycle interface for a message transport (Discord, etc.). */
-export interface Transport {
-  start(): Promise<void>;
-  stop(): Promise<void>;
-  /** Reply to a specific message by ID. If channelId is provided, skip O(n) channel scan. */
-  reply?(messageId: string, content: string, channelId?: string, attachments?: Array<{ buffer: Buffer; name: string }>): Promise<{ messageId: string }>;
-  /** Add a reaction emoji to a specific message by ID. If channelId is provided, skip O(n) channel scan. */
-  react?(messageId: string, emoji: string, channelId?: string): Promise<void>;
-}
+// Automation
+export type { CronActionConfig } from "../../automation/types.js";

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -1,0 +1,58 @@
+// src/sessions/types.ts — Session storage contract
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+/** A conversation session binding an agent to a transport channel. */
+export interface Session {
+  id: string;
+  agentId: string;
+  metadata?: SessionMetadata;
+  lastActiveAt: Date;
+}
+
+/**
+ * Session metadata. `transport` is set for sessions originating from a chat
+ * transport (discord/web).
+ */
+export interface SessionMetadata {
+  key?: string;                        // Unique key for session lookup (e.g., discord:{botId}:channel:{id}:{agentId})
+  transport?: string;
+  channelId?: string;
+  channelName?: string;
+  guildName?: string;
+  threadId?: string;
+  /** If true, session is exempt from TTL-based cleanup */
+  persistent?: boolean;
+}
+
+/** Session TTL and cleanup configuration */
+export interface SessionConfig {
+  /** Session time-to-live in seconds. Default: 86400 (24 hours) */
+  ttl?: number;
+  /** Interval between cleanup sweeps in seconds. Default: 3600 (1 hour) */
+  cleanupInterval?: number;
+}
+
+/** Configuration for the session store (data directory, limits, TTL). */
+export interface SessionStoreConfig {
+  dataDir: string;
+  maxSessions?: number;       // default: 100
+  maxTotalSizeMB?: number;    // default: 100
+  session?: SessionConfig;
+}
+
+/** Persistent store for sessions and their message histories. */
+export interface SessionStore {
+  create(agentId: string, metadata?: SessionMetadata): Promise<Session>;
+  get(sessionId: string): Promise<Session | undefined>;
+  findByKey(key: string): Promise<Session | undefined>;
+  addMessage(sessionId: string, message: AgentMessage): Promise<void>;
+  getMessages(sessionId: string): Promise<AgentMessage[]>;
+  delete(sessionId: string): Promise<void>;
+  list(): Promise<Session[]>;
+  clearMessages(sessionId: string): Promise<void>;
+  setMessages(sessionId: string, messages: AgentMessage[]): Promise<void>;
+  setMetadata(sessionId: string, patch: Partial<SessionMetadata>): Promise<void>;
+  /** Get the underlying SDK SessionManager for a session (for AgentSession creation). */
+  getSessionManager(sessionId: string): Promise<import("@mariozechner/pi-coding-agent").SessionManager | undefined>;
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,0 +1,13 @@
+// src/tools/types.ts — Generic tool contract (no business logic)
+
+export interface Tool {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface AgentToolSettings {
+  web?: boolean;
+  allow?: string[];
+  deny?: string[];
+}


### PR DESCRIPTION
#632 segment 2, step A1 of the types split.

## What

Extracts type definitions from \`src/legacy/core/types.ts\` into per-layer files. The original file becomes a pure re-export shim — **zero behavior change, no callers updated**.

A1 = create new files + shim.
A2 (next PR) = rewrite importers + delete shim.

## Per-layer destinations

| Type | New home |
|---|---|
| \`Tool\`, \`AgentToolSettings\` | \`src/tools/types.ts\` (new dir) |
| \`ProviderConfig\`, \`AgentConfig\`, \`CompactionMode\`, \`CompactionConfig\` | \`src/agent/types.ts\` |
| \`Session\`, \`SessionMetadata\`, \`SessionConfig\`, \`SessionStoreConfig\`, \`SessionStore\` | \`src/sessions/types.ts\` (new dir) |
| \`PeerKind\`, \`BindingPeer\`, \`BindingMatch\`, \`Binding\`, \`ChannelsConfig\`, \`Transport\` | \`src/gateway/types.ts\` |
| \`CronActionConfig\` | \`src/automation/types.ts\` (new dir, ahead of automation move) |
| SDK re-exports (\`AgentMessage\`, \`AgentEvent\`, \`Usage\`, \`ImageContent\`) | stay in shim for now |

## Acknowledged transitional leak

\`src/agent/types.ts\` imports \`SandboxConfig\` from \`../legacy/sandbox/config.js\`. Sandbox migration is a later segment; the leaked path makes the dependency visible until then.

## Verification

- \`tsc --noEmit\` clean
- \`vitest run\` — 1165/1165 tests pass (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)