### PR TITLE
fix(session-store): atomic findOrCreateByKey to fix concurrent spawn race (#688)

### DIFF
--- a/src/agent/runners/pi/runner.ts
+++ b/src/agent/runners/pi/runner.ts
@@ -30,10 +30,8 @@ export class PiRunner {
       ? req.parentSessionId
       : randomUUID();
     const sessionKey = `peer:${fromId}:${suffix}`;
-    const existing = await store.findByKey(sessionKey);
-    if (existing) return existing.id;
-    const created = await store.create(this.opts.agent.id, { key: sessionKey });
-    return created.id;
+    const session = await store.findOrCreateByKey(sessionKey, this.opts.agent.id);
+    return session.id;
   }
 
   async *run(opts: {

--- a/src/agent/runners/pi/session-store.test.ts
+++ b/src/agent/runners/pi/session-store.test.ts
@@ -144,6 +144,34 @@ describe("DefaultSessionStore", () => {
     });
   });
 
+  describe("findOrCreateByKey", () => {
+    it("returns the existing session when the key is present", async () => {
+      const created = await store.create("agent-1", { key: "k" });
+      const got = await store.findOrCreateByKey("k", "agent-1");
+      expect(got.id).toBe(created.id);
+    });
+
+    it("creates a new session when the key is absent", async () => {
+      const got = await store.findOrCreateByKey("k", "agent-1", {
+        transport: "discord",
+      });
+      expect(got.id).toBeDefined();
+      expect(got.metadata?.key).toBe("k");
+      expect(got.metadata?.transport).toBe("discord");
+    });
+
+    it("coalesces concurrent calls with the same key (regression: spawn race #688)", async () => {
+      const results = await Promise.all([
+        store.findOrCreateByKey("race-key", "agent-1"),
+        store.findOrCreateByKey("race-key", "agent-1"),
+        store.findOrCreateByKey("race-key", "agent-1"),
+      ]);
+      expect(results[0].id).toBe(results[1].id);
+      expect(results[1].id).toBe(results[2].id);
+      expect((await store.list()).filter((s) => s.metadata?.key === "race-key")).toHaveLength(1);
+    });
+  });
+
   describe("addMessage / getMessages", () => {
     it("stores and retrieves messages", async () => {
       const session = await store.create("agent-1");

--- a/src/agent/runners/pi/session-store.ts
+++ b/src/agent/runners/pi/session-store.ts
@@ -39,6 +39,7 @@ interface StoredSession extends Session {
 export class DefaultSessionStore implements SessionStore {
   private sessions = new Map<string, StoredSession>();
   private keyIndex = new Map<string, string>();
+  private inflightByKey = new Map<string, Promise<Session>>();
   private indexDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private static readonly INDEX_DEBOUNCE_MS = 1_000;
 
@@ -60,6 +61,21 @@ export class DefaultSessionStore implements SessionStore {
     if (metadata?.key) this.keyIndex.set(metadata.key, id);
     await this.persistIndex();
     return toSession(session);
+  }
+
+  async findOrCreateByKey(
+    key: string,
+    agentId: string,
+    metadata?: Omit<SessionMetadata, "key">,
+  ): Promise<Session> {
+    const existing = await this.findByKey(key);
+    if (existing) return existing;
+    const pending = this.inflightByKey.get(key);
+    if (pending) return pending;
+    const promise = this.create(agentId, { ...(metadata ?? {}), key })
+      .finally(() => this.inflightByKey.delete(key));
+    this.inflightByKey.set(key, promise);
+    return promise;
   }
 
   async get(sessionId: string): Promise<Session | undefined> {

--- a/src/app.ts
+++ b/src/app.ts
@@ -159,7 +159,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       runAgentLoop: async (agentId, prompt, _sessionKey) => {
         const store = await sessionStoreManager.getOrCreate(agentId);
         const sessionKey = `heartbeat:${agentId}`;
-        const session = (await store.findByKey(sessionKey)) ?? (await store.create(agentId, { key: sessionKey }));
+        const session = await store.findOrCreateByKey(sessionKey, agentId);
         const result = await runAgent(agentRuntime, {
           to: agentId,
           sessionId: session.id,
@@ -227,7 +227,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
 
     try {
       const store = await sessionStoreManager.getOrCreate(job.agentId);
-      const session = (await store.findByKey(sessionKey)) ?? (await store.create(job.agentId, { key: sessionKey }));
+      const session = await store.findOrCreateByKey(sessionKey, job.agentId);
       const result = await runAgent(agentRuntime, {
         to: job.agentId,
         sessionId: session.id,

--- a/src/legacy/plugins/discord/discord.ts
+++ b/src/legacy/plugins/discord/discord.ts
@@ -691,11 +691,10 @@ export class DiscordTransport implements Transport {
       return existing;
     }
 
-    // Create new session with key
+    // Create new session with key (atomic against concurrent spawns)
     const channelName = "name" in msg.channel ? (msg.channel as { name?: string }).name : undefined;
     const guildName = msg.guild?.name;
-    const session = await sessionStore.create(agentId, {
-      key: sessionKey,
+    const session = await sessionStore.findOrCreateByKey(sessionKey, agentId, {
       transport: "discord",
       channelId: msg.channelId,
       channelName: channelName ?? undefined,

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -235,7 +235,7 @@ addRoute("POST", "/api/sessions/:agentId", async (req, res, deps) => {
       sessionId = existing.id;
       resumed = true;
     } else {
-      const session = await store.create(agentId, { key: sessionKey });
+      const session = await store.findOrCreateByKey(sessionKey, agentId);
       sessionId = session.id;
     }
   } else {

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -26,6 +26,13 @@ export interface SessionMetadata {
 /** Persistent store for sessions and their message histories. */
 export interface SessionStore {
   create(agentId: string, metadata?: SessionMetadata): Promise<Session>;
+  /**
+   * Atomic find-by-key-or-create. Concurrent calls with the same key
+   * coalesce to one underlying create — the alternative
+   * `(await findByKey(k)) ?? (await create(...))` racing pattern throws
+   * "Session with key already exists" under parallel access.
+   */
+  findOrCreateByKey(key: string, agentId: string, metadata?: Omit<SessionMetadata, "key">): Promise<Session>;
   get(sessionId: string): Promise<Session | undefined>;
   findByKey(key: string): Promise<Session | undefined>;
   addMessage(sessionId: string, message: AgentMessage): Promise<void>;

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -48,6 +48,11 @@ export function createMockSessionStore(sessionId = "session-123"): SessionStore 
       agentId: "default",
       lastActiveAt: new Date(),
     }),
+    findOrCreateByKey: vi.fn().mockResolvedValue({
+      id: sessionId,
+      agentId: "default",
+      lastActiveAt: new Date(),
+    }),
     get: vi.fn(),
     findByKey: vi.fn().mockResolvedValue(undefined),
     addMessage: vi.fn(),


### PR DESCRIPTION
Closes #688 (Bug A).

## Summary
- Adds \`SessionStore.findOrCreateByKey(key, agentId, metadata?)\` — atomic find-or-create.
- \`DefaultSessionStore\` coalesces concurrent calls per key via an in-memory Promise map (same pattern as \`SessionStoreManager.getOrCreate\`).
- Migrates 5 callsites that previously did \`(await findByKey(k)) ?? (await create(...))\`:
  - \`src/agent/runners/pi/runner.ts\` — the immediate user-visible failure (\`spawn_agent\` parent-reuse)
  - \`src/app.ts\` × 2 — heartbeat + cron
  - \`src/legacy/plugins/discord/discord.ts\` — Discord \`findOrCreateSession\`
  - \`src/legacy/plugins/http/sessions.ts\` — HTTP chat session create

## Bug A: what was broken
Three concurrent \`spawn_agent\` calls against the same parent + target agent compute an identical sessionKey, all see \`findByKey\` return \`undefined\`, then race into \`store.create()\`. First wins, the other two throw \`Session with key already exists\`.

Reporter hit this live in Discord with \"同时 spawn 三个 agent\" — 1 success + 2 failures.

## Bug B not in this PR
Issue #688 also tracks stale in-memory state when the user deletes \`<sessionId>.jsonl\` from disk while the daemon runs. Different root cause and needs the multi-process / external-mutation story worked out. Will follow up separately.

## Test plan
- [x] Regression test in \`session-store.test.ts\`: 3 concurrent \`findOrCreateByKey\` calls return the same id and only 1 underlying create happens
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (930 pass)
- [x] \`pnpm lint\`
- [ ] Smoke: spawn 3 agents in parallel via Discord (reporter to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)