### PR TITLE
fix(pi): cwd fallback to agent's workspace, not process.cwd() (#672)

### DIFF
--- a/src/agent/runners/pi/session-factory.ts
+++ b/src/agent/runners/pi/session-factory.ts
@@ -14,6 +14,7 @@ import type { ProviderConfig, RegisteredAgent } from "../../types.js";
 import type { HookRegistry } from "../../../legacy/plugins/hooks.js";
 import { overrideSessionSystemPrompt } from "./system-prompt-override.js";
 import { buildAgentSystemPrompt } from "../../workspace.js";
+import { resolveAgentWorkspacePath } from "../../../paths.js";
 
 const ISOTOPES_HOME = process.env.ISOTOPES_HOME || path.join(process.env.HOME || "/tmp", ".isotopes");
 const DEFAULT_MODEL = "claude-opus-4-7";
@@ -89,7 +90,7 @@ export async function createPiSession(
   });
 
   const { session } = await createAgentSession({
-    cwd: cwd ?? process.cwd(),
+    cwd: cwd ?? resolveAgentWorkspacePath(agent.config),
     agentDir: path.join(ISOTOPES_HOME, "agents", agent.id, "agent"),
     authStorage: deps.authStorage,
     modelRegistry: deps.modelRegistry,


### PR DESCRIPTION
Closes #672

## Summary

\`createPiSession\` was falling back to \`process.cwd()\` when \`req.cwd\` was unset. For top-level transport calls (Discord, TUI, heartbeat, cron) this meant the session reported its cwd as wherever the \`isotopes\` daemon was launched — almost never meaningful.

## Fix

\`\`\`diff
-    cwd: cwd ?? process.cwd(),
+    cwd: cwd ?? resolveAgentWorkspacePath(agent.config),
\`\`\`

Pi tools resolve fs paths against their own pre-baked \`workspacePath\`, so file ops weren't broken — but \`session.cwd\` is surfaced in SDK metadata, logs, and any future tool that reads ctx cwd at execute time.

After this change, \`session.cwd\` is always meaningful:
- caller-supplied \`req.cwd\` for \`send_message\`-spawned runs
- agent's own workspace path for everything else

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 934 passing
- [x] \`pnpm lint\` clean

## Why no formal regression test

Adding one would require module-level mocking of \`createAgentSession\` from the pi SDK to capture the cwd argument — heavy setup for a one-line change. \`resolveAgentWorkspacePath\` itself is already covered in \`paths.test.ts\`. Smoke covered by manual boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)