### PR TITLE
refactor(compaction): drop dead config + redundant SDK overrides

### DIFF
--- a/src/agent/runners/pi/session-factory.ts
+++ b/src/agent/runners/pi/session-factory.ts
@@ -82,7 +82,6 @@ export async function createPiSession(
   if (!sessionManager) throw new Error(`Session "${sessionId}" not found`);
 
   const customTools = deps.getAgentTools(agent.id).map((t) => toToolDefinition(t, deps.hooks, agent.id));
-  const settingsManager = SettingsManager.inMemory();
 
   const { session } = await createAgentSession({
     cwd: cwd ?? resolveAgentWorkspacePath(agent.config),
@@ -95,7 +94,7 @@ export async function createPiSession(
     tools: customTools.map((t) => t.name).filter((n): n is string => typeof n === "string"),
     customTools,
     sessionManager,
-    settingsManager,
+    settingsManager: SettingsManager.inMemory(),
   });
 
   overrideSessionSystemPrompt(session, await buildAgentSystemPrompt(agent.config));

--- a/src/agent/runners/pi/session-factory.ts
+++ b/src/agent/runners/pi/session-factory.ts
@@ -82,12 +82,7 @@ export async function createPiSession(
   if (!sessionManager) throw new Error(`Session "${sessionId}" not found`);
 
   const customTools = deps.getAgentTools(agent.id).map((t) => toToolDefinition(t, deps.hooks, agent.id));
-  const compactionEnabled = !!(agent.config.compaction && agent.config.compaction.mode !== "off");
-  const settingsManager = SettingsManager.inMemory({
-    compaction: compactionEnabled
-      ? { enabled: true, reserveTokens: agent.config.compaction?.reserveTokens ?? 20_000, keepRecentTokens: 20_000 }
-      : { enabled: false, reserveTokens: 20_000, keepRecentTokens: 20_000 },
-  });
+  const settingsManager = SettingsManager.inMemory();
 
   const { session } = await createAgentSession({
     cwd: cwd ?? resolveAgentWorkspacePath(agent.config),

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -24,7 +24,6 @@ import {
   toAgentConfig,
   type AgentConfigFile,
   type AgentDefaultsConfigFile,
-  type CompactionConfigFile,
   type SandboxConfigFile,
   type AgentToolsConfigFile,
   type ProviderConfigFile,
@@ -78,7 +77,6 @@ export interface AddAgentOptions {
   agentDefaults?: AgentDefaultsConfigFile;
   provider?: ProviderConfigFile;
   globalTools?: AgentToolsConfigFile;
-  compaction?: CompactionConfigFile;
   sandbox?: SandboxConfigFile;
   sandboxExecutor?: SandboxExecutor;
   transportContext?: LazyTransportContext;
@@ -299,8 +297,8 @@ export class AgentRuntime {
 
   /** Single registration entry point. Branches on agent.runner. */
   async register(opts: AddAgentOptions): Promise<AddAgentResult> {
-    const { agentFile, agentDefaults, provider, globalTools, compaction, sandbox } = opts;
-    const agentConfig = toAgentConfig(agentFile, agentDefaults, provider, globalTools, compaction, sandbox);
+    const { agentFile, agentDefaults, provider, globalTools, sandbox } = opts;
+    const agentConfig = toAgentConfig(agentFile, agentDefaults, provider, globalTools, sandbox);
     return agentConfig.runner === "claude"
       ? this.registerClaude(agentConfig)
       : this.registerPi(agentConfig, opts);

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -20,23 +20,11 @@ export interface AgentConfig {
   workspace?: string;
   toolSettings?: AgentToolSettings;
   model?: string;
-  compaction?: CompactionConfig;
   sandbox?: SandboxConfig;
   /** Default false. */
   spawnable?: boolean;
   /** Default "parent-reuse". */
   sessionPolicy?: "always-new" | "parent-reuse";
-}
-
-export type CompactionMode = 'off' | 'safeguard' | 'aggressive';
-
-export interface CompactionConfig {
-  mode: CompactionMode;
-  contextWindow?: number;
-  threshold?: number;
-  preserveRecent?: number;
-  /** Absolute token reserve before compaction triggers. Overrides threshold if set. */
-  reserveTokens?: number;
 }
 
 /** "always-new": fresh session per send_message call.

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,7 +70,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   let sandboxExecutor: SandboxExecutor | undefined;
   const baseSandboxFile = config.agentDefaults?.sandbox ?? config.sandbox;
   const resolvedAgentConfigs = config.agents.map((a) =>
-    toAgentConfig(a, config.agentDefaults, config.provider, config.tools, config.compaction, config.sandbox),
+    toAgentConfig(a, config.agentDefaults, config.provider, config.tools, config.sandbox),
   );
   const anySandboxed = resolvedAgentConfigs.some((c) => c.sandbox && c.sandbox.mode !== "off");
   if (anySandboxed) {
@@ -103,7 +103,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       agentDefaults: config.agentDefaults,
       provider: config.provider,
       globalTools: config.tools,
-      compaction: config.compaction,
       sandbox: config.sandbox,
       sandboxExecutor,
       transportContext: transportCtx,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -8,7 +8,6 @@ import {
   loadConfig,
   toAgentConfig,
   resolveToolSettings,
-  resolveCompactionConfigFromFile,
   resolveSessionConfig,
   resolveSandboxConfigFromFile,
 } from "./config.js";
@@ -169,8 +168,8 @@ provider:
 
 agents:
   defaults:
-    compaction:
-      mode: safeguard
+    tools:
+      deny: [shell]
   list:
     - id: major
     - id: tachikoma
@@ -188,7 +187,7 @@ agents:
 
       // agentDefaults should be extracted
       expect(config.agentDefaults).toBeDefined();
-      expect(config.agentDefaults?.compaction?.mode).toBe("safeguard");
+      expect(config.agentDefaults?.tools?.deny).toEqual(["shell"]);
     });
 
     it("legacy array form still works and agentDefaults is undefined", async () => {
@@ -289,53 +288,6 @@ agents:
       expect(config.toolSettings?.allow).toEqual(["read"]);
     });
 
-    it("includes compaction config from agent-level", () => {
-      const agentFile = {
-        id: "test",
-        compaction: { mode: "aggressive" },
-      };
-      const config = toAgentConfig(agentFile);
-
-      expect(config.compaction?.mode).toBe("aggressive");
-    });
-
-    it("includes compaction config from defaults", () => {
-      const agentFile = { id: "test" };
-      const config = toAgentConfig(agentFile, undefined, undefined, undefined, {
-        mode: "safeguard",
-      });
-
-      expect(config.compaction?.mode).toBe("safeguard");
-    });
-
-    it("agent compaction overrides default compaction", () => {
-      const agentFile = {
-        id: "test",
-        compaction: { mode: "off" },
-      };
-      const config = toAgentConfig(agentFile, undefined, undefined, undefined, {
-        mode: "safeguard",
-      });
-
-      expect(config.compaction?.mode).toBe("off");
-    });
-
-    it("omits compaction when neither agent nor default has it", () => {
-      const agentFile = { id: "test" };
-      const config = toAgentConfig(agentFile);
-
-      expect(config.compaction).toBeUndefined();
-    });
-
-    it("inherits compaction from agentDefaults", () => {
-      const agentFile = { id: "test" };
-      const defaults = { compaction: { mode: "aggressive" } };
-
-      const config = toAgentConfig(agentFile, defaults);
-
-      expect(config.compaction?.mode).toBe("aggressive");
-    });
-
     it("inherits tools from agentDefaults", () => {
       const agentFile = { id: "test" };
       const defaults = { tools: { allow: ["read"] } };
@@ -406,45 +358,6 @@ agents:
         { deny: ["shell"] },
       );
       expect(result.deny).toEqual(["shell"]);
-    });
-  });
-
-  describe("resolveCompactionConfigFromFile", () => {
-    it("returns undefined when neither agent nor default config provided", () => {
-      expect(resolveCompactionConfigFromFile()).toBeUndefined();
-    });
-
-    it("returns config with defaults for safeguard mode", () => {
-      const config = resolveCompactionConfigFromFile({ mode: "safeguard" });
-
-      expect(config).toBeDefined();
-      expect(config!.mode).toBe("safeguard");
-    });
-
-    it("agent config overrides default config", () => {
-      const config = resolveCompactionConfigFromFile(
-        { mode: "off" },
-        { mode: "safeguard" },
-      );
-
-      expect(config!.mode).toBe("off");
-    });
-
-    it("merges agent and default config fields", () => {
-      const config = resolveCompactionConfigFromFile(
-        { contextWindow: 200_000 },
-        { mode: "aggressive", threshold: 0.5 },
-      );
-
-      expect(config!.mode).toBe("aggressive");
-      expect(config!.contextWindow).toBe(200_000);
-      expect(config!.threshold).toBe(0.5);
-    });
-
-    it("throws on invalid mode", () => {
-      expect(() =>
-        resolveCompactionConfigFromFile({ mode: "invalid" }),
-      ).toThrow('Invalid compaction mode "invalid"');
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,6 @@ import YAML from "yaml";
 import type { ProviderType } from "./agent/types.js";
 import type {
   AgentConfig,
-  CompactionConfig,
-  CompactionMode,
 } from "./agent/types.js";
 import type { AgentToolSettings } from "./tools/types.js";
 import type {
@@ -81,7 +79,6 @@ export interface AgentConfigFile {
   workspace?: string;
   tools?: AgentToolsConfigFile;
   model?: string;
-  compaction?: CompactionConfigFile;
   sandbox?: SandboxConfigFile;
   heartbeat?: HeartbeatConfigFile;
   cron?: { tasks: CronTaskConfigFile[] };
@@ -98,14 +95,6 @@ export interface AgentToolsConfigFile {
   allow?: string[];
   /** Tool names to explicitly deny (takes precedence over allow) */
   deny?: string[];
-}
-
-/** Compaction configuration in config file */
-export interface CompactionConfigFile {
-  mode?: string;
-  contextWindow?: number;
-  threshold?: number;
-  preserveRecent?: number;
 }
 
 /** Sandbox Docker configuration in config file */
@@ -187,7 +176,6 @@ export interface CronJobConfigFile {
 /** Agent defaults — shared configuration inherited by all agents unless overridden */
 export interface AgentDefaultsConfigFile {
   tools?: AgentToolsConfigFile;
-  compaction?: CompactionConfigFile;
   sandbox?: SandboxConfigFile;
 }
 
@@ -197,8 +185,6 @@ export interface IsotopesConfigFileRaw {
   provider?: ProviderConfigFile;
   /** Default tool policy/guards for all agents */
   tools?: AgentToolsConfigFile;
-  /** Default compaction config for all agents */
-  compaction?: CompactionConfigFile;
   /** Default sandbox config for all agents */
   sandbox?: SandboxConfigFile;
   /** Session management (TTL, cleanup) */
@@ -229,37 +215,6 @@ export function resolveToolSettings(
     // allow/deny: agent-level overrides defaults entirely (not merged)
     allow: agentTools?.allow ?? defaultTools?.allow,
     deny: agentTools?.deny ?? defaultTools?.deny,
-  };
-}
-
-const VALID_COMPACTION_MODES = new Set<string>(["off", "safeguard", "aggressive"]);
-
-/**
- * Resolve compaction config, merging agent-level overrides with defaults.
- * Returns undefined if compaction is not configured at all.
- */
-export function resolveCompactionConfigFromFile(
-  agentCompaction?: CompactionConfigFile,
-  defaultCompaction?: CompactionConfigFile,
-): CompactionConfig | undefined {
-  // If neither agent nor default has compaction config, return undefined
-  if (!agentCompaction && !defaultCompaction) return undefined;
-
-  const rawMode = agentCompaction?.mode ?? defaultCompaction?.mode ?? "safeguard";
-
-  if (!VALID_COMPACTION_MODES.has(rawMode)) {
-    throw new Error(
-      `Invalid compaction mode "${rawMode}" (must be off, safeguard, or aggressive)`,
-    );
-  }
-
-  const mode = rawMode as CompactionMode;
-
-  return {
-    mode,
-    contextWindow: agentCompaction?.contextWindow ?? defaultCompaction?.contextWindow,
-    threshold: agentCompaction?.threshold ?? defaultCompaction?.threshold,
-    preserveRecent: agentCompaction?.preserveRecent ?? defaultCompaction?.preserveRecent,
   };
 }
 
@@ -419,13 +374,11 @@ export function toAgentConfig(
   agentDefaults?: AgentDefaultsConfigFile,
   globalProvider?: ProviderConfigFile,
   globalTools?: AgentToolsConfigFile,
-  globalCompaction?: CompactionConfigFile,
   globalSandbox?: SandboxConfigFile,
 ): AgentConfig {
   // 3-tier merge: agent > defaults > global (shallow replace per block)
   const tools = agent.tools ?? agentDefaults?.tools ?? globalTools;
   const resolvedToolSettings = resolveToolSettings(tools);
-  const agentCompaction = agent.compaction ?? agentDefaults?.compaction ?? globalCompaction;
   // Sandbox: agents-level (defaults > global) is the base; per-agent overlays
   // partial overrides (typically just `mode: "off"`). The merge happens inside
   // resolveSandboxConfigFromFile so per-agent need not repeat docker config.
@@ -434,7 +387,6 @@ export function toAgentConfig(
   // Model: per-agent override > global defaultModel
   const model = agent.model ?? globalProvider?.defaultModel;
 
-  const compaction = resolveCompactionConfigFromFile(agentCompaction);
   const sandbox =
     agent.sandbox || baseSandbox
       ? resolveSandboxConfigFromFile(agent.id, agent.sandbox, baseSandbox)
@@ -446,7 +398,6 @@ export function toAgentConfig(
     ...(agent.workspace ? { workspace: agent.workspace } : {}),
     toolSettings: resolvedToolSettings,
     ...(model ? { model } : {}),
-    compaction,
     sandbox,
     spawnable: agent.spawnable,
     sessionPolicy: agent.sessionPolicy,


### PR DESCRIPTION
## Summary

The `compaction` config block was almost entirely dead weight on top of pi SDK defaults:

- `contextWindow` / `threshold` / `preserveRecent` were accepted in yaml, plumbed into `CompactionConfig`, and **never read** by anything.
- `mode` had three values (`off` / `safeguard` / `aggressive`) but only `off` was actually checked — `safeguard` and `aggressive` were behaviorally identical.
- `session-factory.ts` hard-coded `reserveTokens: 20_000` and `keepRecentTokens: 20_000`, which match (or near-match: 16384 vs 20000) the SDK defaults — i.e. the override did nothing meaningful.
- The on/off switch itself is unnecessary — SDK defaults compaction to enabled, and turning it off just lets long sessions overflow.

Drop the whole block. `SettingsManager.inMemory()` is now called with no args; pi SDK defaults take over. #671 (per-model scaling) can re-introduce a minimal, purposeful config surface when actually implemented.

**Net: -156 lines.**

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 924/924 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)