### PR TITLE
refactor(claude): rename ClaudeRunner.sendMessage → run

### DIFF
--- a/src/agent/runners/claude/runner.ts
+++ b/src/agent/runners/claude/runner.ts
@@ -56,14 +56,14 @@ export class ClaudeRunner {
 
   /** `request.cwd` is required; Claude CLI manages its own session state
    * so conversational continuity across calls is out of scope. */
-  async *sendMessage(opts: {
+  async *run(opts: {
     request: SendMessageRequest;
     runId: string;
     abort: AbortSignal;
   }): AsyncGenerator<AgentEvent> {
     const { request, runId, abort } = opts;
     if (!request.cwd) {
-      throw new Error("ClaudeRunner.sendMessage: request.cwd is required");
+      throw new Error("ClaudeRunner.run: request.cwd is required");
     }
 
     const sdkAbort = new AbortController();
@@ -82,7 +82,7 @@ export class ClaudeRunner {
     if (this.defaultModel) sdkOptions.model = this.defaultModel;
     if (this.defaultMaxTurns !== undefined) sdkOptions.maxTurns = this.defaultMaxTurns;
 
-    log.info("ClaudeRunner.sendMessage", { runId, cwd: request.cwd });
+    log.info("ClaudeRunner.run", { runId, cwd: request.cwd });
 
     const toolNameById = new Map<string, string>();
     let assistantText = "";

--- a/src/legacy/agents/runtime.ts
+++ b/src/legacy/agents/runtime.ts
@@ -380,7 +380,7 @@ export class AgentRuntime {
 
     try {
       if (isClaude) {
-        yield* this.claudeRunner!.sendMessage({
+        yield* this.claudeRunner!.run({
           request: req,
           runId,
           abort: abort.signal,


### PR DESCRIPTION
## Summary

Mirrors the PiRunner.run rename (#644). \`sendMessage\` is a routing-layer verb (implies addressing); a runner is an execution primitive — \`run\` is the honest name.

\`AgentRuntime.sendMessage\` stays the public addressing API.

## Changes

- \`async *sendMessage\` → \`async *run\` in \`src/agent/runners/claude/runner.ts\`
- 2 log message strings updated
- 1 caller in \`src/legacy/agents/runtime.ts\`

4 lines net.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` — 1084 passing