### PR TITLE
refactor(runtime): replace per-session event bus with transcript bus

### DIFF
--- a/src/agent/runners/pi/session-store.test.ts
+++ b/src/agent/runners/pi/session-store.test.ts
@@ -333,14 +333,31 @@ describe("DefaultSessionStore", () => {
       expect(seen).toHaveLength(1);
     });
 
-    it("rejects a second attach to the same sessionId", async () => {
+    it("fans out to multiple subscribers", async () => {
       const session = await store.create("agent-1");
-      const unsub = store.attach(session.id, () => {});
-      expect(() => store.attach(session.id, () => {})).toThrow(/already attached/);
-      unsub();
-      // After unsub, re-attach is allowed.
-      const unsub2 = store.attach(session.id, () => {});
-      unsub2();
+      const a: number[] = [];
+      const b: number[] = [];
+      const ua = store.attach(session.id, () => a.push(1));
+      const ub = store.attach(session.id, () => b.push(1));
+      try {
+        await store.addMessage(session.id, userMessage("hi"));
+      } finally { ua(); ub(); }
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+    });
+
+    it("unsubscribe stops only that listener", async () => {
+      const session = await store.create("agent-1");
+      const a: number[] = [];
+      const b: number[] = [];
+      const ua = store.attach(session.id, () => a.push(1));
+      const ub = store.attach(session.id, () => b.push(1));
+      await store.addMessage(session.id, userMessage("first"));
+      ua();
+      await store.addMessage(session.id, userMessage("second"));
+      ub();
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(2);
     });
 
     it("does not emit after unsubscribe", async () => {

--- a/src/agent/runners/pi/session-store.test.ts
+++ b/src/agent/runners/pi/session-store.test.ts
@@ -308,15 +308,15 @@ describe("DefaultSessionStore", () => {
     });
   });
 
-  describe("transcript bus (attach)", () => {
+  describe("transcript bus (subscribe)", () => {
     it("emits a TranscriptUpdate when addMessage appends", async () => {
       const session = await store.create("agent-1");
       const seen: Array<{ messageId: string }> = [];
-      const unsub = store.attach(session.id, (u) => seen.push({ messageId: u.messageId }));
+      const unsubscribe = store.subscribe(session.id, (u) => seen.push({ messageId: u.messageId }));
       try {
         await store.addMessage(session.id, userMessage("hello"));
         await store.addMessage(session.id, assistantMessage("hi"));
-      } finally { unsub(); }
+      } finally { unsubscribe(); }
       expect(seen).toHaveLength(2);
       expect(seen[0].messageId).toBeTruthy();
     });
@@ -324,12 +324,12 @@ describe("DefaultSessionStore", () => {
     it("emits when SDK writes via the shared SessionManager (post-getSessionManager)", async () => {
       const session = await store.create("agent-1");
       const seen: number[] = [];
-      const unsub = store.attach(session.id, () => seen.push(1));
+      const unsubscribe = store.subscribe(session.id, () => seen.push(1));
       try {
         const sm = await store.getSessionManager(session.id);
         // Simulate SDK-side write through the patched appendMessage.
         sm!.appendMessage(userMessage("from-sdk") as never);
-      } finally { unsub(); }
+      } finally { unsubscribe(); }
       expect(seen).toHaveLength(1);
     });
 
@@ -337,8 +337,8 @@ describe("DefaultSessionStore", () => {
       const session = await store.create("agent-1");
       const a: number[] = [];
       const b: number[] = [];
-      const ua = store.attach(session.id, () => a.push(1));
-      const ub = store.attach(session.id, () => b.push(1));
+      const ua = store.subscribe(session.id, () => a.push(1));
+      const ub = store.subscribe(session.id, () => b.push(1));
       try {
         await store.addMessage(session.id, userMessage("hi"));
       } finally { ua(); ub(); }
@@ -350,8 +350,8 @@ describe("DefaultSessionStore", () => {
       const session = await store.create("agent-1");
       const a: number[] = [];
       const b: number[] = [];
-      const ua = store.attach(session.id, () => a.push(1));
-      const ub = store.attach(session.id, () => b.push(1));
+      const ua = store.subscribe(session.id, () => a.push(1));
+      const ub = store.subscribe(session.id, () => b.push(1));
       await store.addMessage(session.id, userMessage("first"));
       ua();
       await store.addMessage(session.id, userMessage("second"));
@@ -363,9 +363,9 @@ describe("DefaultSessionStore", () => {
     it("does not emit after unsubscribe", async () => {
       const session = await store.create("agent-1");
       const seen: number[] = [];
-      const unsub = store.attach(session.id, () => seen.push(1));
+      const unsubscribe = store.subscribe(session.id, () => seen.push(1));
       await store.addMessage(session.id, userMessage("a"));
-      unsub();
+      unsubscribe();
       await store.addMessage(session.id, userMessage("b"));
       expect(seen).toHaveLength(1);
     });
@@ -375,8 +375,8 @@ describe("DefaultSessionStore", () => {
       const b = await store.create("agent-1");
       const seenA: number[] = [];
       const seenB: number[] = [];
-      const ua = store.attach(a.id, () => seenA.push(1));
-      const ub = store.attach(b.id, () => seenB.push(1));
+      const ua = store.subscribe(a.id, () => seenA.push(1));
+      const ub = store.subscribe(b.id, () => seenB.push(1));
       try {
         await store.addMessage(a.id, userMessage("for-a"));
         await store.addMessage(b.id, userMessage("for-b"));
@@ -388,10 +388,10 @@ describe("DefaultSessionStore", () => {
 
     it("listener errors do not propagate (turn state safe)", async () => {
       const session = await store.create("agent-1");
-      const unsub = store.attach(session.id, () => { throw new Error("boom"); });
+      const unsubscribe = store.subscribe(session.id, () => { throw new Error("boom"); });
       try {
         await expect(store.addMessage(session.id, userMessage("hi"))).resolves.not.toThrow();
-      } finally { unsub(); }
+      } finally { unsubscribe(); }
     });
   });
 

--- a/src/agent/runners/pi/session-store.test.ts
+++ b/src/agent/runners/pi/session-store.test.ts
@@ -308,6 +308,76 @@ describe("DefaultSessionStore", () => {
     });
   });
 
+  describe("transcript bus (attach)", () => {
+    it("emits a TranscriptUpdate when addMessage appends", async () => {
+      const session = await store.create("agent-1");
+      const seen: Array<{ messageId: string }> = [];
+      const unsub = store.attach(session.id, (u) => seen.push({ messageId: u.messageId }));
+      try {
+        await store.addMessage(session.id, userMessage("hello"));
+        await store.addMessage(session.id, assistantMessage("hi"));
+      } finally { unsub(); }
+      expect(seen).toHaveLength(2);
+      expect(seen[0].messageId).toBeTruthy();
+    });
+
+    it("emits when SDK writes via the shared SessionManager (post-getSessionManager)", async () => {
+      const session = await store.create("agent-1");
+      const seen: number[] = [];
+      const unsub = store.attach(session.id, () => seen.push(1));
+      try {
+        const sm = await store.getSessionManager(session.id);
+        // Simulate SDK-side write through the patched appendMessage.
+        sm!.appendMessage(userMessage("from-sdk") as never);
+      } finally { unsub(); }
+      expect(seen).toHaveLength(1);
+    });
+
+    it("rejects a second attach to the same sessionId", async () => {
+      const session = await store.create("agent-1");
+      const unsub = store.attach(session.id, () => {});
+      expect(() => store.attach(session.id, () => {})).toThrow(/already attached/);
+      unsub();
+      // After unsub, re-attach is allowed.
+      const unsub2 = store.attach(session.id, () => {});
+      unsub2();
+    });
+
+    it("does not emit after unsubscribe", async () => {
+      const session = await store.create("agent-1");
+      const seen: number[] = [];
+      const unsub = store.attach(session.id, () => seen.push(1));
+      await store.addMessage(session.id, userMessage("a"));
+      unsub();
+      await store.addMessage(session.id, userMessage("b"));
+      expect(seen).toHaveLength(1);
+    });
+
+    it("isolates listeners between sessions", async () => {
+      const a = await store.create("agent-1");
+      const b = await store.create("agent-1");
+      const seenA: number[] = [];
+      const seenB: number[] = [];
+      const ua = store.attach(a.id, () => seenA.push(1));
+      const ub = store.attach(b.id, () => seenB.push(1));
+      try {
+        await store.addMessage(a.id, userMessage("for-a"));
+        await store.addMessage(b.id, userMessage("for-b"));
+        await store.addMessage(b.id, userMessage("for-b-2"));
+      } finally { ua(); ub(); }
+      expect(seenA).toHaveLength(1);
+      expect(seenB).toHaveLength(2);
+    });
+
+    it("listener errors do not propagate (turn state safe)", async () => {
+      const session = await store.create("agent-1");
+      const unsub = store.attach(session.id, () => { throw new Error("boom"); });
+      try {
+        await expect(store.addMessage(session.id, userMessage("hi"))).resolves.not.toThrow();
+      } finally { unsub(); }
+    });
+  });
+
 });
 let tmpRoot: string;
 let originalHome: string | undefined;

--- a/src/agent/runners/pi/session-store.ts
+++ b/src/agent/runners/pi/session-store.ts
@@ -8,6 +8,8 @@ import type {
   Session,
   SessionMetadata,
   SessionStore,
+  TranscriptListener,
+  TranscriptUpdate,
 } from "../../../sessions/types.js";
 import {
   ensureAgentSessionsDir,
@@ -36,11 +38,33 @@ interface StoredSession extends Session {
   manager?: SessionManager;
 }
 
+/** Monkey-patch SessionManager.appendMessage to emit after each persisted entry.
+ * Mirrors openclaw's session-tool-result-guard.ts:269 hot-path strategy:
+ * any write — by transports (user input) or by the SDK (assistant/tool) — fans out. */
+function installTranscriptEmitter(
+  sm: SessionManager,
+  sessionId: string,
+  emit: (update: TranscriptUpdate) => void,
+): void {
+  const original = sm.appendMessage.bind(sm);
+  sm.appendMessage = (message: PiMessage) => {
+    const messageId = original(message);
+    try {
+      emit({ sessionId, message: message as unknown as AgentMessage, messageId });
+    } catch {
+      // listener errors don't propagate — they would corrupt SDK turn state
+    }
+    return messageId;
+  };
+}
+
 export class DefaultSessionStore implements SessionStore {
   private sessions = new Map<string, StoredSession>();
   private keyIndex = new Map<string, string>();
   private indexDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private static readonly INDEX_DEBOUNCE_MS = 1_000;
+  /** Single-attach: at most one transcript-bus listener per sessionId. */
+  private listeners = new Map<string, TranscriptListener>();
 
   constructor(private readonly dataDir: string) {}
 
@@ -55,6 +79,7 @@ export class DefaultSessionStore implements SessionStore {
     }
     const id = randomUUID();
     const manager = SessionManager.open(this.transcriptFile(id));
+    installTranscriptEmitter(manager, id, (u) => this.emitTranscript(u));
     const session: StoredSession = { id, agentId, metadata, lastActiveAt: new Date(), manager };
     this.sessions.set(id, session);
     if (metadata?.key) this.keyIndex.set(metadata.key, id);
@@ -119,6 +144,7 @@ export class DefaultSessionStore implements SessionStore {
     session.lastActiveAt = new Date();
     await fs.writeFile(this.transcriptFile(sessionId), "");
     session.manager = SessionManager.open(this.transcriptFile(sessionId));
+    installTranscriptEmitter(session.manager, sessionId, (u) => this.emitTranscript(u));
     await this.persistIndex();
   }
 
@@ -196,8 +222,29 @@ export class DefaultSessionStore implements SessionStore {
   private ensureManager(session: StoredSession): SessionManager {
     if (!session.manager) {
       session.manager = SessionManager.open(this.transcriptFile(session.id));
+      installTranscriptEmitter(session.manager, session.id, (u) => this.emitTranscript(u));
     }
     return session.manager;
+  }
+
+  private emitTranscript(update: TranscriptUpdate): void {
+    const listener = this.listeners.get(update.sessionId);
+    if (!listener) return;
+    try { listener(update); }
+    catch (err) { log.warn("Transcript listener threw", err); }
+  }
+
+  /** Attach a single listener for transcript appends on a sessionId. Throws if already attached. */
+  attach(sessionId: string, listener: TranscriptListener): () => void {
+    if (this.listeners.has(sessionId)) {
+      throw new Error(`Session "${sessionId}" already attached`);
+    }
+    this.listeners.set(sessionId, listener);
+    return () => {
+      if (this.listeners.get(sessionId) === listener) {
+        this.listeners.delete(sessionId);
+      }
+    };
   }
 }
 

--- a/src/agent/runners/pi/session-store.ts
+++ b/src/agent/runners/pi/session-store.ts
@@ -62,8 +62,8 @@ export class DefaultSessionStore implements SessionStore {
   private keyIndex = new Map<string, string>();
   private indexDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private static readonly INDEX_DEBOUNCE_MS = 1_000;
-  /** At most one transcript-bus listener per sessionId. */
-  private listeners = new Map<string, TranscriptListener>();
+  /** Transcript-bus listeners per sessionId. */
+  private listeners = new Map<string, Set<TranscriptListener>>();
 
   constructor(private readonly dataDir: string) {}
 
@@ -227,22 +227,25 @@ export class DefaultSessionStore implements SessionStore {
   }
 
   private emitTranscript(update: TranscriptUpdate): void {
-    const listener = this.listeners.get(update.sessionId);
-    if (!listener) return;
-    try { listener(update); }
-    catch (err) { log.warn("Transcript listener threw", err); }
+    const set = this.listeners.get(update.sessionId);
+    if (!set) return;
+    for (const fn of set) {
+      try { fn(update); }
+      catch (err) { log.warn("Transcript listener threw", err); }
+    }
   }
 
-  /** Attach a single listener; throws if already attached. */
+  /** Attach a transcript-bus listener. Multiple listeners per session are allowed. */
   attach(sessionId: string, listener: TranscriptListener): () => void {
-    if (this.listeners.has(sessionId)) {
-      throw new Error(`Session "${sessionId}" already attached`);
+    let set = this.listeners.get(sessionId);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(sessionId, set);
     }
-    this.listeners.set(sessionId, listener);
+    set.add(listener);
     return () => {
-      if (this.listeners.get(sessionId) === listener) {
-        this.listeners.delete(sessionId);
-      }
+      set!.delete(listener);
+      if (set!.size === 0) this.listeners.delete(sessionId);
     };
   }
 }

--- a/src/agent/runners/pi/session-store.ts
+++ b/src/agent/runners/pi/session-store.ts
@@ -77,8 +77,7 @@ export class DefaultSessionStore implements SessionStore {
       throw new Error(`Session with key already exists: ${metadata.key}`);
     }
     const id = randomUUID();
-    const manager = SessionManager.open(this.transcriptFile(id));
-    installTranscriptEmitter(manager, id, (u) => this.emitTranscript(u));
+    const manager = this.openPatchedManager(id);
     const session: StoredSession = { id, agentId, metadata, lastActiveAt: new Date(), manager };
     this.sessions.set(id, session);
     if (metadata?.key) this.keyIndex.set(metadata.key, id);
@@ -142,8 +141,7 @@ export class DefaultSessionStore implements SessionStore {
     if (!session) throw new Error(`Session "${sessionId}" not found`);
     session.lastActiveAt = new Date();
     await fs.writeFile(this.transcriptFile(sessionId), "");
-    session.manager = SessionManager.open(this.transcriptFile(sessionId));
-    installTranscriptEmitter(session.manager, sessionId, (u) => this.emitTranscript(u));
+    session.manager = this.openPatchedManager(sessionId);
     await this.persistIndex();
   }
 
@@ -220,10 +218,17 @@ export class DefaultSessionStore implements SessionStore {
 
   private ensureManager(session: StoredSession): SessionManager {
     if (!session.manager) {
-      session.manager = SessionManager.open(this.transcriptFile(session.id));
-      installTranscriptEmitter(session.manager, session.id, (u) => this.emitTranscript(u));
+      session.manager = this.openPatchedManager(session.id);
     }
     return session.manager;
+  }
+
+  /** Single source of truth for opening a SessionManager — patches it
+   * with the transcript emitter exactly once. */
+  private openPatchedManager(sessionId: string): SessionManager {
+    const sm = SessionManager.open(this.transcriptFile(sessionId));
+    installTranscriptEmitter(sm, sessionId, (u) => this.emitTranscript(u));
+    return sm;
   }
 
   private emitTranscript(update: TranscriptUpdate): void {

--- a/src/agent/runners/pi/session-store.ts
+++ b/src/agent/runners/pi/session-store.ts
@@ -38,8 +38,6 @@ interface StoredSession extends Session {
   manager?: SessionManager;
 }
 
-/** Patch appendMessage to fan out every persisted entry — covers both
- * transport-side user writes and SDK-side assistant/tool writes. */
 function installTranscriptEmitter(
   sm: SessionManager,
   sessionId: string,
@@ -49,8 +47,7 @@ function installTranscriptEmitter(
   sm.appendMessage = (message: PiMessage) => {
     const messageId = original(message);
     try {
-      // PiMessage and AgentMessage are structurally compatible — they share
-      // the role/content shape that pi-agent-core re-exports under both names.
+      // PiMessage === AgentMessage structurally; pi-agent-core re-exports both names.
       emit({ sessionId, message: message as unknown as AgentMessage, messageId });
     } catch {
       // swallow: a throw here would corrupt SDK turn state

--- a/src/agent/runners/pi/session-store.ts
+++ b/src/agent/runners/pi/session-store.ts
@@ -49,6 +49,8 @@ function installTranscriptEmitter(
   sm.appendMessage = (message: PiMessage) => {
     const messageId = original(message);
     try {
+      // PiMessage and AgentMessage are structurally compatible — they share
+      // the role/content shape that pi-agent-core re-exports under both names.
       emit({ sessionId, message: message as unknown as AgentMessage, messageId });
     } catch {
       // swallow: a throw here would corrupt SDK turn state

--- a/src/agent/runners/pi/session-store.ts
+++ b/src/agent/runners/pi/session-store.ts
@@ -38,9 +38,8 @@ interface StoredSession extends Session {
   manager?: SessionManager;
 }
 
-/** Monkey-patch SessionManager.appendMessage to emit after each persisted entry.
- * Mirrors openclaw's session-tool-result-guard.ts:269 hot-path strategy:
- * any write — by transports (user input) or by the SDK (assistant/tool) — fans out. */
+/** Patch appendMessage to fan out every persisted entry — covers both
+ * transport-side user writes and SDK-side assistant/tool writes. */
 function installTranscriptEmitter(
   sm: SessionManager,
   sessionId: string,
@@ -52,7 +51,7 @@ function installTranscriptEmitter(
     try {
       emit({ sessionId, message: message as unknown as AgentMessage, messageId });
     } catch {
-      // listener errors don't propagate — they would corrupt SDK turn state
+      // swallow: a throw here would corrupt SDK turn state
     }
     return messageId;
   };
@@ -63,7 +62,7 @@ export class DefaultSessionStore implements SessionStore {
   private keyIndex = new Map<string, string>();
   private indexDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private static readonly INDEX_DEBOUNCE_MS = 1_000;
-  /** Single-attach: at most one transcript-bus listener per sessionId. */
+  /** At most one transcript-bus listener per sessionId. */
   private listeners = new Map<string, TranscriptListener>();
 
   constructor(private readonly dataDir: string) {}
@@ -234,7 +233,7 @@ export class DefaultSessionStore implements SessionStore {
     catch (err) { log.warn("Transcript listener threw", err); }
   }
 
-  /** Attach a single listener for transcript appends on a sessionId. Throws if already attached. */
+  /** Attach a single listener; throws if already attached. */
   attach(sessionId: string, listener: TranscriptListener): () => void {
     if (this.listeners.has(sessionId)) {
       throw new Error(`Session "${sessionId}" already attached`);

--- a/src/agent/runners/pi/session-store.ts
+++ b/src/agent/runners/pi/session-store.ts
@@ -239,8 +239,8 @@ export class DefaultSessionStore implements SessionStore {
     }
   }
 
-  /** Attach a transcript-bus listener. Multiple listeners per session are allowed. */
-  attach(sessionId: string, listener: TranscriptListener): () => void {
+  /** Subscribe a transcript-bus listener. Multiple listeners per session are allowed. */
+  subscribe(sessionId: string, listener: TranscriptListener): () => void {
     let set = this.listeners.get(sessionId);
     if (!set) {
       set = new Set();

--- a/src/agent/runtime-adapter.test.ts
+++ b/src/agent/runtime-adapter.test.ts
@@ -98,7 +98,7 @@ describe("runAgent", () => {
     expect(scanCount).toBe(0);
   });
 
-  it("emits every AgentEvent to runtime.on(sessionId)", async () => {
+  it("calls onEvent for every AgentEvent yielded by runtime.run", async () => {
     const rt = new AgentRuntime();
     rt.registerRunner("main", stubRunner(async function* () {
       yield buildTextDelta("hi");
@@ -106,12 +106,13 @@ describe("runAgent", () => {
     }));
 
     const seen: AgentEvent["type"][] = [];
-    const unsub = rt.on("s4", (e) => seen.push(e.type));
-    try {
-      await runAgent(rt, { to: "main", sessionId: "s4", content: "hi", log });
-    } finally {
-      unsub();
-    }
+    await runAgent(rt, {
+      to: "main",
+      sessionId: "s4",
+      content: "hi",
+      log,
+      onEvent: (e) => seen.push(e.type),
+    });
 
     expect(seen).toEqual(["message_update", "agent_end"]);
   });

--- a/src/agent/runtime-adapter.ts
+++ b/src/agent/runtime-adapter.ts
@@ -6,6 +6,7 @@ import { userMessage, assistantMessage, getAgentEndMeta } from "./runners/pi/mes
 import type { Logger } from "../logging/logger.js";
 import type { HookRegistry } from "../legacy/plugins/hooks.js";
 import { runWithMessageContext } from "../legacy/transport/context.js";
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
 
 export interface RunAgentOptions {
   to: string;
@@ -16,6 +17,8 @@ export interface RunAgentOptions {
   hooks?: HookRegistry;
   /** Fires at every turn boundary; non-null return is steered into the next turn. */
   onTurnEnd?: () => Promise<string | null>;
+  /** Fires for every event yielded by runtime.run. Use to render streaming UI in the driving caller. */
+  onEvent?: (event: AgentEvent) => void;
 }
 
 export interface RunAgentResult {
@@ -27,7 +30,7 @@ export async function runAgent(
   runtime: AgentRuntime,
   opts: RunAgentOptions,
 ): Promise<RunAgentResult> {
-  const { to, sessionId, content, cwd, log, hooks, onTurnEnd } = opts;
+  const { to, sessionId, content, cwd, log, hooks, onTurnEnd, onEvent } = opts;
 
   if (hooks && content) {
     await hooks.emit("message_received", {
@@ -52,6 +55,10 @@ export async function runAgent(
       { transport: "internal", channelKey: sessionId, agentId: to, parentSessionId: sessionId },
       async () => {
         for await (const event of stream) {
+          if (onEvent) {
+            try { onEvent(event); }
+            catch (err) { log.warn("onEvent callback threw", { error: err }); }
+          }
           if (event.type === "message_update") {
             const ame = event.assistantMessageEvent;
             if (ame.type === "text_delta") responseText += ame.delta;

--- a/src/agent/runtime.test.ts
+++ b/src/agent/runtime.test.ts
@@ -434,8 +434,6 @@ describe("runtime.steer — wires onSession into RunHandle", () => {
 describe("AgentRuntime no longer exposes a per-session event bus", () => {
   it("removed runtime.on/emitSessionEvent/endSession/sessionListenerCount", () => {
     const rt = new AgentRuntime();
-    // These were removed in the #684 fix — fan-out lives in SessionStore (transcript bus)
-    // and live driver streams now go through runAgent's onEvent callback.
     expect((rt as unknown as { on?: unknown }).on).toBeUndefined();
     expect((rt as unknown as { emitSessionEvent?: unknown }).emitSessionEvent).toBeUndefined();
     expect((rt as unknown as { endSession?: unknown }).endSession).toBeUndefined();

--- a/src/agent/runtime.test.ts
+++ b/src/agent/runtime.test.ts
@@ -19,19 +19,6 @@ function fakeAgent(id: string): RegisteredAgent {
   };
 }
 
-function makeEvent(text: string): AgentEvent {
-  return {
-    type: "message_update",
-    message: { role: "assistant", content: [{ type: "text", text }] } as never,
-    assistantMessageEvent: {
-      type: "text_delta",
-      contentIndex: 0,
-      delta: text,
-      partial: { role: "assistant", content: [{ type: "text", text }] } as never,
-    } as never,
-  };
-}
-
 function buildAgentEnd(text: string, stopReason = "end", errorMessage?: string): AgentEvent {
   return {
     type: "agent_end",
@@ -444,119 +431,14 @@ describe("runtime.steer — wires onSession into RunHandle", () => {
   });
 });
 
-describe("AgentRuntime session event subscription", () => {
-  it("delivers events to a subscribed listener", () => {
+describe("AgentRuntime no longer exposes a per-session event bus", () => {
+  it("removed runtime.on/emitSessionEvent/endSession/sessionListenerCount", () => {
     const rt = new AgentRuntime();
-    const seen: AgentEvent[] = [];
-    rt.on("s", (e) => seen.push(e));
-
-    rt.emitSessionEvent("s", makeEvent("a"));
-    rt.emitSessionEvent("s", makeEvent("b"));
-
-    expect(seen).toHaveLength(2);
-  });
-
-  it("fans out to multiple listeners on the same session", () => {
-    const rt = new AgentRuntime();
-    const a: AgentEvent[] = [];
-    const b: AgentEvent[] = [];
-    rt.on("s", (e) => a.push(e));
-    rt.on("s", (e) => b.push(e));
-
-    rt.emitSessionEvent("s", makeEvent("hi"));
-
-    expect(a).toHaveLength(1);
-    expect(b).toHaveLength(1);
-  });
-
-  it("returns an unsubscribe function that stops only that listener", () => {
-    const rt = new AgentRuntime();
-    const a: AgentEvent[] = [];
-    const b: AgentEvent[] = [];
-    const unsubA = rt.on("s", (e) => a.push(e));
-    rt.on("s", (e) => b.push(e));
-
-    rt.emitSessionEvent("s", makeEvent("1"));
-    unsubA();
-    rt.emitSessionEvent("s", makeEvent("2"));
-
-    expect(a).toHaveLength(1);
-    expect(b).toHaveLength(2);
-  });
-
-  it("isolates a throwing listener so others still receive the event", () => {
-    const rt = new AgentRuntime();
-    const seen: AgentEvent[] = [];
-    rt.on("s", () => { throw new Error("boom"); });
-    rt.on("s", (e) => seen.push(e));
-
-    expect(() => rt.emitSessionEvent("s", makeEvent("x"))).not.toThrow();
-    expect(seen).toHaveLength(1);
-  });
-
-  it("isolates events between sessions", () => {
-    const rt = new AgentRuntime();
-    const a: AgentEvent[] = [];
-    const b: AgentEvent[] = [];
-    rt.on("sessionA", (e) => a.push(e));
-    rt.on("sessionB", (e) => b.push(e));
-
-    rt.emitSessionEvent("sessionA", makeEvent("for-a"));
-    rt.emitSessionEvent("sessionB", makeEvent("for-b"));
-    rt.emitSessionEvent("sessionB", makeEvent("for-b-2"));
-
-    expect(a).toHaveLength(1);
-    expect(b).toHaveLength(2);
-  });
-
-  it("emit on a session with no listeners is a no-op", () => {
-    const rt = new AgentRuntime();
-    expect(() => rt.emitSessionEvent("nobody-home", makeEvent("x"))).not.toThrow();
-  });
-
-  it("sessionListenerCount tracks adds and unsubs", () => {
-    const rt = new AgentRuntime();
-    expect(rt.sessionListenerCount("s")).toBe(0);
-
-    const u1 = rt.on("s", () => {});
-    const u2 = rt.on("s", () => {});
-    expect(rt.sessionListenerCount("s")).toBe(2);
-
-    u1();
-    expect(rt.sessionListenerCount("s")).toBe(1);
-
-    u2();
-    expect(rt.sessionListenerCount("s")).toBe(0);
-  });
-
-  it("endSession removes all listeners and stops further delivery", () => {
-    const rt = new AgentRuntime();
-    const seen: AgentEvent[] = [];
-    rt.on("s", (e) => seen.push(e));
-    rt.on("s", (e) => seen.push(e));
-
-    expect(rt.sessionListenerCount("s")).toBe(2);
-
-    rt.endSession("s");
-    expect(rt.sessionListenerCount("s")).toBe(0);
-
-    rt.emitSessionEvent("s", makeEvent("after-end"));
-    expect(seen).toHaveLength(0);
-  });
-
-  it("endSession on an unknown session is a no-op", () => {
-    const rt = new AgentRuntime();
-    expect(() => rt.endSession("never-existed")).not.toThrow();
-  });
-
-  it("logs and swallows listener errors (no crash propagation)", () => {
-    const rt = new AgentRuntime();
-    const errSpy = vi.fn();
-    rt.on("s", () => { throw new Error("nope"); });
-    rt.on("s", errSpy);
-
-    rt.emitSessionEvent("s", makeEvent("x"));
-
-    expect(errSpy).toHaveBeenCalledTimes(1);
+    // These were removed in the #684 fix — fan-out lives in SessionStore (transcript bus)
+    // and live driver streams now go through runAgent's onEvent callback.
+    expect((rt as unknown as { on?: unknown }).on).toBeUndefined();
+    expect((rt as unknown as { emitSessionEvent?: unknown }).emitSessionEvent).toBeUndefined();
+    expect((rt as unknown as { endSession?: unknown }).endSession).toBeUndefined();
+    expect((rt as unknown as { sessionListenerCount?: unknown }).sessionListenerCount).toBeUndefined();
   });
 });

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -93,47 +93,6 @@ export interface AddAgentResult {
   transportContext?: LazyTransportContext;
 }
 
-/** Per-session pub/sub keyed by sessionId. Private to AgentRuntime —
- * subscribe via runtime.on / endSession. */
-class SessionEventBus {
-  private listeners = new Map<string, Set<(event: AgentEvent) => void>>();
-
-  on(sessionId: string, listener: (event: AgentEvent) => void): () => void {
-    let set = this.listeners.get(sessionId);
-    if (!set) {
-      set = new Set();
-      this.listeners.set(sessionId, set);
-    }
-    set.add(listener);
-    return () => {
-      set!.delete(listener);
-    };
-  }
-
-  emit(sessionId: string, event: AgentEvent): void {
-    const set = this.listeners.get(sessionId);
-    if (!set) return;
-    for (const fn of set) {
-      try {
-        fn(event);
-      } catch (err) {
-        log.warn("Session event listener threw", err);
-      }
-    }
-  }
-
-  endSession(sessionId: string): void {
-    const set = this.listeners.get(sessionId);
-    if (!set) return;
-    set.clear();
-    this.listeners.delete(sessionId);
-  }
-
-  listenerCount(sessionId: string): number {
-    return this.listeners.get(sessionId)?.size ?? 0;
-  }
-}
-
 export interface Runner {
   /** Backing isotopes agent (drives getAgent / listAgents). */
   agent?(): RegisteredAgent | undefined;
@@ -161,7 +120,6 @@ export class AgentRuntime {
   private piGlobalProvider?: ProviderConfig;
   private piAuthStorage?: AuthStorage;
   private piModelRegistry?: ModelRegistry;
-  private events = new SessionEventBus();
   private hooks?: HookRegistry;
 
   constructor(options?: AgentRuntimeOptions) {
@@ -243,24 +201,6 @@ export class AgentRuntime {
   getAgentTools(agentId: string): AgentTool[] {
     const map = this.toolRegistries.get(agentId);
     return map ? Array.from(map.values()) : [];
-  }
-
-  on(sessionId: string, listener: (event: AgentEvent) => void): () => void {
-    return this.events.on(sessionId, listener);
-  }
-
-  /** @internal — runtime auto-fans on yield; external callers use on(). */
-  emitSessionEvent(sessionId: string, event: AgentEvent): void {
-    this.events.emit(sessionId, event);
-  }
-
-  /** Drop all listeners for a session. Tears down concurrent subscriptions. */
-  endSession(sessionId: string): void {
-    this.events.endSession(sessionId);
-  }
-
-  sessionListenerCount(sessionId: string): number {
-    return this.events.listenerCount(sessionId);
   }
 
   validateCwd(cwd: string): void {
@@ -472,14 +412,12 @@ export class AgentRuntime {
     }
 
     try {
-      // Auto fan-out + debug-log so consumers stay uniform.
       for await (const event of entry.runner.run({
         request: req,
         sessionId,
         abort: abort.signal,
         onSession: (session) => { handle.session = session; },
       })) {
-        this.emitSessionEvent(sessionId, event);
         if (event.type === "tool_execution_start") {
           log.debug("tool_call", { runId, sessionId, agentId: req.to, toolName: event.toolName, id: event.toolCallId });
         } else if (event.type === "tool_execution_end") {

--- a/src/legacy/cli.ts
+++ b/src/legacy/cli.ts
@@ -162,6 +162,7 @@ const { values, positionals } = parseArgs({
     level: { type: "string" },
     follow: { type: "boolean", short: "f" },
     force: { type: "boolean" },
+    session: { type: "string" },
   },
   allowPositionals: true,
 });
@@ -181,7 +182,7 @@ Usage:
   isotopes status                    Show daemon status
   isotopes restart [--config path]   Restart the daemon
 
-  isotopes tui [--agent id] [--message "text"]
+  isotopes tui [--agent id] [--message "text"] [--session key]
                                      Interactive TUI chat with an agent
 
   isotopes sessions list             List all sessions
@@ -708,7 +709,7 @@ async function run(): Promise<void> {
 
     case "tui": {
       const { launchTui } = await import("./tui/index.js");
-      await launchTui({ agent: values.agent, config: values.config, message: values.message });
+      await launchTui({ agent: values.agent, config: values.config, message: values.message, session: values.session });
       break;
     }
 

--- a/src/legacy/plugins/discord/discord.ts
+++ b/src/legacy/plugins/discord/discord.ts
@@ -737,18 +737,6 @@ export class DiscordTransport implements Transport {
       throw new Error("DiscordTransport.runAgentAndRespond requires agentRuntime");
     }
 
-    const unsubBus = runtime.on(sessionId, (e) => {
-      if (e.type === "message_update" && streamBuffer) {
-        const ame = e.assistantMessageEvent;
-        if (ame.type === "text_delta" && ame.delta.length > 0) {
-          void streamBuffer.append(ame.delta);
-        }
-      }
-      if (this.config.showToolCalls && e.type === "tool_execution_start") {
-        toolSummaries.push(`🔧 ${e.toolName}`);
-      }
-    });
-
     try {
       // Create segmented stream buffer that sends new messages at sentence boundaries
       streamBuffer = new SegmentedStreamBuffer(async (text: string) => {
@@ -777,6 +765,17 @@ export class DiscordTransport implements Transport {
           content: "",
           ...(cwd ? { cwd } : {}),
           log,
+          onEvent: (e) => {
+            if (e.type === "message_update" && streamBuffer) {
+              const ame = e.assistantMessageEvent;
+              if (ame.type === "text_delta" && ame.delta.length > 0) {
+                void streamBuffer.append(ame.delta);
+              }
+            }
+            if (this.config.showToolCalls && e.type === "tool_execution_start") {
+              toolSummaries.push(`🔧 ${e.toolName}`);
+            }
+          },
           onTurnEnd: async () => {
             const pending = this.pendingMessages.get(sessionId);
             if (!pending?.length) return null;
@@ -849,8 +848,6 @@ export class DiscordTransport implements Transport {
         log.debug("Failed to send error message to Discord", sendErr);
       }
     } finally {
-      unsubBus();
-      runtime.endSession(sessionId);
       typing.stop();
       this.pendingMessages.delete(sessionId);
     }

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -212,18 +212,12 @@ addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => 
     return;
   }
 
-  let unsub: (() => void) | undefined;
-  try {
-    unsub = store.attach(resolved.sessionId, (update) => {
-      res.write(`event: message\ndata: ${JSON.stringify({
-        message: update.message,
-        messageId: update.messageId,
-      })}\n\n`);
-    });
-  } catch (err) {
-    sendError(res, 409, err instanceof Error ? err.message : String(err));
-    return;
-  }
+  const unsub = store.attach(resolved.sessionId, (update) => {
+    res.write(`event: message\ndata: ${JSON.stringify({
+      message: update.message,
+      messageId: update.messageId,
+    })}\n\n`);
+  });
 
   res.writeHead(200, {
     "Content-Type": "text/event-stream",
@@ -237,7 +231,7 @@ addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => 
 
   const cleanup = () => {
     clearInterval(heartbeat);
-    unsub?.();
+    unsub();
   };
   res.on("close", cleanup);
   req.on("aborted", cleanup);

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -312,9 +312,30 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
   const { agentId, key: urlKey } = req.params;
   const sessionKey = `${agentId}:${urlKey}`;
 
-  const active = activeSessions.get(sessionKey);
+  let active = activeSessions.get(sessionKey);
   if (!active) {
-    sendError(res, 404, `Active session not found — create or resume it first`);
+    // Session may exist in the store but was never registered via the HTTP create
+    // path (e.g. transport-driven sessions like Discord). Look it up and register
+    // on demand so HTTP clients can send into it.
+    if (deps.sessionStoreManager) {
+      const store = deps.sessionStoreManager.peek(agentId);
+      if (store) {
+        const resolved = await resolveSessionKey(store, agentId, urlKey);
+        if (resolved) {
+          active = {
+            sessionKey: resolved.sessionKey,
+            sessionId: resolved.sessionId,
+            agentId,
+            lastActivity: Date.now(),
+            pendingMessages: [],
+          };
+          activeSessions.set(resolved.sessionKey, active);
+        }
+      }
+    }
+  }
+  if (!active) {
+    sendError(res, 404, `Session not found`);
     return;
   }
   active.lastActivity = Date.now();

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -193,6 +193,58 @@ addRoute("GET", "/api/sessions/:agentId/:key/messages", async (req, res, deps) =
 });
 
 // ---------------------------------------------------------------------------
+// GET /api/sessions/:agentId/:key/stream — observer SSE for transcript appends
+// Single subscriber per sessionId; second connection rejected with 409.
+// ---------------------------------------------------------------------------
+
+addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => {
+  if (!deps.sessionStoreManager) {
+    sendError(res, 503, "Session store not available");
+    return;
+  }
+  const store = deps.sessionStoreManager.peek(req.params.agentId);
+  if (!store) {
+    sendError(res, 404, "Session not found");
+    return;
+  }
+  const resolved = await resolveSessionKey(store, req.params.agentId, req.params.key);
+  if (!resolved) {
+    sendError(res, 404, "Session not found");
+    return;
+  }
+
+  let unsub: (() => void) | undefined;
+  try {
+    unsub = store.attach(resolved.sessionId, (update) => {
+      res.write(`event: message\ndata: ${JSON.stringify({
+        message: update.message,
+        messageId: update.messageId,
+      })}\n\n`);
+    });
+  } catch (err) {
+    sendError(res, 409, err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+  });
+  // Heartbeat every 25s to keep proxies from idling out.
+  const heartbeat = setInterval(() => {
+    res.write(": ping\n\n");
+  }, 25_000);
+
+  const cleanup = () => {
+    clearInterval(heartbeat);
+    unsub?.();
+  };
+  res.on("close", cleanup);
+  req.on("aborted", cleanup);
+});
+
+// ---------------------------------------------------------------------------
 // POST /api/sessions/:agentId — create or resume a session
 // ---------------------------------------------------------------------------
 
@@ -304,21 +356,6 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
     res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
   };
 
-  const unsub = deps.agentRuntime.on(sessionId, (e) => {
-    if (e.type === "message_update") {
-      const ame = e.assistantMessageEvent;
-      if (ame.type === "text_delta") {
-        writeEvent("text_delta", { text: ame.delta });
-      }
-    } else if (e.type === "tool_execution_start") {
-      writeEvent("tool_call", { toolCallId: e.toolCallId, toolName: e.toolName, args: e.args });
-    } else if (e.type === "tool_execution_end") {
-      writeEvent("tool_result", { toolCallId: e.toolCallId, toolName: e.toolName, result: e.result, isError: e.isError });
-    } else if (e.type === "turn_end") {
-      writeEvent("turn_end", {});
-    }
-  });
-
   try {
     const cwd = ((c) => c ? resolveAgentWorkspacePath(c) : undefined)(deps.agentRuntime?.getAgent(agentId)?.config);
 
@@ -329,6 +366,20 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
       ...(cwd ? { cwd } : {}),
       log,
       ...(deps.hooks ? { hooks: deps.hooks } : {}),
+      onEvent: (e) => {
+        if (e.type === "message_update") {
+          const ame = e.assistantMessageEvent;
+          if (ame.type === "text_delta") {
+            writeEvent("text_delta", { text: ame.delta });
+          }
+        } else if (e.type === "tool_execution_start") {
+          writeEvent("tool_call", { toolCallId: e.toolCallId, toolName: e.toolName, args: e.args });
+        } else if (e.type === "tool_execution_end") {
+          writeEvent("tool_result", { toolCallId: e.toolCallId, toolName: e.toolName, result: e.result, isError: e.isError });
+        } else if (e.type === "turn_end") {
+          writeEvent("turn_end", {});
+        }
+      },
       onTurnEnd: async () => {
         const pending = active.pendingMessages;
         if (pending.length === 0) return null;
@@ -348,8 +399,6 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
   } catch (err) {
     writeEvent("error", { message: err instanceof Error ? err.message : String(err) });
   } finally {
-    unsub();
-    deps.agentRuntime.endSession(sessionId);
     res.end();
   }
 });

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -221,7 +221,7 @@ addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => 
   // response until the first event, which can be 25s on a quiet session.
   res.write(": connected\n\n");
 
-  const unsub = store.attach(resolved.sessionId, (update) => {
+  const unsubscribe = store.subscribe(resolved.sessionId, (update) => {
     res.write(`event: message\ndata: ${JSON.stringify({
       message: update.message,
       messageId: update.messageId,
@@ -234,7 +234,7 @@ addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => 
 
   const cleanup = () => {
     clearInterval(heartbeat);
-    unsub();
+    unsubscribe();
   };
   res.on("close", cleanup);
   req.on("aborted", cleanup);

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -63,8 +63,15 @@ async function resolveSessionKey(
   agentId: string,
   urlKey: string,
 ): Promise<{ sessionKey: string; sessionId: string; session: Session } | undefined> {
-  const sessionKey = `${agentId}:${urlKey}`;
-  const session = await store.findByKey(sessionKey);
+  // Direct lookup first — transports (e.g. Discord) store keys without an
+  // agentId prefix, so the URL-supplied key may already be the stored form.
+  let session = await store.findByKey(urlKey);
+  let sessionKey = urlKey;
+  if (!session) {
+    // HTTP-API-created sessions are stored under `${agentId}:${userKey}`.
+    sessionKey = `${agentId}:${urlKey}`;
+    session = await store.findByKey(sessionKey);
+  }
   if (!session) return undefined;
   return { sessionKey, sessionId: session.id, session };
 }

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -212,6 +212,15 @@ addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => 
     return;
   }
 
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+  });
+  // Initial flush — without this, buffering proxies (nginx default) hold the
+  // response until the first event, which can be 25s on a quiet session.
+  res.write(": connected\n\n");
+
   const unsub = store.attach(resolved.sessionId, (update) => {
     res.write(`event: message\ndata: ${JSON.stringify({
       message: update.message,
@@ -219,12 +228,6 @@ addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => 
     })}\n\n`);
   });
 
-  res.writeHead(200, {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    "Connection": "keep-alive",
-  });
-  // Heartbeat keeps proxies from idling out.
   const heartbeat = setInterval(() => {
     res.write(": ping\n\n");
   }, 25_000);

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -194,7 +194,6 @@ addRoute("GET", "/api/sessions/:agentId/:key/messages", async (req, res, deps) =
 
 // ---------------------------------------------------------------------------
 // GET /api/sessions/:agentId/:key/stream — observer SSE for transcript appends
-// Single subscriber per sessionId; second connection rejected with 409.
 // ---------------------------------------------------------------------------
 
 addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => {
@@ -231,7 +230,7 @@ addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => 
     "Cache-Control": "no-cache",
     "Connection": "keep-alive",
   });
-  // Heartbeat every 25s to keep proxies from idling out.
+  // Heartbeat keeps proxies from idling out.
   const heartbeat = setInterval(() => {
     res.write(": ping\n\n");
   }, 25_000);

--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -107,6 +107,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
   const [error, setError] = useState<string | null>(null);
   const sessionKeyRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const attachAbortRef = useRef<AbortController | null>(null);
   const pendingSteerRef = useRef<ChatMessage[]>([]);
   const settledRef = useRef<ChatMessage[]>([]);
   const autoMessageSent = useRef(false);
@@ -131,6 +132,34 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         }
       }
 
+      // Attach mode: --session <key> skips create, loads full history, subscribes to /stream.
+      if (options.session) {
+        sessionKeyRef.current = options.session;
+        setAgentId(resolvedAgentId);
+        const { items: history } = await api.getHistory(resolvedAgentId, options.session);
+        const chatMessages = historyToChatMessages(history);
+        setMessages(chatMessages);
+        // Open attach stream — single subscriber per session, /stream rejects 2nd.
+        const attachAbort = new AbortController();
+        attachAbortRef.current = attachAbort;
+        void (async () => {
+          try {
+            await api.attachStream(resolvedAgentId, options.session!, (m) => {
+              const converted = historyToChatMessages([m.message as { role: string; content: unknown; toolCallId?: string }]);
+              if (converted.length > 0) {
+                setMessages((prev) => [...prev, ...converted]);
+              }
+            }, attachAbort.signal);
+          } catch (err) {
+            if (!attachAbort.signal.aborted) {
+              setError(`Attach failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+          }
+        })();
+        setAgentReady(true);
+        return;
+      }
+
       const session = await api.createSession(resolvedAgentId, "tui:main");
       sessionKeyRef.current = session.key;
       setAgentId(session.agentId);
@@ -151,12 +180,13 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
-  }, []);
+  }, [options.session]);
 
   useEffect(() => {
     void initAgent(options.agent);
     return () => {
       abortRef.current?.abort();
+      attachAbortRef.current?.abort();
     };
   }, []);
 

--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -311,6 +311,10 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     if (slash) {
       const handled = dispatch(slash.command, slash.args, {
         onNewChat: () => {
+          if (options.session) {
+            setMessages((prev) => [...prev, { role: "system", content: "/new is disabled in --session attach mode (would delete the attached session). Exit and relaunch without --session.", timestamp: new Date() }]);
+            return;
+          }
           setMessages([]);
           settledRef.current = [];
           setIsStreaming(true);

--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -132,14 +132,12 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         }
       }
 
-      // Attach mode: --session <key> skips create, loads full history, subscribes to /stream.
       if (options.session) {
         sessionKeyRef.current = options.session;
         setAgentId(resolvedAgentId);
         const { items: history } = await api.getHistory(resolvedAgentId, options.session);
         const chatMessages = historyToChatMessages(history);
         setMessages(chatMessages);
-        // Open attach stream — single subscriber per session, /stream rejects 2nd.
         const attachAbort = new AbortController();
         attachAbortRef.current = attachAbort;
         void (async () => {

--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -197,6 +197,28 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
 
   const sendMessage = async (text: string) => {
     if (!sessionKeyRef.current || isStreaming) return;
+
+    // Attach mode: attachStream is the single source of truth for UI updates.
+    // Skip local user echo and inline streaming preview — the persisted
+    // user message + assistant response will arrive via the bus.
+    if (options.session) {
+      setIsStreaming(true);
+      const abort = new AbortController();
+      abortRef.current = abort;
+      try {
+        await api.sendMessage(agentId, sessionKeyRef.current, text, () => {}, abort.signal);
+      } catch (err) {
+        if (!abort.signal.aborted) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setMessages((prev) => [...prev, { role: "system", content: `Error: ${msg}`, timestamp: new Date() }]);
+        }
+      } finally {
+        abortRef.current = null;
+        setIsStreaming(false);
+      }
+      return;
+    }
+
     const userMsg: ChatMessage = { role: "user", content: text, timestamp: new Date() };
     setMessages((prev) => [...prev, userMsg]);
     setIsStreaming(true);

--- a/src/legacy/tui/api.ts
+++ b/src/legacy/tui/api.ts
@@ -177,7 +177,6 @@ export async function attachStream(
   signal: AbortSignal,
 ): Promise<void> {
   const res = await fetch(`${getBaseUrl()}${sessionPath(agentId, sessionKey)}/stream`, { signal });
-  if (res.status === 409) throw new Error("Session already attached by another viewer");
   if (!res.ok) throw new Error(`API stream: ${res.status} ${res.statusText}`);
 
   const reader = res.body?.getReader();

--- a/src/legacy/tui/api.ts
+++ b/src/legacy/tui/api.ts
@@ -162,3 +162,55 @@ export async function sendMessage(
     }
   }
 }
+
+// -- Observer-mode SSE: attach to /stream for transcript-bus updates --
+
+export interface AttachedMessage {
+  message: { role: string; content: unknown; toolCallId?: string };
+  messageId: string;
+}
+
+export async function attachStream(
+  agentId: string,
+  sessionKey: string,
+  onMessage: (m: AttachedMessage) => void,
+  signal: AbortSignal,
+): Promise<void> {
+  const res = await fetch(`${getBaseUrl()}${sessionPath(agentId, sessionKey)}/stream`, { signal });
+  if (res.status === 409) throw new Error("Session already attached by another viewer");
+  if (!res.ok) throw new Error(`API stream: ${res.status} ${res.statusText}`);
+
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error("No response body");
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let currentEvent = "";
+  let dataLines: string[] = [];
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.startsWith(":")) continue; // heartbeat comment
+      if (line.startsWith("event: ")) {
+        currentEvent = line.slice(7).trim();
+        dataLines = [];
+      } else if (line.startsWith("data: ")) {
+        dataLines.push(line.slice(6));
+      } else if (line === "") {
+        if (currentEvent === "message" && dataLines.length > 0) {
+          try {
+            const parsed = JSON.parse(dataLines.join("\n")) as AttachedMessage;
+            onMessage(parsed);
+          } catch { /* malformed, skip */ }
+        }
+        currentEvent = "";
+        dataLines = [];
+      }
+    }
+  }
+}

--- a/src/legacy/tui/api.ts
+++ b/src/legacy/tui/api.ts
@@ -170,6 +170,8 @@ export interface AttachedMessage {
   messageId: string;
 }
 
+/** Long-lived SSE reader. Server keeps the stream open with heartbeats and
+ * never sends an end marker — terminates only when `signal` is aborted. */
 export async function attachStream(
   agentId: string,
   sessionKey: string,

--- a/src/legacy/tui/api.ts
+++ b/src/legacy/tui/api.ts
@@ -191,7 +191,7 @@ export async function attachStream(
     const { done, value } = await reader.read();
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
+    const lines = buffer.split(/\r?\n/);
     buffer = lines.pop() ?? "";
     for (const line of lines) {
       if (line.startsWith(":")) continue; // heartbeat comment
@@ -205,7 +205,10 @@ export async function attachStream(
           try {
             const parsed = JSON.parse(dataLines.join("\n")) as AttachedMessage;
             onMessage(parsed);
-          } catch { /* malformed, skip */ }
+          } catch (err) {
+             
+            console.error("attachStream: malformed JSON", err);
+          }
         }
         currentEvent = "";
         dataLines = [];

--- a/src/legacy/tui/index.tsx
+++ b/src/legacy/tui/index.tsx
@@ -7,11 +7,13 @@ export async function launchTui(values: {
   agent?: string;
   config?: string;
   message?: string;
+  session?: string;
 }): Promise<void> {
   const options: TuiOptions = {
     agent: values.agent,
     config: values.config,
     message: values.message,
+    session: values.session,
   };
 
   const { waitUntilExit } = render(<App options={options} />);

--- a/src/legacy/tui/types.ts
+++ b/src/legacy/tui/types.ts
@@ -61,4 +61,6 @@ export interface TuiOptions {
   agent?: string;
   config?: string;
   message?: string;
+  /** Attach to an existing session by key instead of creating tui:main. */
+  session?: string;
 }

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -2,6 +2,15 @@
 
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
+/** Per-message append notification for transcript-bus subscribers. */
+export interface TranscriptUpdate {
+  sessionId: string;
+  message: AgentMessage;
+  messageId: string;
+}
+
+export type TranscriptListener = (update: TranscriptUpdate) => void;
+
 /** A conversation session binding an agent to a transport channel. */
 export interface Session {
   id: string;
@@ -35,4 +44,7 @@ export interface SessionStore {
   clearMessages(sessionId: string): Promise<void>;
   /** Get the underlying SDK SessionManager for a session (for AgentSession creation). */
   getSessionManager(sessionId: string): Promise<import("@mariozechner/pi-coding-agent").SessionManager | undefined>;
+  /** Subscribe to transcript appends for a sessionId. At most one listener per session;
+   * throws if already attached. Returns an unsubscribe function. */
+  attach(sessionId: string, listener: TranscriptListener): () => void;
 }

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -44,7 +44,7 @@ export interface SessionStore {
   clearMessages(sessionId: string): Promise<void>;
   /** Get the underlying SDK SessionManager for a session (for AgentSession creation). */
   getSessionManager(sessionId: string): Promise<import("@mariozechner/pi-coding-agent").SessionManager | undefined>;
-  /** Subscribe to transcript appends for a sessionId. At most one listener per session;
-   * throws if already attached. Returns an unsubscribe function. */
+  /** Subscribe to transcript appends for a sessionId. Multiple listeners allowed.
+   * Returns an unsubscribe function. */
   attach(sessionId: string, listener: TranscriptListener): () => void;
 }

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -46,5 +46,5 @@ export interface SessionStore {
   getSessionManager(sessionId: string): Promise<import("@mariozechner/pi-coding-agent").SessionManager | undefined>;
   /** Subscribe to transcript appends for a sessionId. Multiple listeners allowed.
    * Returns an unsubscribe function. */
-  attach(sessionId: string, listener: TranscriptListener): () => void;
+  subscribe(sessionId: string, listener: TranscriptListener): () => void;
 }

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -59,6 +59,6 @@ export function createMockSessionStore(sessionId = "session-123"): SessionStore 
       loadMessages: vi.fn().mockReturnValue([]),
       appendMessage: vi.fn(),
     }),
-    attach: vi.fn().mockReturnValue(() => {}),
+    subscribe: vi.fn().mockReturnValue(() => {}),
   };
 }

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -59,5 +59,6 @@ export function createMockSessionStore(sessionId = "session-123"): SessionStore 
       loadMessages: vi.fn().mockReturnValue([]),
       appendMessage: vi.fn(),
     }),
+    attach: vi.fn().mockReturnValue(() => {}),
   };
 }


### PR DESCRIPTION
## Summary

- Removes `AgentRuntime`'s per-session `SessionEventBus` and the auto fan-out inside `runtime.run`, eliminating the double-delivery foot-gun described in #684.
- Introduces a `SessionStore`-level transcript bus (`subscribe(sessionId, listener)`) emitting per-message updates after persistence. Mirrors openclaw's monkey-patch on `SessionManager.appendMessage`: one hook covers all writes (transport user input + SDK assistant/tool messages). Multiple listeners per session are supported.
- Adds `--session <key>` to TUI: loads history snapshot + subscribes to the new `GET /api/sessions/:agent/:key/stream` SSE endpoint. A TUI viewer can now follow a session driven from a different transport (e.g. Discord) at message granularity.

Closes #684. Compaction edge case (TUI snapshot drift after SDK compaction) deferred and tracked in #691. In-TUI `/sessions` and `/attach` slash commands tracked in #698.

## Architecture

Layers are now clean and aligned with openclaw:

- **Driver path** (Discord, HTTP send): `runAgent` accepts `onEvent?: (e: AgentEvent) => void` for raw token-level events. Drivers render their own UI off this callback.
- **Observer path** (TUI subscribe, future WebUI): `store.subscribe(sessionId, listener)` receives completed messages from the transcript bus. Multiple subscribers per session — TUI + WebUI + admin panel can all follow the same session concurrently.

No more "yield AND emit the same `AgentEvent`" — driver events and observer events have different shapes, different timing, different consumers. Foot-gun gone structurally.

## Test plan

- [x] `pnpm ci` — lint + typecheck + 925 tests pass (+7 new transcript-bus tests covering subscribe/multi-subscribe/unsubscribe/listener isolation/error swallow/SDK-side write capture)
- [ ] Manual: run daemon + Discord transport, send messages from Discord, attach TUI via `isotopes tui --session <discord-session-key>`, verify message + tool-call updates appear live
- [ ] Manual: confirm two TUIs (or TUI + curl) on the same `/stream` both receive events
- [ ] Manual: confirm TUI's own send through `--session` enters the session and persists (Discord side won't render but next history scroll on Discord shows it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)