### PR TITLE
refactor: relocate test-helpers.ts out of legacy/core/

### DIFF
--- a/src/legacy/commands/slash-commands.test.ts
+++ b/src/legacy/commands/slash-commands.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SlashCommandHandler, type CommandContext } from "./slash-commands.js";
-import { createMockSessionStore } from "../core/test-helpers.js";
+import { createMockSessionStore } from "../../test-helpers.js";
 import type { AgentRuntime } from "../../agent/runtime.js";
 import type { AgentConfig } from "../../agent/types.js";
 

--- a/src/legacy/plugins/discord/discord-manager.test.ts
+++ b/src/legacy/plugins/discord/discord-manager.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DiscordTransportManager } from "./discord-manager.js";
-import { createMockSessionStore } from "../../core/test-helpers.js";
+import { createMockSessionStore } from "../../../test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Mock discord.js (same pattern as discord.test.ts)

--- a/src/legacy/plugins/discord/discord.test.ts
+++ b/src/legacy/plugins/discord/discord.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DiscordTransport } from "./discord.js";
 import type { SessionStore } from "../../../sessions/types.js";
 import { ThreadBindingManager } from "./thread-bindings.js";
-import { createMockSessionStore } from "../../core/test-helpers.js";
+import { createMockSessionStore } from "../../../test-helpers.js";
 import { AgentRuntime } from "../../../agent/runtime.js";
 
 function makeMockRuntime(agentId: string, cache: unknown, sessionStore: SessionStore): AgentRuntime {

--- a/src/legacy/plugins/http/chat.test.ts
+++ b/src/legacy/plugins/http/chat.test.ts
@@ -6,7 +6,7 @@ import { ApiServer } from "./server.js";
 import { CronScheduler } from "../../automation/cron-job.js";
 import { SessionStoreManager } from "../../core/session-store-manager.js";
 import { AgentRuntime } from "../../../agent/runtime.js";
-import { createMockSessionStore } from "../../core/test-helpers.js";
+import { createMockSessionStore } from "../../../test-helpers.js";
 
 const MOCK_AGENT_ID = "mock";
 

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,7 +1,7 @@
-// src/core/test-helpers.ts — Shared test mocks for transport tests
+// src/test-helpers.ts — Shared test mocks for transport tests
 
 import { vi } from "vitest";
-import type { SessionStore } from "../../sessions/types.js";
+import type { SessionStore } from "./sessions/types.js";
 
 export function createMockSession() {
   let subscriber: ((event: Record<string, unknown>) => void) | null = null;


### PR DESCRIPTION
Bottom-up cleanup of \`src/legacy/core/\`. Pure mechanical relocate, no behavior change.

## Summary

\`src/legacy/core/test-helpers.ts\` (65 LOC) — vitest mock factories \`createMockSession\` + \`createMockSessionStore\` for transport tests. Was originally in \`src/core/\`, dragged into \`legacy/core/\` during the #630 quarantine. Conceptually a framework-wide test utility, not a "legacy core" thing.

Moved to \`src/test-helpers.ts\` (top-level, sibling of \`paths.ts\`).

## Why top-level (not src/agent/)

- Doesn't lock the file into agent-only scope — future test mocks (cron, plugin manager, hook registry, etc.) can land in the same file
- Keeps \`src/agent/\` pure of test code beyond co-located \`.test.ts\` files
- Mirrors the placement style we used for other framework-wide utilities (\`paths.ts\`, \`config.ts\`)

## Diff

- \`git mv src/legacy/core/test-helpers.ts src/test-helpers.ts\`
- 4 importers updated:
  - \`src/legacy/commands/slash-commands.test.ts\`
  - \`src/legacy/plugins/http/chat.test.ts\`
  - \`src/legacy/plugins/discord/discord-manager.test.ts\`
  - \`src/legacy/plugins/discord/discord.test.ts\`
- File header comment + relative \`./sessions/types.js\` import path corrected for the new location

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 934 passing
- [x] \`pnpm lint\` clean

## Bottom-up cleanup status

\`src/legacy/core/\` files remaining after this PR (5):
- \`agent-run.ts\` — next bottom-up candidate (mechanical relocate to \`src/agent/run-adapter.ts\`)
- \`session-store.ts\` + \`session-store-manager.ts\` — needs \`sessions/\` design pass
- \`tools.ts\` — needs split into multiple files (largest, last)
- \`silent-reply.ts\` — separately tracked in #676

Related: parent #623, #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)