### PR TITLE
refactor: relocate PiRunner to src/agent/runners/pi/runner.ts

### DIFF
--- a/src/agent/runners/pi/runner.ts
+++ b/src/agent/runners/pi/runner.ts
@@ -1,16 +1,16 @@
-// In-process runner. Two kinds: root (registered agent's cache+SOUL+store)
+// src/agent/runners/pi/runner.ts — In-process runner. Two kinds: root (registered agent's cache+SOUL+store)
 // and leaf (ephemeral cache + parent's filtered tools).
 
 import { randomUUID } from "node:crypto";
 import { createLogger } from "../../../logging/logger.js";
-import { PiMonoCore } from "../../core/pi-mono.js";
-import { ToolRegistry, type ToolHandler } from "../../core/tools.js";
-import { buildSpawnAgentSystemPrompt } from "../builtin/system-prompt.js";
+import { PiMonoCore } from "../../../legacy/core/pi-mono.js";
+import { ToolRegistry, type ToolHandler } from "../../../legacy/core/tools.js";
+import { buildSpawnAgentSystemPrompt } from "../../../legacy/agents/builtin/system-prompt.js";
 import type {
   AgentSessionKind,
   RegisteredAgent,
   SendMessageRequest,
-} from "../types.js";
+} from "../../../legacy/agents/types.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { AgentSession, AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import { SessionManager } from "@mariozechner/pi-coding-agent";

--- a/src/legacy/agents/runtime.ts
+++ b/src/legacy/agents/runtime.ts
@@ -13,7 +13,7 @@ import type {
   RunInfo,
 } from "./types.js";
 import type { PiMonoCore } from "../core/pi-mono.js";
-import { PiRunner } from "./runners/pi.js";
+import { PiRunner } from "../../agent/runners/pi/runner.js";
 import { ClaudeRunner, type ClaudeRunnerOptions } from "./runners/claude.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";


### PR DESCRIPTION
#632 segment 2. Pure relocate, no logic change.

## Why first

Bottom-up step before the pi-mono redesign (next PR). Moving the runner to its new home now means the upcoming pi-mono split (\`service-cache\` + \`session-factory\` + \`tool-adapter\` + \`model\` + \`system-prompt-override\`) can target the new sibling location directly, with same-directory imports — instead of redesigning across legacy ↔ new boundary, then chasing a second wave of import updates when the runner relocates.

## Scope

- \`git mv src/legacy/agents/runners/pi.ts\` → \`src/agent/runners/pi/runner.ts\`
- 4 import paths inside the moved file rewired to \`../../../legacy/...\` (pi-mono, tools, builtin/system-prompt, agents/types — all still in legacy/ for now)
- \`src/legacy/agents/runtime.ts\` import path updated to new location
- Header comment synced

## Verification

- \`tsc --noEmit\` clean
- \`vitest run\` — 1158/1158 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)