### PR TITLE
refactor(agent): relocate agent-run.ts → src/agent/run-adapter.ts

### DIFF
--- a/src/agent/run-adapter.test.ts
+++ b/src/agent/run-adapter.test.ts
@@ -1,11 +1,11 @@
 // Direct unit coverage for consumeRootRun + cancelRunBySessionId.
 
 import { describe, it, expect, vi } from "vitest";
-import { consumeRootRun, cancelRunBySessionId } from "./agent-run.js";
-import { AgentRuntime } from "../agents/runtime.js";
-import type { RegisteredAgent, SendMessageRequest } from "../agents/types.js";
+import { consumeRootRun, cancelRunBySessionId } from "./run-adapter.js";
+import { AgentRuntime } from "../legacy/agents/runtime.js";
+import type { RegisteredAgent, SendMessageRequest } from "../legacy/agents/types.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
-import { createLogger } from "../../logging/logger.js";
+import { createLogger } from "../logging/logger.js";
 
 const log = createLogger("test:agent-run");
 

--- a/src/agent/run-adapter.ts
+++ b/src/agent/run-adapter.ts
@@ -2,11 +2,11 @@
 // callers (REST/Discord/heartbeat/cron). Also wires hooks, usage tracker,
 // runtime per-session event emission, and mid-turn steer-from-pending-buffer.
 
-import type { AgentRuntime } from "../agents/runtime.js";
-import { userMessage, assistantMessage, getAgentEndMeta } from "../../agent/runners/pi/messages.js";
-import type { Logger } from "../../logging/logger.js";
-import type { HookRegistry } from "../plugins/hooks.js";
-import { runWithMessageContext } from "../transport/context.js";
+import type { AgentRuntime } from "../legacy/agents/runtime.js";
+import { userMessage, assistantMessage, getAgentEndMeta } from "./runners/pi/messages.js";
+import type { Logger } from "../logging/logger.js";
+import type { HookRegistry } from "../legacy/plugins/hooks.js";
+import { runWithMessageContext } from "../legacy/transport/context.js";
 
 export interface ConsumeRootRunOptions {
   /** Registered agent id to address. */

--- a/src/legacy/core/runtime.ts
+++ b/src/legacy/core/runtime.ts
@@ -27,7 +27,7 @@ import { HeartbeatManager } from "../automation/heartbeat.js";
 import { PluginManager } from "../plugins/manager.js";
 import { getIsotopesHome } from "../../paths.js";
 import { AgentRuntime } from "../agents/runtime.js";
-import { consumeRootRun } from "./agent-run.js";
+import { consumeRootRun } from "../../agent/run-adapter.js";
 
 const log = createLogger("runtime");
 

--- a/src/legacy/plugins/discord/discord.ts
+++ b/src/legacy/plugins/discord/discord.ts
@@ -22,7 +22,7 @@ import type { ContextConfigFile } from "../../../config.js";
 import { shouldRespondToMessage } from "../../../gateway/mention.js";
 import { loggers } from "../../../logging/logger.js";
 import { ThreadBindingManager } from "./thread-bindings.js";
-import { consumeRootRun, cancelRunBySessionId, isRootRunActive } from "../../core/agent-run.js";
+import { consumeRootRun, cancelRunBySessionId, isRootRunActive } from "../../../agent/run-adapter.js";
 import { runWithDiscordSubagentStream, type DiscordSubagentStreamContext } from "./subagent-stream-context.js";
 import { isSilentReply } from "../../core/silent-reply.js";
 import { extractDiscordMetadata, formatInboundMeta } from "./message-metadata.js";

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -11,7 +11,7 @@ import { addRoute } from "./routes.js";
 import { sendJson, sendError } from "./middleware.js";
 import { createLogger } from "../../../logging/logger.js";
 import { randomUUID } from "node:crypto";
-import { consumeRootRun, cancelRunBySessionId } from "../../core/agent-run.js";
+import { consumeRootRun, cancelRunBySessionId } from "../../../agent/run-adapter.js";
 import { userMessage } from "../../../agent/runners/pi/messages.js";
 import { resolveAgentWorkspacePath } from "../../../paths.js";
 import type { DefaultSessionStore } from "../../core/session-store.js";


### PR DESCRIPTION
## Summary
- Moves the chat-side adapter (`consumeRootRun` / `cancelRunBySessionId` / `isRootRunActive`) from `src/legacy/core/agent-run.ts` to `src/agent/run-adapter.ts`, alongside the other agent-layer modules (`init.ts`, `system-prompt.ts`, `workspace.ts`).
- Updates the 3 callers (`legacy/core/runtime.ts`, `legacy/plugins/discord/discord.ts`, `legacy/plugins/http/sessions.ts`) and the co-located test.
- No behavior change.

Continues #632 (agent-layer flat-src migration).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (1051 passed)