### PR TITLE
fix(sandbox): #706 follow-ups + per-agent mounts

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -32,9 +32,7 @@ Sandbox config can live in three places (in order of precedence — later wins):
 3. **Per-agent `agents.list[].sandbox:`** — partial override for one agent
    (typically just `enabled: false` to opt out, or `enabled: true` to opt in).
 
-Per-agent overrides may set `enabled`, `workspaceAccess`, and `mounts` (per-agent mounts are appended to base mounts). The
-`docker:` block must live at the top-level / agents-defaults layer because
-the runtime maintains a single `ContainerManager` per process.
+Per-agent overrides may set `enabled`, `workspaceAccess`, `mounts` (per-agent mounts are appended to base mounts), and `docker` (per-field merge — agent fields override base fields).
 
 ```yaml
 # Simplest form — top-level, applies to every agent

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -32,7 +32,7 @@ Sandbox config can live in three places (in order of precedence — later wins):
 3. **Per-agent `agents.list[].sandbox:`** — partial override for one agent
    (typically just `enabled: false` to opt out, or `enabled: true` to opt in).
 
-Per-agent overrides may set `enabled`, `workspaceAccess`, and `mounts` (mounts replace defaults entirely). The
+Per-agent overrides may set `enabled`, `workspaceAccess`, and `mounts` (per-agent mounts are appended to base mounts). The
 `docker:` block must live at the top-level / agents-defaults layer because
 the runtime maintains a single `ContainerManager` per process.
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -32,7 +32,7 @@ Sandbox config can live in three places (in order of precedence — later wins):
 3. **Per-agent `agents.list[].sandbox:`** — partial override for one agent
    (typically just `enabled: false` to opt out, or `enabled: true` to opt in).
 
-Per-agent overrides may only set `enabled` and `workspaceAccess`. The
+Per-agent overrides may set `enabled`, `workspaceAccess`, and `mounts` (mounts replace defaults entirely). The
 `docker:` block must live at the top-level / agents-defaults layer because
 the runtime maintains a single `ContainerManager` per process.
 

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -10,7 +10,7 @@ import { Type } from "typebox";
 import type { AgentToolSettings } from "./types.js";
 import { HostFs, SandboxFs, type FsBridge } from "../../sandbox/fs-bridge.js";
 import { SandboxExecutor } from "../../sandbox/executor.js";
-import { type SandboxConfig, shouldSandbox } from "../../sandbox/config.js";
+import { type SandboxConfig } from "../../sandbox/config.js";
 import { createWebFetchTool, createWebSearchTool } from "../../legacy/tools/web.js";
 import { createReactTools, type LazyTransportContext } from "../../legacy/tools/react.js";
 import { createExecTools, ProcessRegistry } from "../../legacy/tools/exec.js";
@@ -297,7 +297,7 @@ export async function shutdownToolsLayer(): Promise<void> {
 }
 
 export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
-  const isSandboxed = !!(opts.agentSandboxConfig && shouldSandbox(opts.agentSandboxConfig));
+  const isSandboxed = !!opts.agentSandboxConfig?.enabled;
   if (isSandboxed && !sandboxExecutor) {
     throw new Error(
       `agent "${opts.agentId}" requires sandbox but no sandbox infrastructure is configured. ` +

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -307,6 +307,9 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
   if (isSandboxed && opts.agentSandboxConfig?.mounts) {
     sandboxExecutor!.registerAgentMounts(opts.agentId, opts.agentSandboxConfig.mounts);
   }
+  if (isSandboxed && opts.agentSandboxConfig?.docker) {
+    sandboxExecutor!.registerAgentDocker(opts.agentId, opts.agentSandboxConfig.docker);
+  }
   const fs: FsBridge = isSandboxed
     ? new SandboxFs(sandboxExecutor!, opts.agentId)
     : new HostFs();

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -304,6 +304,9 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
       "Define `sandbox.docker` in isotopes.yaml (top-level or agents.defaults.sandbox).",
     );
   }
+  if (isSandboxed && opts.agentSandboxConfig?.mounts) {
+    sandboxExecutor!.registerAgentMounts(opts.agentId, opts.agentSandboxConfig.mounts);
+  }
   const fs: FsBridge = isSandboxed
     ? new SandboxFs(sandboxExecutor!, opts.agentId)
     : new HostFs();

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -304,11 +304,8 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
       "Define `sandbox.docker` in isotopes.yaml (top-level or agents.defaults.sandbox).",
     );
   }
-  if (isSandboxed && opts.agentSandboxConfig?.mounts) {
-    sandboxExecutor!.registerAgentMounts(opts.agentId, opts.agentSandboxConfig.mounts);
-  }
-  if (isSandboxed && opts.agentSandboxConfig?.docker) {
-    sandboxExecutor!.registerAgentDocker(opts.agentId, opts.agentSandboxConfig.docker);
+  if (isSandboxed && opts.agentSandboxConfig) {
+    sandboxExecutor!.registerAgent(opts.agentId, opts.agentSandboxConfig);
   }
   const fs: FsBridge = isSandboxed
     ? new SandboxFs(sandboxExecutor!, opts.agentId)

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -398,14 +398,16 @@ agents:
       expect(config!.docker?.image).toBe("team:latest");
     });
 
-    it("rejects per-agent sandbox.docker with a clear error", () => {
-      expect(() =>
-        resolveSandboxConfigFromFile(
-          "test-agent",
-          { enabled: true, docker: { image: "agent-specific:latest" } },
-          { enabled: true, docker: { image: "team:latest" } },
-        ),
-      ).toThrow(/sandbox\.docker is not supported at the per-agent level/);
+    it("per-agent docker fields override base docker fields (per-field merge)", () => {
+      const config = resolveSandboxConfigFromFile(
+        "test-agent",
+        { enabled: true, docker: { image: "agent-specific:latest" } },
+        { enabled: true, docker: { image: "team:latest", network: "host", cpuLimit: 2 } },
+      );
+      // override `image` from agent, inherit `network` and `cpuLimit` from base
+      expect(config!.docker?.image).toBe("agent-specific:latest");
+      expect(config!.docker?.network).toBe("host");
+      expect(config!.docker?.cpuLimit).toBe(2);
     });
 
     it("per-agent mounts concat onto base mounts", () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -408,14 +408,13 @@ agents:
       ).toThrow(/sandbox\.docker is not supported at the per-agent level/);
     });
 
-    it("rejects per-agent sandbox.mounts with a clear error", () => {
-      expect(() =>
-        resolveSandboxConfigFromFile(
-          "test-agent",
-          { enabled: true, mounts: [{ host: "/foo", container: "/foo" }] },
-          { enabled: true },
-        ),
-      ).toThrow(/sandbox\.mounts is not supported at the per-agent level/);
+    it("per-agent mounts override base mounts", () => {
+      const config = resolveSandboxConfigFromFile(
+        "test-agent",
+        { enabled: true, mounts: [{ host: "/agent-foo", container: "/foo" }] },
+        { enabled: true, mounts: [{ host: "/base-bar", container: "/bar" }] },
+      );
+      expect(config!.mounts).toEqual([{ host: "/agent-foo", container: "/foo" }]);
     });
     it("propagates pidsLimit / noNewPrivileges from file", () => {
       const config = resolveSandboxConfigFromFile("test-agent", undefined, {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -408,6 +408,15 @@ agents:
       ).toThrow(/sandbox\.docker is not supported at the per-agent level/);
     });
 
+    it("rejects per-agent sandbox.mounts with a clear error", () => {
+      expect(() =>
+        resolveSandboxConfigFromFile(
+          "test-agent",
+          { enabled: true, mounts: [{ host: "/foo", container: "/foo" }] },
+          { enabled: true },
+        ),
+      ).toThrow(/sandbox\.mounts is not supported at the per-agent level/);
+    });
     it("propagates pidsLimit / noNewPrivileges from file", () => {
       const config = resolveSandboxConfigFromFile("test-agent", undefined, {
         enabled: true,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -408,13 +408,16 @@ agents:
       ).toThrow(/sandbox\.docker is not supported at the per-agent level/);
     });
 
-    it("per-agent mounts override base mounts", () => {
+    it("per-agent mounts concat onto base mounts", () => {
       const config = resolveSandboxConfigFromFile(
         "test-agent",
         { enabled: true, mounts: [{ host: "/agent-foo", container: "/foo" }] },
         { enabled: true, mounts: [{ host: "/base-bar", container: "/bar" }] },
       );
-      expect(config!.mounts).toEqual([{ host: "/agent-foo", container: "/foo" }]);
+      expect(config!.mounts).toEqual([
+        { host: "/base-bar", container: "/bar" },
+        { host: "/agent-foo", container: "/foo" },
+      ]);
     });
     it("propagates pidsLimit / noNewPrivileges from file", () => {
       const config = resolveSandboxConfigFromFile("test-agent", undefined, {

--- a/src/config.ts
+++ b/src/config.ts
@@ -220,14 +220,6 @@ export function resolveSandboxConfigFromFile(
 ): SandboxConfig | undefined {
   if (!agentSandbox && !defaultSandbox) return undefined;
 
-  if (agentSandbox?.docker) {
-    throw new Error(
-      `agent "${agentId}": sandbox.docker is not supported at the per-agent level. ` +
-        `Move docker config to the agents-level (agents.defaults.sandbox.docker or top-level sandbox.docker); ` +
-        `each agent may only override sandbox.enabled, sandbox.workspaceAccess, and sandbox.mounts.`,
-    );
-  }
-
   const defaults = defaultSandbox
     ? toSandboxConfig(defaultSandbox)
     : undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -228,6 +228,14 @@ export function resolveSandboxConfigFromFile(
     );
   }
 
+  if (agentSandbox?.mounts) {
+    throw new Error(
+      `agent "${agentId}": sandbox.mounts is not supported at the per-agent level. ` +
+        `The runtime maintains one container per agent built from base mounts; per-agent overrides would be silently ignored. ` +
+        `Move mounts to agents.defaults.sandbox.mounts or top-level sandbox.mounts.`,
+    );
+  }
+
   const defaults = defaultSandbox
     ? toSandboxConfig(defaultSandbox)
     : undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -224,15 +224,7 @@ export function resolveSandboxConfigFromFile(
     throw new Error(
       `agent "${agentId}": sandbox.docker is not supported at the per-agent level. ` +
         `Move docker config to the agents-level (agents.defaults.sandbox.docker or top-level sandbox.docker); ` +
-        `each agent may only override sandbox.enabled and sandbox.workspaceAccess.`,
-    );
-  }
-
-  if (agentSandbox?.mounts) {
-    throw new Error(
-      `agent "${agentId}": sandbox.mounts is not supported at the per-agent level. ` +
-        `The runtime maintains one container per agent built from base mounts; per-agent overrides would be silently ignored. ` +
-        `Move mounts to agents.defaults.sandbox.mounts or top-level sandbox.mounts.`,
+        `each agent may only override sandbox.enabled, sandbox.workspaceAccess, and sandbox.mounts.`,
     );
   }
 

--- a/src/legacy/tools/exec.test.ts
+++ b/src/legacy/tools/exec.test.ts
@@ -523,7 +523,6 @@ import type { SandboxConfig } from "../../sandbox/config.js";
 
 function makeMockSandboxExecutor(overrides?: Partial<SandboxExecutor>): SandboxExecutor {
   return {
-    shouldExecuteInSandbox: vi.fn(() => true),
     execute: vi.fn(async () => ({ exitCode: 0, stdout: "sandboxed-out", stderr: "" })),
     buildExecArgv: vi.fn(async (_id: string, cmd: string[]) => [
       "docker", "exec", "-i", "ctr-1", ...cmd,
@@ -644,10 +643,8 @@ describe("exec tool sandbox routing", () => {
     expect(result.error).toMatch(/Sandbox container creation failed/);
   });
 
-  it("falls back to host when shouldExecuteInSandbox returns false", async () => {
-    const executor = makeMockSandboxExecutor({
-      shouldExecuteInSandbox: vi.fn(() => false),
-    });
+  it("falls back to host when sandbox config is disabled", async () => {
+    const executor = makeMockSandboxExecutor();
     const tool = createExecTool({
       cwd: "/tmp",
       sandboxExecutor: executor,

--- a/src/legacy/tools/exec.ts
+++ b/src/legacy/tools/exec.ts
@@ -7,7 +7,7 @@ import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type, type Static } from "typebox";
 import { createLogger } from "../../logging/logger.js";
 import type { SandboxExecutor } from "../../sandbox/executor.js";
-import type { SandboxConfig } from "../../sandbox/config.js";
+import { type SandboxConfig, shouldSandbox } from "../../sandbox/config.js";
 
 const execAsync = promisify(exec);
 const log = createLogger("tools:exec");
@@ -251,8 +251,7 @@ export function createExecTool(options: ExecToolOptions = {}): AgentTool<typeof 
   const { sandboxExecutor, agentId, agentSandboxConfig } = options;
 
   const useSandbox = (): boolean =>
-    !!(sandboxExecutor && agentId && agentSandboxConfig &&
-       sandboxExecutor.shouldExecuteInSandbox(agentId, agentSandboxConfig));
+    !!(sandboxExecutor && agentId && agentSandboxConfig && shouldSandbox(agentSandboxConfig));
 
   return {
     name: "exec",

--- a/src/legacy/tools/exec.ts
+++ b/src/legacy/tools/exec.ts
@@ -7,7 +7,7 @@ import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type, type Static } from "typebox";
 import { createLogger } from "../../logging/logger.js";
 import type { SandboxExecutor } from "../../sandbox/executor.js";
-import { type SandboxConfig, shouldSandbox } from "../../sandbox/config.js";
+import type { SandboxConfig } from "../../sandbox/config.js";
 
 const execAsync = promisify(exec);
 const log = createLogger("tools:exec");
@@ -251,7 +251,7 @@ export function createExecTool(options: ExecToolOptions = {}): AgentTool<typeof 
   const { sandboxExecutor, agentId, agentSandboxConfig } = options;
 
   const useSandbox = (): boolean =>
-    !!(sandboxExecutor && agentId && agentSandboxConfig && shouldSandbox(agentSandboxConfig));
+    !!(sandboxExecutor && agentId && agentSandboxConfig?.enabled);
 
   return {
     name: "exec",

--- a/src/sandbox/config.test.ts
+++ b/src/sandbox/config.test.ts
@@ -194,6 +194,16 @@ describe("Sandbox Config", () => {
       expect(cfg.docker?.noNewPrivileges).toBe(false);
     });
 
+    it("throws when base + agent mounts produce duplicate container paths", () => {
+      expect(() =>
+        resolveSandboxConfig(
+          "test-agent",
+          { enabled: true, mounts: [{ host: "/a", container: "/foo" }] },
+          { enabled: true, mounts: [{ host: "/b", container: "/foo" }] },
+        ),
+      ).toThrow(/mounts\[1\]\.container "\/foo" duplicates/);
+    });
+
     it("throws on negative pidsLimit", () => {
       expect(() =>
         resolveSandboxConfig("test-agent", {

--- a/src/sandbox/config.test.ts
+++ b/src/sandbox/config.test.ts
@@ -1,7 +1,7 @@
 // src/sandbox/config.test.ts — Unit tests for sandbox config resolution
 
 import { describe, it, expect } from "vitest";
-import { resolveSandboxConfig, shouldSandbox } from "./config.js";
+import { resolveSandboxConfig } from "./config.js";
 import type { SandboxConfig } from "./config.js";
 
 describe("Sandbox Config", () => {
@@ -201,16 +201,6 @@ describe("Sandbox Config", () => {
           docker: { image: "test:latest", pidsLimit: -1 },
         }),
       ).toThrow("docker.pidsLimit must be a non-negative integer");
-    });
-  });
-
-  describe("shouldSandbox", () => {
-    it("returns false when disabled", () => {
-      expect(shouldSandbox({ enabled: false })).toBe(false);
-    });
-
-    it("returns true when enabled", () => {
-      expect(shouldSandbox({ enabled: true })).toBe(true);
     });
   });
 });

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -77,10 +77,11 @@ export function resolveSandboxConfig(
 ): SandboxConfig {
   if (!defaults && !override) return { enabled: false };
 
+  const mounts = [...(defaults?.mounts ?? []), ...(override?.mounts ?? [])];
   const resolved: SandboxConfig = {
     enabled: override?.enabled ?? defaults?.enabled ?? false,
     workspaceAccess: override?.workspaceAccess ?? defaults?.workspaceAccess ?? "rw",
-    mounts: override?.mounts ?? defaults?.mounts,
+    ...(mounts.length > 0 && { mounts }),
     docker: mergeDockerConfig(defaults?.docker, override?.docker),
   };
 

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -100,7 +100,3 @@ function mergeDockerConfig(defaults?: DockerConfig, override?: DockerConfig): Do
     noNewPrivileges: override?.noNewPrivileges ?? defaults?.noNewPrivileges ?? DEFAULT_DOCKER_CONFIG.noNewPrivileges,
   };
 }
-
-export function shouldSandbox(config: SandboxConfig): boolean {
-  return config.enabled;
-}

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -42,10 +42,13 @@ function validateSandboxConfig(config: SandboxConfig, label: string): void {
   }
 
   if (config.mounts !== undefined) {
+    const seen = new Set<string>();
     for (let i = 0; i < config.mounts.length; i++) {
       const m = config.mounts[i];
       check(m.host.startsWith("/"), `mounts[${i}].host must be an absolute path`);
       check(m.container.startsWith("/"), `mounts[${i}].container must be an absolute path`);
+      check(!seen.has(m.container), `mounts[${i}].container "${m.container}" duplicates an earlier mount`);
+      seen.add(m.container);
     }
   }
 

--- a/src/sandbox/container.test.ts
+++ b/src/sandbox/container.test.ts
@@ -50,14 +50,14 @@ describe("ContainerManager", () => {
 
   beforeEach(() => {
     mockSpawn.mockReset();
-    manager = new ContainerManager(defaultDockerConfig);
+    manager = new ContainerManager();
   });
 
   describe("create", () => {
     it("calls docker create with correct arguments", async () => {
       mockSpawn.mockReturnValue(fakeChild({ code: 0, stdout: "abc123\n" }));
 
-      const result = await manager.create("test-container", "/home/user/workspace", "rw");
+      const result = await manager.create("test-container", "/home/user/workspace", "rw", [], defaultDockerConfig);
 
       expect(mockSpawn).toHaveBeenCalledWith("docker", [
         "create",
@@ -85,9 +85,8 @@ describe("ContainerManager", () => {
         pidsLimit: 256,
         noNewPrivileges: true,
       };
-      const m = new ContainerManager(hardened);
 
-      await m.create("hardened", "/workspace", "rw");
+      await manager.create("hardened", "/workspace", "rw", [], hardened);
 
       const args = mockSpawn.mock.calls[0][1] as string[];
       expect(args).toContain("--init");
@@ -100,7 +99,7 @@ describe("ContainerManager", () => {
     it("omits --pids-limit when set to 0", async () => {
       mockSpawn.mockReturnValue(fakeChild({ code: 0, stdout: "abc123\n" }));
       const cfg: DockerConfig = { ...defaultDockerConfig, pidsLimit: 0 };
-      await new ContainerManager(cfg).create("t", "/w", "rw");
+      await manager.create("t", "/w", "rw", [], cfg);
       const args = mockSpawn.mock.calls[0][1] as string[];
       expect(args).not.toContain("--pids-limit");
     });
@@ -108,7 +107,7 @@ describe("ContainerManager", () => {
     it("omits --security-opt when noNewPrivileges is false", async () => {
       mockSpawn.mockReturnValue(fakeChild({ code: 0, stdout: "abc123\n" }));
       const cfg: DockerConfig = { ...defaultDockerConfig, noNewPrivileges: false };
-      await new ContainerManager(cfg).create("t", "/w", "rw");
+      await manager.create("t", "/w", "rw", [], cfg);
       const args = mockSpawn.mock.calls[0][1] as string[];
       expect(args).not.toContain("--security-opt");
     });
@@ -116,7 +115,7 @@ describe("ContainerManager", () => {
     it("adds :ro suffix for read-only workspace access", async () => {
       mockSpawn.mockReturnValue(fakeChild({ code: 0, stdout: "abc123\n" }));
 
-      await manager.create("test-container", "/workspace", "ro");
+      await manager.create("test-container", "/workspace", "ro", [], defaultDockerConfig);
 
       const args = mockSpawn.mock.calls[0][1] as string[];
       expect(args).toContain("/workspace:/workspace:ro");
@@ -129,9 +128,8 @@ describe("ContainerManager", () => {
         ...defaultDockerConfig,
         extraHosts: ["host.docker.internal:host-gateway", "myhost:192.168.1.1"],
       };
-      const m = new ContainerManager(configWithHosts);
 
-      await m.create("test", "/workspace", "rw");
+      await manager.create("test", "/workspace", "rw", [], configWithHosts);
 
       const args = mockSpawn.mock.calls[0][1] as string[];
       expect(args).toContain("--add-host");
@@ -147,9 +145,8 @@ describe("ContainerManager", () => {
         cpuLimit: 1.5,
         memoryLimit: "512m",
       };
-      const m = new ContainerManager(configWithLimits);
 
-      await m.create("test", "/workspace", "rw");
+      await manager.create("test", "/workspace", "rw", [], configWithLimits);
 
       const args = mockSpawn.mock.calls[0][1] as string[];
       expect(args).toContain("--cpus");
@@ -164,7 +161,7 @@ describe("ContainerManager", () => {
       await manager.create("test", "/workspace", "rw", [
         { host: "/host/data", container: "/data", readOnly: true },
         { host: "/host/scratch", container: "/scratch", readOnly: false },
-      ]);
+      ], defaultDockerConfig);
 
       const args = mockSpawn.mock.calls[0][1] as string[];
       expect(args).toContain("/host/data:/data:ro");
@@ -177,7 +174,7 @@ describe("ContainerManager", () => {
       await manager.create("test", "/workspace", "rw", [
         { host: "/workspace", container: "/workspace", readOnly: true },
         { host: "/extra", container: "/extra" },
-      ]);
+      ], defaultDockerConfig);
 
       const args = mockSpawn.mock.calls[0][1] as string[];
       expect(args).not.toContain("/workspace:/workspace:ro");

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -25,17 +25,16 @@ export interface ExecResult {
   truncated?: boolean;
 }
 
-/** Wraps the `docker` CLI rather than the API to avoid heavy SDK deps. */
+/** Wraps the `docker` CLI rather than the API to avoid heavy SDK deps. Stateless — DockerConfig is per-call. */
 export class ContainerManager {
-  constructor(private config: DockerConfig) {}
-
   async create(
     name: string,
     workspacePath: string,
     access: WorkspaceAccess,
-    mounts: Mount[] = [],
+    mounts: Mount[],
+    docker: DockerConfig,
   ): Promise<ContainerInfo> {
-    const args = this.buildCreateArgs(name, workspacePath, access, mounts);
+    const args = this.buildCreateArgs(name, workspacePath, access, mounts, docker);
     const { stdout } = await this.runDocker(args);
     const containerId = stdout.toString("utf8").trim();
 
@@ -43,7 +42,7 @@ export class ContainerManager {
       id: containerId,
       name,
       status: "created",
-      image: this.config.image,
+      image: docker.image,
       createdAt: new Date(),
     };
   }
@@ -162,6 +161,7 @@ export class ContainerManager {
     workspacePath: string,
     access: WorkspaceAccess,
     mounts: Mount[],
+    docker: DockerConfig,
   ): string[] {
     const args: string[] = ["create", "--name", name, "--init"];
 
@@ -177,26 +177,26 @@ export class ContainerManager {
       args.push("-v", `${m.host}:${m.container}${suffix}`);
     }
 
-    if (this.config.network) {
-      args.push("--network", this.config.network);
+    if (docker.network) {
+      args.push("--network", docker.network);
     }
-    if (this.config.extraHosts) {
-      for (const host of this.config.extraHosts) args.push("--add-host", host);
+    if (docker.extraHosts) {
+      for (const host of docker.extraHosts) args.push("--add-host", host);
     }
-    if (this.config.cpuLimit !== undefined) {
-      args.push("--cpus", String(this.config.cpuLimit));
+    if (docker.cpuLimit !== undefined) {
+      args.push("--cpus", String(docker.cpuLimit));
     }
-    if (this.config.memoryLimit) {
-      args.push("--memory", this.config.memoryLimit);
+    if (docker.memoryLimit) {
+      args.push("--memory", docker.memoryLimit);
     }
-    if (this.config.pidsLimit !== undefined && this.config.pidsLimit > 0) {
-      args.push("--pids-limit", String(this.config.pidsLimit));
+    if (docker.pidsLimit !== undefined && docker.pidsLimit > 0) {
+      args.push("--pids-limit", String(docker.pidsLimit));
     }
-    if (this.config.noNewPrivileges !== false) {
+    if (docker.noNewPrivileges !== false) {
       args.push("--security-opt", "no-new-privileges");
     }
 
-    args.push(this.config.image);
+    args.push(docker.image);
     args.push("tail", "-f", "/dev/null");  // keep container alive
     return args;
   }

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
+import { createLogger } from "../logging/logger.js";
 import type { DockerConfig, Mount, WorkspaceAccess } from "./config.js";
+
+const log = createLogger("sandbox:container");
 
 /** Cap collected stdout/stderr per `exec()` call to prevent OOM from runaway commands. */
 const EXEC_MAX_OUTPUT_BYTES = 1024 * 1024;
@@ -74,7 +77,7 @@ export class ContainerManager {
     return ["docker", "exec", "-i", containerId, ...command];
   }
 
-  /** Returns null when the container doesn't exist. */
+  /** Returns null when the container doesn't exist (or docker can't be reached — see debug log). */
   async status(containerId: string): Promise<ContainerInfo | null> {
     try {
       const { stdout } = await this.runDocker([
@@ -87,7 +90,8 @@ export class ContainerManager {
       const line = stdout.toString("utf8").trim();
       if (!line) return null;
       return parseInspectLine(line);
-    } catch {
+    } catch (err) {
+      log.debug(`status(${containerId}) failed`, err);
       return null;
     }
   }

--- a/src/sandbox/executor.test.ts
+++ b/src/sandbox/executor.test.ts
@@ -70,6 +70,7 @@ describe("SandboxExecutor", () => {
         "/home/user/workspace",
         "rw",
         [],
+        defaultConfig.docker,
       );
       expect(mockManager.start).toHaveBeenCalledWith("container-123");
       expect(mockManager.exec).toHaveBeenCalledWith("container-123", [
@@ -174,6 +175,19 @@ describe("SandboxExecutor", () => {
       expect(mockManager.create).toHaveBeenCalledTimes(2);
     });
 
+    it("uses per-agent docker when registered, overriding default docker", async () => {
+      executor.registerAgentDocker("agent-1", { image: "custom:v2", network: "host" });
+      await executor.execute("agent-1", ["ls"], { workspacePath: "/ws" });
+
+      expect(mockManager.create).toHaveBeenCalledWith(
+        "isotopes-sandbox-agent-1",
+        "/ws",
+        "rw",
+        [],
+        { image: "custom:v2", network: "host" },
+      );
+    });
+
     it("uses per-agent mounts when registered, overriding defaults", async () => {
       executor.registerAgentMounts("agent-1", [
         { host: "/agent/foo", container: "/foo", readOnly: true },
@@ -185,6 +199,7 @@ describe("SandboxExecutor", () => {
         "/ws",
         "rw",
         [{ host: "/agent/foo", container: "/foo", readOnly: true }],
+        defaultConfig.docker,
       );
     });
 
@@ -196,6 +211,7 @@ describe("SandboxExecutor", () => {
         "/tmp",
         "rw",
         [],
+        defaultConfig.docker,
       );
     });
 
@@ -207,6 +223,7 @@ describe("SandboxExecutor", () => {
         "/ws",
         "rw",
         [],
+        defaultConfig.docker,
       );
     });
 
@@ -233,6 +250,7 @@ describe("SandboxExecutor", () => {
         "/ws",
         "rw",
         [],
+        defaultConfig.docker,
       );
       expect(mockManager.start).toHaveBeenCalled();
       expect(mockManager.buildExecArgv).toHaveBeenCalledWith("container-123", [

--- a/src/sandbox/executor.test.ts
+++ b/src/sandbox/executor.test.ts
@@ -56,7 +56,8 @@ describe("SandboxExecutor", () => {
 
   beforeEach(() => {
     mockManager = createMockContainerManager();
-    executor = new SandboxExecutor(mockManager, defaultConfig);
+    executor = new SandboxExecutor(mockManager);
+    executor.registerAgent("agent-1", defaultConfig);
   });
 
   describe("execute", () => {
@@ -176,7 +177,7 @@ describe("SandboxExecutor", () => {
     });
 
     it("uses per-agent docker when registered, overriding default docker", async () => {
-      executor.registerAgentDocker("agent-1", { image: "custom:v2", network: "host" });
+      executor.registerAgent("agent-1", { enabled: true, docker: { image: "custom:v2", network: "host" } });
       await executor.execute("agent-1", ["ls"], { workspacePath: "/ws" });
 
       expect(mockManager.create).toHaveBeenCalledWith(
@@ -189,9 +190,10 @@ describe("SandboxExecutor", () => {
     });
 
     it("uses per-agent mounts when registered, overriding defaults", async () => {
-      executor.registerAgentMounts("agent-1", [
-        { host: "/agent/foo", container: "/foo", readOnly: true },
-      ]);
+      executor.registerAgent("agent-1", {
+        ...defaultConfig,
+        mounts: [{ host: "/agent/foo", container: "/foo", readOnly: true }],
+      });
       await executor.execute("agent-1", ["ls"], { workspacePath: "/ws" });
 
       expect(mockManager.create).toHaveBeenCalledWith(
@@ -320,6 +322,8 @@ describe("SandboxExecutor", () => {
           createdAt: new Date(),
         });
 
+      executor.registerAgent("agent-a", defaultConfig);
+      executor.registerAgent("agent-b", defaultConfig);
       await executor.execute("agent-a", ["echo", "a"]);
       await executor.execute("agent-b", ["echo", "b"]);
 

--- a/src/sandbox/executor.test.ts
+++ b/src/sandbox/executor.test.ts
@@ -236,22 +236,6 @@ describe("SandboxExecutor", () => {
     });
   });
 
-  describe("shouldExecuteInSandbox", () => {
-    it("returns true when default config is enabled", () => {
-      expect(executor.shouldExecuteInSandbox("agent-1")).toBe(true);
-    });
-
-    it("returns false when default config is disabled", () => {
-      const offExecutor = new SandboxExecutor(mockManager, { enabled: false });
-      expect(offExecutor.shouldExecuteInSandbox("agent-1")).toBe(false);
-    });
-
-    it("uses agent-level config override when provided", () => {
-      const agentOverride: SandboxConfig = { enabled: false };
-      expect(executor.shouldExecuteInSandbox("agent-1", agentOverride)).toBe(false);
-    });
-  });
-
   describe("cleanup", () => {
     it("stops and removes a specific agent's container", async () => {
       // Create a container first

--- a/src/sandbox/executor.test.ts
+++ b/src/sandbox/executor.test.ts
@@ -176,6 +176,12 @@ describe("SandboxExecutor", () => {
       expect(mockManager.create).toHaveBeenCalledTimes(2);
     });
 
+    it("throws when executing for an unregistered agent", async () => {
+      await expect(executor.execute("never-registered", ["echo"])).rejects.toThrow(
+        /sandboxed but no docker config registered/,
+      );
+    });
+
     it("uses per-agent docker when registered, overriding default docker", async () => {
       executor.registerAgent("agent-1", { enabled: true, docker: { image: "custom:v2", network: "host" } });
       await executor.execute("agent-1", ["ls"], { workspacePath: "/ws" });

--- a/src/sandbox/executor.test.ts
+++ b/src/sandbox/executor.test.ts
@@ -174,6 +174,20 @@ describe("SandboxExecutor", () => {
       expect(mockManager.create).toHaveBeenCalledTimes(2);
     });
 
+    it("uses per-agent mounts when registered, overriding defaults", async () => {
+      executor.registerAgentMounts("agent-1", [
+        { host: "/agent/foo", container: "/foo", readOnly: true },
+      ]);
+      await executor.execute("agent-1", ["ls"], { workspacePath: "/ws" });
+
+      expect(mockManager.create).toHaveBeenCalledWith(
+        "isotopes-sandbox-agent-1",
+        "/ws",
+        "rw",
+        [{ host: "/agent/foo", container: "/foo", readOnly: true }],
+      );
+    });
+
     it("uses /tmp as default workspace when none specified", async () => {
       await executor.execute("agent-1", ["ls"]);
 

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -2,7 +2,7 @@
 
 import { createLogger } from "../logging/logger.js";
 import { ContainerManager, type ContainerInfo, type ExecResult } from "./container.js";
-import { type SandboxConfig, type WorkspaceAccess } from "./config.js";
+import { type Mount, type SandboxConfig, type WorkspaceAccess } from "./config.js";
 
 const log = createLogger("sandbox:executor");
 
@@ -18,6 +18,7 @@ export interface SandboxExecOptions {
 export class SandboxExecutor {
   private containers: Map<string, ContainerInfo> = new Map();
   private inflight: Map<string, Promise<ContainerInfo>> = new Map();
+  private agentMounts: Map<string, Mount[]> = new Map();
 
   constructor(
     private containerManager: ContainerManager,
@@ -28,6 +29,11 @@ export class SandboxExecutor {
   static fromConfig(config: SandboxConfig): SandboxExecutor | undefined {
     if (!config.docker) return undefined;
     return new SandboxExecutor(new ContainerManager(config.docker), config);
+  }
+
+  /** Override the mounts used when this agent's container is created. Replaces defaults entirely. */
+  registerAgentMounts(agentId: string, mounts: Mount[]): void {
+    this.agentMounts.set(agentId, mounts);
   }
 
   async execute(
@@ -107,7 +113,7 @@ export class SandboxExecutor {
       containerName,
       workspace,
       access,
-      this.defaultConfig.mounts ?? [],
+      this.agentMounts.get(agentId) ?? this.defaultConfig.mounts ?? [],
     );
 
     await this.containerManager.start(container.id);

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -113,7 +113,7 @@ export class SandboxExecutor {
       containerName,
       workspace,
       access,
-      this.agentMounts.get(agentId) ?? this.defaultConfig.mounts ?? [],
+      this.agentMounts.get(agentId) ?? [],
     );
 
     await this.containerManager.start(container.id);

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -2,7 +2,7 @@
 
 import { createLogger } from "../logging/logger.js";
 import { ContainerManager, type ContainerInfo, type ExecResult } from "./container.js";
-import { type Mount, type SandboxConfig, type WorkspaceAccess } from "./config.js";
+import { type DockerConfig, type Mount, type SandboxConfig, type WorkspaceAccess } from "./config.js";
 
 const log = createLogger("sandbox:executor");
 
@@ -19,6 +19,7 @@ export class SandboxExecutor {
   private containers: Map<string, ContainerInfo> = new Map();
   private inflight: Map<string, Promise<ContainerInfo>> = new Map();
   private agentMounts: Map<string, Mount[]> = new Map();
+  private agentDocker: Map<string, DockerConfig> = new Map();
 
   constructor(
     private containerManager: ContainerManager,
@@ -28,12 +29,17 @@ export class SandboxExecutor {
   /** Returns an executor when sandbox docker config is present, else undefined. */
   static fromConfig(config: SandboxConfig): SandboxExecutor | undefined {
     if (!config.docker) return undefined;
-    return new SandboxExecutor(new ContainerManager(config.docker), config);
+    return new SandboxExecutor(new ContainerManager(), config);
   }
 
   /** Override the mounts used when this agent's container is created. Replaces defaults entirely. */
   registerAgentMounts(agentId: string, mounts: Mount[]): void {
     this.agentMounts.set(agentId, mounts);
+  }
+
+  /** Override the docker config used when this agent's container is created. */
+  registerAgentDocker(agentId: string, docker: DockerConfig): void {
+    this.agentDocker.set(agentId, docker);
   }
 
   async execute(
@@ -109,11 +115,17 @@ export class SandboxExecutor {
       await this.safeRemove(orphan.id);
     }
 
+    const docker = this.agentDocker.get(agentId) ?? this.defaultConfig.docker;
+    if (!docker) {
+      throw new Error(`agent "${agentId}" sandboxed but no docker config available (neither base nor per-agent)`);
+    }
+
     const container = await this.containerManager.create(
       containerName,
       workspace,
       access,
       this.agentMounts.get(agentId) ?? [],
+      docker,
     );
 
     await this.containerManager.start(container.id);

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -20,26 +20,21 @@ export class SandboxExecutor {
   private inflight: Map<string, Promise<ContainerInfo>> = new Map();
   private agentMounts: Map<string, Mount[]> = new Map();
   private agentDocker: Map<string, DockerConfig> = new Map();
+  private agentWorkspaceAccess: Map<string, WorkspaceAccess> = new Map();
 
-  constructor(
-    private containerManager: ContainerManager,
-    private defaultConfig: SandboxConfig,
-  ) {}
+  constructor(private containerManager: ContainerManager) {}
 
   /** Returns an executor when sandbox docker config is present, else undefined. */
   static fromConfig(config: SandboxConfig): SandboxExecutor | undefined {
     if (!config.docker) return undefined;
-    return new SandboxExecutor(new ContainerManager(), config);
+    return new SandboxExecutor(new ContainerManager());
   }
 
-  /** Override the mounts used when this agent's container is created. Replaces defaults entirely. */
-  registerAgentMounts(agentId: string, mounts: Mount[]): void {
-    this.agentMounts.set(agentId, mounts);
-  }
-
-  /** Override the docker config used when this agent's container is created. */
-  registerAgentDocker(agentId: string, docker: DockerConfig): void {
-    this.agentDocker.set(agentId, docker);
+  /** Register an agent's resolved sandbox config. Idempotent — last write wins. */
+  registerAgent(agentId: string, config: SandboxConfig): void {
+    if (config.docker) this.agentDocker.set(agentId, config.docker);
+    if (config.mounts) this.agentMounts.set(agentId, config.mounts);
+    if (config.workspaceAccess) this.agentWorkspaceAccess.set(agentId, config.workspaceAccess);
   }
 
   async execute(
@@ -106,7 +101,7 @@ export class SandboxExecutor {
 
     const containerName = `isotopes-sandbox-${agentId}`;
     const workspace = workspacePath ?? "/tmp";
-    const access: WorkspaceAccess = this.defaultConfig.workspaceAccess ?? "rw";
+    const access: WorkspaceAccess = this.agentWorkspaceAccess.get(agentId) ?? "rw";
 
     // Reap an orphan from a previous process — otherwise `docker create` fails on the name conflict.
     const orphan = await this.containerManager.status(containerName);
@@ -115,9 +110,9 @@ export class SandboxExecutor {
       await this.safeRemove(orphan.id);
     }
 
-    const docker = this.agentDocker.get(agentId) ?? this.defaultConfig.docker;
+    const docker = this.agentDocker.get(agentId);
     if (!docker) {
-      throw new Error(`agent "${agentId}" sandboxed but no docker config available (neither base nor per-agent)`);
+      throw new Error(`agent "${agentId}" sandboxed but no docker config registered`);
     }
 
     const container = await this.containerManager.create(
@@ -153,9 +148,13 @@ export class SandboxExecutor {
 
   private async cleanupAgent(agentId: string): Promise<void> {
     const container = this.containers.get(agentId);
-    if (!container) return;
-    await this.safeRemove(container.id);
-    this.containers.delete(agentId);
+    if (container) {
+      await this.safeRemove(container.id);
+      this.containers.delete(agentId);
+    }
+    this.agentMounts.delete(agentId);
+    this.agentDocker.delete(agentId);
+    this.agentWorkspaceAccess.delete(agentId);
   }
 
   private async cleanupAll(): Promise<void> {
@@ -166,6 +165,9 @@ export class SandboxExecutor {
         this.containers.delete(agentId);
       }),
     );
+    this.agentMounts.clear();
+    this.agentDocker.clear();
+    this.agentWorkspaceAccess.clear();
   }
 
   private async safeRemove(containerId: string): Promise<void> {

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -2,7 +2,7 @@
 
 import { createLogger } from "../logging/logger.js";
 import { ContainerManager, type ContainerInfo, type ExecResult } from "./container.js";
-import { shouldSandbox, type SandboxConfig, type WorkspaceAccess } from "./config.js";
+import { type SandboxConfig, type WorkspaceAccess } from "./config.js";
 
 const log = createLogger("sandbox:executor");
 
@@ -50,10 +50,6 @@ export class SandboxExecutor {
   ): Promise<string[]> {
     const container = await this.ensureContainer(agentId, options?.workspacePath);
     return this.containerManager.buildExecArgv(container.id, command);
-  }
-
-  shouldExecuteInSandbox(_agentId: string, agentConfig?: SandboxConfig): boolean {
-    return shouldSandbox(agentConfig ?? this.defaultConfig);
   }
 
   async cleanup(agentId?: string): Promise<void> {

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -30,7 +30,7 @@ export class SandboxExecutor {
     return new SandboxExecutor(new ContainerManager());
   }
 
-  /** Register an agent's resolved sandbox config. Idempotent — last write wins. */
+  /** Register an agent's resolved sandbox config. Re-calling merges into existing — absent fields preserve previous values. */
   registerAgent(agentId: string, config: SandboxConfig): void {
     if (config.docker) this.agentDocker.set(agentId, config.docker);
     if (config.mounts) this.agentMounts.set(agentId, config.mounts);


### PR DESCRIPTION
Picks 3 items from #706, plus enables per-agent mounts and per-agent docker (the original "must be base only" restriction turned out to be a stale assumption from when ContainerManager was stateful).

## Changes

- **Per-agent \`sandbox.docker\` now works** — ContainerManager is now stateless (DockerConfig is per-\`create()\` call). \`SandboxExecutor.registerAgent(agentId, config)\` stores the agent's resolved sandbox config (workspaceAccess + mounts + docker). Config layer's \`mergeDockerConfig\` does per-field override-wins. Common use case: per-agent custom image while inheriting base limits.
- **Per-agent \`sandbox.mounts\` now works** — per-agent mounts are **appended** to base mounts (concat semantics, not replace). Validation rejects duplicate \`container\` paths so docker doesn't get confused.
- **\`SandboxExecutor.defaultConfig\` removed** — base config is merged into per-agent config at config-resolve time, so the executor only needs per-agent state. Eliminates a footgun where \`defaultConfig.workspaceAccess\` was silently ignored when an agent overrode it.
- **\`ContainerManager.status\` logs inspect failures** — \`catch {}\` was treating "container missing" and "daemon unreachable" identically. Add \`log.debug(err)\` so daemon problems are observable.
- **Drop \`SandboxExecutor.shouldExecuteInSandbox\`** — both callers go through the standalone \`shouldSandbox(config)\` function. Single decision path; one less wrapper.
- **Drop \`shouldSandbox\` helper entirely** — was a one-line \`config.enabled\` getter, meaningful when SandboxMode existed (off/non-main/all + isMainAgent), redundant now. Callers read \`config.enabled\` directly.

Suggest **squash merge** — commit history reflects iteration (initial reject mounts → flip to support → consolidate APIs) that doesn't need to land on main.

## Test plan

- [x] pnpm typecheck
- [x] pnpm test (920 passed)
- [x] new test: per-agent mounts concat onto base mounts
- [x] new test: per-agent docker per-field override-wins
- [x] new test: duplicate container path rejected
- [x] new test: executor uses registered per-agent mounts and docker on container create

Refs #706. Follow-ups in #709, #710, #711.