### PR TITLE
refactor: relocate ClaudeRunner to src/agent/runners/claude/

### DIFF
--- a/src/agent/runners/claude/runner.ts
+++ b/src/agent/runners/claude/runner.ts
@@ -8,7 +8,7 @@ import {
   type SettingSource,
   type SpawnPermissionMode,
 } from "../../../config.js";
-import type { SendMessageRequest } from "../types.js";
+import type { SendMessageRequest } from "../../../legacy/agents/types.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, AssistantMessageEvent } from "@mariozechner/pi-ai";

--- a/src/legacy/agents/runtime.ts
+++ b/src/legacy/agents/runtime.ts
@@ -16,7 +16,7 @@ import type { ProviderConfig } from "../../agent/types.js";
 import type { HookRegistry } from "../plugins/hooks.js";
 import { PiRunner } from "../../agent/runners/pi/runner.js";
 import { createRootPiSession, createLeafPiSession } from "../../agent/runners/pi/session-factory.js";
-import { ClaudeRunner, type ClaudeRunnerOptions } from "./runners/claude.js";
+import { ClaudeRunner, type ClaudeRunnerOptions } from "../../agent/runners/claude/runner.js";
 import type { AgentEvent, AgentTool } from "@mariozechner/pi-agent-core";
 import {
   type AgentSession,


### PR DESCRIPTION
## Summary

Mirror PiRunner layout (established in #644) for ClaudeRunner.

- \`src/legacy/agents/runners/claude.ts\` → \`src/agent/runners/claude/runner.ts\`
- 1 import in \`src/legacy/agents/runtime.ts\` updated
- Empty \`src/legacy/agents/runners/\` removed

Pure mechanical move. Zero behavior change.

Part of #632 segment 2 (kernel relocation). Both runner subtrees now live under \`src/agent/runners/{pi,claude}/\` symmetrically.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` — 1084 passing