### PR TITLE
refactor(http/sessions): unify session key format with transports

### DIFF
--- a/src/gateway/session-keys.test.ts
+++ b/src/gateway/session-keys.test.ts
@@ -5,44 +5,46 @@ import { buildSessionKey } from "./session-keys.js";
 
 describe("buildSessionKey", () => {
   it("builds a colon-delimited key", () => {
-    expect(buildSessionKey("discord", "bot-1", "channel", "ch-1", "agent-1")).toBe(
-      "discord:bot-1:channel:ch-1:agent-1",
+    expect(buildSessionKey("discord", "bot-1", "channel", "ch-1")).toBe(
+      "discord:bot-1:channel:ch-1",
     );
   });
 
   it("supports dm scope", () => {
-    expect(buildSessionKey("discord", "bot-1", "dm", "user-1", "agent-1")).toBe(
-      "discord:bot-1:dm:user-1:agent-1",
+    expect(buildSessionKey("discord", "bot-1", "dm", "user-1")).toBe(
+      "discord:bot-1:dm:user-1",
     );
   });
 
   it("supports thread scope", () => {
-    expect(buildSessionKey("discord", "bot-1", "thread", "thread-1", "agent-1")).toBe(
-      "discord:bot-1:thread:thread-1:agent-1",
+    expect(buildSessionKey("discord", "bot-1", "thread", "thread-1")).toBe(
+      "discord:bot-1:thread:thread-1",
     );
   });
 
   it("supports group scope", () => {
-    expect(buildSessionKey("feishu", "app-1", "group", "group-1", "agent-1")).toBe(
-      "feishu:app-1:group:group-1:agent-1",
+    expect(buildSessionKey("feishu", "app-1", "group", "group-1")).toBe(
+      "feishu:app-1:group:group-1",
     );
   });
 
   it("produces unique keys for different transports", () => {
-    const k1 = buildSessionKey("discord", "id", "dm", "u1", "a1");
-    const k2 = buildSessionKey("feishu", "id", "dm", "u1", "a1");
+    const k1 = buildSessionKey("discord", "id", "dm", "u1");
+    const k2 = buildSessionKey("feishu", "id", "dm", "u1");
     expect(k1).not.toBe(k2);
   });
 
   it("produces unique keys for different scopes", () => {
-    const k1 = buildSessionKey("discord", "b1", "channel", "x", "a1");
-    const k2 = buildSessionKey("discord", "b1", "dm", "x", "a1");
+    const k1 = buildSessionKey("discord", "b1", "channel", "x");
+    const k2 = buildSessionKey("discord", "b1", "dm", "x");
     expect(k1).not.toBe(k2);
   });
 
-  it("produces unique keys for different agents", () => {
-    const k1 = buildSessionKey("discord", "b1", "channel", "ch1", "a1");
-    const k2 = buildSessionKey("discord", "b1", "channel", "ch1", "a2");
-    expect(k1).not.toBe(k2);
+  it("produces same key for different agents — agentId is not part of the key", () => {
+    // (agentId, sessionKey) pair is the unique identifier; agentId namespacing
+    // happens at the per-agent SessionStore layer, not in the key string.
+    const k1 = buildSessionKey("discord", "b1", "channel", "ch1");
+    const k2 = buildSessionKey("discord", "b1", "channel", "ch1");
+    expect(k1).toBe(k2);
   });
 });

--- a/src/gateway/session-keys.test.ts
+++ b/src/gateway/session-keys.test.ts
@@ -41,8 +41,6 @@ describe("buildSessionKey", () => {
   });
 
   it("produces same key for different agents — agentId is not part of the key", () => {
-    // (agentId, sessionKey) pair is the unique identifier; agentId namespacing
-    // happens at the per-agent SessionStore layer, not in the key string.
     const k1 = buildSessionKey("discord", "b1", "channel", "ch1");
     const k2 = buildSessionKey("discord", "b1", "channel", "ch1");
     expect(k1).toBe(k2);

--- a/src/gateway/session-keys.ts
+++ b/src/gateway/session-keys.ts
@@ -1,27 +1,27 @@
 // src/gateway/session-keys.ts — Shared session key builder
 // Standardises the session key format across all transports.
 //
-// Format: {transport}:{botId}:{scope}:{scopeId}:{agentId}
+// Format: {transport}:{botId}:{scope}:{scopeId}
 //
 // Examples:
-//   discord:bot-123:channel:456:default
-//   discord:bot-123:thread:789:default
-//   discord:bot-123:dm:user-1:default
+//   discord:bot-123:channel:456
+//   discord:bot-123:thread:789
+//   discord:bot-123:dm:user-1
+//
+// Keys describe WHERE the conversation lives — they do NOT encode WHICH
+// agent owns it. Agent ownership is the (agentId, sessionKey) pair, with
+// agentId routed by binding.
+//
+// Constraint: keys appear in URL path segments. Avoid '/', '?', '#'.
 
 export type SessionScope = "channel" | "thread" | "dm" | "group";
 
-/**
- * Build a deterministic, colon-delimited session key.
- *
- * Every transport uses the same format so that session keys are
- * consistent, collision-free, and easy to parse.
- */
+/** Build a deterministic, colon-delimited session key. */
 export function buildSessionKey(
   transport: string,
   botId: string,
   scope: SessionScope,
   scopeId: string,
-  agentId: string,
 ): string {
-  return `${transport}:${botId}:${scope}:${scopeId}:${agentId}`;
+  return `${transport}:${botId}:${scope}:${scopeId}`;
 }

--- a/src/gateway/session-keys.ts
+++ b/src/gateway/session-keys.ts
@@ -1,22 +1,8 @@
 // src/gateway/session-keys.ts — Shared session key builder
-// Standardises the session key format across all transports.
-//
 // Format: {transport}:{botId}:{scope}:{scopeId}
-//
-// Examples:
-//   discord:bot-123:channel:456
-//   discord:bot-123:thread:789
-//   discord:bot-123:dm:user-1
-//
-// Keys describe WHERE the conversation lives — they do NOT encode WHICH
-// agent owns it. Agent ownership is the (agentId, sessionKey) pair, with
-// agentId routed by binding.
-//
-// Constraint: keys appear in URL path segments. Avoid '/', '?', '#'.
 
 export type SessionScope = "channel" | "thread" | "dm" | "group";
 
-/** Build a deterministic, colon-delimited session key. */
 export function buildSessionKey(
   transport: string,
   botId: string,

--- a/src/legacy/plugins/discord/discord.test.ts
+++ b/src/legacy/plugins/discord/discord.test.ts
@@ -191,7 +191,7 @@ describe("DiscordTransport", () => {
         }
       ).handleMessage(msg);
 
-      expect(sessionStore.findByKey).toHaveBeenCalledWith("discord:bot-123:channel:channel-1:default");
+      expect(sessionStore.findByKey).toHaveBeenCalledWith("discord:bot-123:channel:channel-1");
       expect(sessionStore.addMessage).toHaveBeenNthCalledWith(
         1,
         "session-123",

--- a/src/legacy/plugins/discord/discord.ts
+++ b/src/legacy/plugins/discord/discord.ts
@@ -402,7 +402,7 @@ export class DiscordTransport implements Transport {
       }
       const agentId = this.resolveAgentId(msg);
       const sessionStore = this.getSessionStore(agentId);
-      const sessionKey = this.getSessionKey(msg, agentId);
+      const sessionKey = this.getSessionKey(msg);
       const session = await sessionStore.findByKey(sessionKey);
       const runtimeForCheck = this.config.agentRuntime;
       const isActive = runtimeForCheck && session
@@ -464,7 +464,7 @@ export class DiscordTransport implements Transport {
     if (this.commandHandler.isCommand(content)) {
       const agentId = this.resolveAgentId(msg);
       const sessionStore = this.getSessionStore(agentId);
-      const sessionKey = this.getSessionKey(msg, agentId);
+      const sessionKey = this.getSessionKey(msg);
       const session = await sessionStore.findByKey(sessionKey);
 
       if (!this.config.agentRuntime) {
@@ -505,7 +505,7 @@ export class DiscordTransport implements Transport {
     }
 
     const sessionStore = this.getSessionStore(agentId);
-    const sessionKey = this.getSessionKey(msg, agentId);
+    const sessionKey = this.getSessionKey(msg);
     const session = await this.findOrCreateSession(sessionStore, sessionKey, agentId, msg);
 
     // 6.5. If session is currently active (in a prompt turn), buffer this message instead.
@@ -660,16 +660,16 @@ export class DiscordTransport implements Transport {
     return this.config.sessionStoreForAgent?.(agentId) ?? this.config.sessionStore;
   }
 
-  private getSessionKey(msg: DiscordMessage, agentId: string): string {
+  private getSessionKey(msg: DiscordMessage): string {
     const botId = this.client.user?.id ?? "unknown";
 
     if (msg.thread) {
-      return buildSessionKey("discord", botId, "thread", msg.thread.id, agentId);
+      return buildSessionKey("discord", botId, "thread", msg.thread.id);
     }
     if (!msg.guild) {
-      return buildSessionKey("discord", botId, "dm", msg.author.id, agentId);
+      return buildSessionKey("discord", botId, "dm", msg.author.id);
     }
-    return buildSessionKey("discord", botId, "channel", msg.channelId, agentId);
+    return buildSessionKey("discord", botId, "channel", msg.channelId);
   }
 
   private async findOrCreateSession(

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -38,6 +38,10 @@ const MAX_SESSIONS = 100;
 const MAX_PENDING_MESSAGES = 50;
 const MAX_STEER_MESSAGE_LEN = 10_000;
 
+/** Index activeSessions by (agentId, sessionKey) — sessionKey alone is per-agent
+ * unique only, two agents can legally hold the same key. */
+const activeKey = (agentId: string, sessionKey: string) => `${agentId}\x00${sessionKey}`;
+
 function evictStaleSessions() {
   const now = Date.now();
   for (const [key, session] of activeSessions) {
@@ -287,7 +291,7 @@ addRoute("POST", "/api/sessions/:agentId", async (req, res, deps) => {
   }
 
   evictStaleSessions();
-  activeSessions.set(sessionKey, { sessionKey, sessionId, agentId, lastActivity: Date.now(), pendingMessages: [] });
+  activeSessions.set(activeKey(agentId, sessionKey), { sessionKey, sessionId, agentId, lastActivity: Date.now(), pendingMessages: [] });
 
   log.info(`Session ${resumed ? "resumed" : "created"}: ${sessionKey} (agent: ${agentId})`);
   sendJson(res, resumed ? 200 : 201, { key: sessionKey, agentId, resumed });
@@ -300,7 +304,7 @@ addRoute("POST", "/api/sessions/:agentId", async (req, res, deps) => {
 addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) => {
   const { agentId, key: sessionKey } = req.params;
 
-  let active = activeSessions.get(sessionKey);
+  let active = activeSessions.get(activeKey(agentId, sessionKey));
   if (!active) {
     // Session may exist in the store but was never registered via the HTTP create
     // path (e.g. transport-driven sessions like Discord). Look it up and register
@@ -317,7 +321,7 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
             lastActivity: Date.now(),
             pendingMessages: [],
           };
-          activeSessions.set(resolved.sessionKey, active);
+          activeSessions.set(activeKey(agentId, resolved.sessionKey), active);
         }
       }
     }
@@ -420,8 +424,8 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
 // ---------------------------------------------------------------------------
 
 addRoute("POST", "/api/sessions/:agentId/:key/steer", async (req, res, _deps) => {
-  const sessionKey = req.params.key;
-  const active = activeSessions.get(sessionKey);
+  const { agentId, key: sessionKey } = req.params;
+  const active = activeSessions.get(activeKey(agentId, sessionKey));
   if (!active) {
     sendError(res, 404, `Active session not found`);
     return;
@@ -452,8 +456,8 @@ addRoute("POST", "/api/sessions/:agentId/:key/steer", async (req, res, _deps) =>
 // ---------------------------------------------------------------------------
 
 addRoute("POST", "/api/sessions/:agentId/:key/abort", (req, res, deps) => {
-  const sessionKey = req.params.key;
-  const session = activeSessions.get(sessionKey);
+  const { agentId, key: sessionKey } = req.params;
+  const session = activeSessions.get(activeKey(agentId, sessionKey));
   if (!session) {
     sendError(res, 404, `Active session not found`);
     return;
@@ -473,10 +477,10 @@ addRoute("POST", "/api/sessions/:agentId/:key/abort", (req, res, deps) => {
 addRoute("DELETE", "/api/sessions/:agentId/:key", async (req, res, deps) => {
   const { agentId, key: sessionKey } = req.params;
 
-  const active = activeSessions.get(sessionKey);
+  const active = activeSessions.get(activeKey(agentId, sessionKey));
   if (active) {
     active.abortController?.abort();
-    activeSessions.delete(sessionKey);
+    activeSessions.delete(activeKey(agentId, sessionKey));
   }
 
   if (deps.sessionStoreManager) {

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -60,18 +60,9 @@ function evictStaleSessions() {
 
 async function resolveSessionKey(
   store: DefaultSessionStore,
-  agentId: string,
-  urlKey: string,
+  sessionKey: string,
 ): Promise<{ sessionKey: string; sessionId: string; session: Session } | undefined> {
-  // Direct lookup first — transports (e.g. Discord) store keys without an
-  // agentId prefix, so the URL-supplied key may already be the stored form.
-  let session = await store.findByKey(urlKey);
-  let sessionKey = urlKey;
-  if (!session) {
-    // HTTP-API-created sessions are stored under `${agentId}:${userKey}`.
-    sessionKey = `${agentId}:${urlKey}`;
-    session = await store.findByKey(sessionKey);
-  }
+  const session = await store.findByKey(sessionKey);
   if (!session) return undefined;
   return { sessionKey, sessionId: session.id, session };
 }
@@ -157,7 +148,7 @@ addRoute("GET", "/api/sessions/:agentId/:key", async (req, res, deps) => {
     return;
   }
 
-  const resolved = await resolveSessionKey(store, req.params.agentId, req.params.key);
+  const resolved = await resolveSessionKey(store, req.params.key);
   if (!resolved) {
     sendError(res, 404, `Session not found`);
     return;
@@ -189,7 +180,7 @@ addRoute("GET", "/api/sessions/:agentId/:key/messages", async (req, res, deps) =
     return;
   }
 
-  const resolved = await resolveSessionKey(store, req.params.agentId, req.params.key);
+  const resolved = await resolveSessionKey(store, req.params.key);
   if (!resolved) {
     sendError(res, 404, `Session not found`);
     return;
@@ -213,7 +204,7 @@ addRoute("GET", "/api/sessions/:agentId/:key/stream", async (req, res, deps) => 
     sendError(res, 404, "Session not found");
     return;
   }
-  const resolved = await resolveSessionKey(store, req.params.agentId, req.params.key);
+  const resolved = await resolveSessionKey(store, req.params.key);
   if (!resolved) {
     sendError(res, 404, "Session not found");
     return;
@@ -268,18 +259,16 @@ addRoute("POST", "/api/sessions/:agentId", async (req, res, deps) => {
 
   const SESSION_KEY_MAX_LEN = 128;
 
-  let urlKey: string;
+  let sessionKey: string;
   if (body?.sessionKey) {
     if (body.sessionKey.length > SESSION_KEY_MAX_LEN) {
       sendError(res, 400, `sessionKey exceeds max length of ${SESSION_KEY_MAX_LEN}`);
       return;
     }
-    urlKey = body.sessionKey;
+    sessionKey = body.sessionKey;
   } else {
-    urlKey = randomUUID();
+    sessionKey = randomUUID();
   }
-
-  const sessionKey = `${agentId}:${urlKey}`;
 
   let sessionId: string;
   let resumed = false;
@@ -301,7 +290,7 @@ addRoute("POST", "/api/sessions/:agentId", async (req, res, deps) => {
   activeSessions.set(sessionKey, { sessionKey, sessionId, agentId, lastActivity: Date.now(), pendingMessages: [] });
 
   log.info(`Session ${resumed ? "resumed" : "created"}: ${sessionKey} (agent: ${agentId})`);
-  sendJson(res, resumed ? 200 : 201, { key: urlKey, agentId, resumed });
+  sendJson(res, resumed ? 200 : 201, { key: sessionKey, agentId, resumed });
 });
 
 // ---------------------------------------------------------------------------
@@ -309,8 +298,7 @@ addRoute("POST", "/api/sessions/:agentId", async (req, res, deps) => {
 // ---------------------------------------------------------------------------
 
 addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) => {
-  const { agentId, key: urlKey } = req.params;
-  const sessionKey = `${agentId}:${urlKey}`;
+  const { agentId, key: sessionKey } = req.params;
 
   let active = activeSessions.get(sessionKey);
   if (!active) {
@@ -320,7 +308,7 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
     if (deps.sessionStoreManager) {
       const store = deps.sessionStoreManager.peek(agentId);
       if (store) {
-        const resolved = await resolveSessionKey(store, agentId, urlKey);
+        const resolved = await resolveSessionKey(store, sessionKey);
         if (resolved) {
           active = {
             sessionKey: resolved.sessionKey,
@@ -432,7 +420,7 @@ addRoute("POST", "/api/sessions/:agentId/:key/message", async (req, res, deps) =
 // ---------------------------------------------------------------------------
 
 addRoute("POST", "/api/sessions/:agentId/:key/steer", async (req, res, _deps) => {
-  const sessionKey = `${req.params.agentId}:${req.params.key}`;
+  const sessionKey = req.params.key;
   const active = activeSessions.get(sessionKey);
   if (!active) {
     sendError(res, 404, `Active session not found`);
@@ -464,7 +452,7 @@ addRoute("POST", "/api/sessions/:agentId/:key/steer", async (req, res, _deps) =>
 // ---------------------------------------------------------------------------
 
 addRoute("POST", "/api/sessions/:agentId/:key/abort", (req, res, deps) => {
-  const sessionKey = `${req.params.agentId}:${req.params.key}`;
+  const sessionKey = req.params.key;
   const session = activeSessions.get(sessionKey);
   if (!session) {
     sendError(res, 404, `Active session not found`);
@@ -483,8 +471,7 @@ addRoute("POST", "/api/sessions/:agentId/:key/abort", (req, res, deps) => {
 // ---------------------------------------------------------------------------
 
 addRoute("DELETE", "/api/sessions/:agentId/:key", async (req, res, deps) => {
-  const { agentId, key: urlKey } = req.params;
-  const sessionKey = `${agentId}:${urlKey}`;
+  const { agentId, key: sessionKey } = req.params;
 
   const active = activeSessions.get(sessionKey);
   if (active) {
@@ -495,7 +482,7 @@ addRoute("DELETE", "/api/sessions/:agentId/:key", async (req, res, deps) => {
   if (deps.sessionStoreManager) {
     const store = deps.sessionStoreManager.peek(agentId);
     if (store) {
-      const resolved = await resolveSessionKey(store, agentId, urlKey);
+      const resolved = await resolveSessionKey(store, sessionKey);
       if (resolved) {
         await store.delete(resolved.sessionId);
         sendJson(res, 200, { ok: true });

--- a/src/legacy/plugins/http/sessions.ts
+++ b/src/legacy/plugins/http/sessions.ts
@@ -38,8 +38,7 @@ const MAX_SESSIONS = 100;
 const MAX_PENDING_MESSAGES = 50;
 const MAX_STEER_MESSAGE_LEN = 10_000;
 
-/** Index activeSessions by (agentId, sessionKey) — sessionKey alone is per-agent
- * unique only, two agents can legally hold the same key. */
+/** sessionKey alone is per-agent unique; two agents can legally hold the same key. */
 const activeKey = (agentId: string, sessionKey: string) => `${agentId}\x00${sessionKey}`;
 
 function evictStaleSessions() {


### PR DESCRIPTION
## Summary

Drops the implicit \`\${agentId}:\` prefix that the HTTP API was prepending to every session key, AND drops the redundant \`agentId\` segment from \`buildSessionKey\` (Discord transport keys). Both changes converge on a single uniform shape:

- HTTP API: stores body.sessionKey verbatim (e.g. \`tui:main\`)
- Transports: \`{transport}:{botId}:{scope}:{scopeId}\` (e.g. \`discord:bot:channel:cid\`)

\`resolveSessionKey\` collapses to a single \`store.findByKey(key)\` call — no more dual-format fallback.

\`activeSessions\` Map is now keyed by composite \`activeKey(agentId, sessionKey)\` because sessionKey alone is only per-agent unique. Without this, two agents with overlapping HTTP-API sessionKeys would clobber each other in the global Map.

Closes #701.

## Breaking changes

Two categories of on-disk sessions in \`~/.isotopes/agents/<id>/sessions/\` become orphaned (transcript files unchanged, but API can no longer find them):

1. **HTTP-API-created sessions** previously stored as \`\${agentId}:\${userKey}\` (e.g. \`main:tui:main\`).
2. **Discord transport sessions** previously stored as \`discord:bot:scope:id:agentId\` (with trailing agentId). New format drops the trailing segment.

No migration provided — pre-1.0 internal change and no production users.

## Diff stats

\`\`\`
src/gateway/session-keys.ts                |  6 +++--
src/gateway/session-keys.test.ts           | 28 +++++++++++-----------
src/legacy/plugins/discord/discord.ts      | 14 ++++++------
src/legacy/plugins/discord/discord.test.ts |  2 +-
src/legacy/plugins/http/sessions.ts        | 39 ++++++++++++++----------------
\`\`\`

Net -19 LOC across 5 files. Clearer call sites, no fallback path.

## Test plan

- [x] \`pnpm ci\` — lint + typecheck + 919 tests pass (session-keys.test.ts updated for new signature; discord.test.ts:194 updated for new key format)
- [x] Manual: TUI default mode (no --session) creates a fresh \`tui:main\` session that works end-to-end
- [x] Manual: TUI \`--session discord:bot:dm:user\` (new format, no trailing agentId) attaches and streams from a Discord-driven session
- [x] Manual: send + abort + steer round-trip works on HTTP-API-created sessions
- [ ] Manual (out of scope): two agents create same body.sessionKey via HTTP — confirm activeSessions doesn't clobber. Single-agent dev environment can't directly reproduce; relies on structural \`activeKey()\` helper.

## Related

- #693 — surfaced the inconsistency by exposing Discord keys via TUI attach mode; introduced the dual-format band-aid being removed here.
- #702 — \`/steer\` and \`/abort\` for transport sessions, separate concern not affected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)