### PR TITLE
refactor(agent): drop duplicate cwd check in ClaudeRunner.run

### DIFF
--- a/src/agent/runners/claude/runner.ts
+++ b/src/agent/runners/claude/runner.ts
@@ -19,7 +19,6 @@ export class ClaudeRunner {
     abort: AbortSignal;
   }): AsyncGenerator<AgentEvent> {
     const { request, runId, abort } = opts;
-    if (!request.cwd) throw new RunValidationError("claude: cwd is required");
 
     const sdkAbort = new AbortController();
     const onAbort = () => sdkAbort.abort();


### PR DESCRIPTION
## Summary
- `ClaudeRunner.run` re-checked `req.cwd` even though `AgentRuntime` always invokes `runner.validateRequest` before dispatch (runtime.ts:407) — the in-run throw was dead.
- Removed the duplicate. Matches `SubagentRunner` (validate-only, trusts the runtime in `run()`).

## Test plan
- [x] `pnpm typecheck`
- [x] `npx vitest run src/agent/` (60 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)