### PR TITLE
refactor(tools): simplify web_fetch + drop web_search

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ink": "^5.2.1",
     "ink-select-input": "^6.2.0",
     "ink-text-input": "^6.0.0",
+    "node-html-markdown": "^2.0.0",
     "react": "^18.3.1",
     "typebox": "^1.1.34",
     "yaml": "2.7.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       ink-text-input:
         specifier: ^6.0.0
         version: 6.0.0(ink@5.2.1(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
+      node-html-markdown:
+        specifier: ^2.0.0
+        version: 2.0.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1306,6 +1309,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -1414,6 +1420,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1456,6 +1469,19 @@ packages:
     resolution: {integrity: sha512-feShi+gULJ6R2MAA4/KkCFnkJcuVrROJrKk4czplzq8gE1oqhqgOy9K0Scu44B8oGeWKe04egquzf+ia6VtXAw==}
     engines: {node: '>=18'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1473,6 +1499,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1715,6 +1745,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -2017,6 +2051,16 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-html-markdown@2.0.0:
+    resolution: {integrity: sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==}
+    engines: {node: '>=20.0.0'}
+
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4144,6 +4188,8 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  boolbase@1.0.0: {}
+
   bowser@2.14.1: {}
 
   brace-expansion@1.1.13:
@@ -4249,6 +4295,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -4292,6 +4348,24 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
@@ -4307,6 +4381,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@4.5.0: {}
 
   environment@1.1.0: {}
 
@@ -4613,6 +4689,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  he@1.2.0: {}
+
   highlight.js@10.7.3: {}
 
   hosted-git-info@9.0.2:
@@ -4914,6 +4992,19 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-html-markdown@2.0.0:
+    dependencies:
+      node-html-parser: 6.1.13
+
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   object-assign@4.1.1: {}
 

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -55,11 +55,11 @@ describe("createAgentTools", () => {
     expect(names).toContain("exec");
   });
 
-  it("adds web tools when settings.web is true", () => {
-    const tools = createAgentTools({ ...baseOpts(), settings: { web: true } });
+  it("registers web_fetch by default", () => {
+    const tools = createAgentTools(baseOpts());
     const names = tools.map((t) => t.name);
     expect(names).toContain("web_fetch");
-    expect(names).toContain("web_search");
+    expect(names).not.toContain("web_search");
   });
 });
 

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -3,6 +3,8 @@ import {
   createTimeTool,
   createAgentTools,
   applyToolPolicy,
+  configureToolsLayer,
+  shutdownToolsLayer,
 } from "./index.js";
 import { createWebFetchTool } from "./web.js";
 import { ProcessRegistry } from "../../legacy/tools/exec.js";
@@ -62,13 +64,29 @@ describe("createAgentTools", () => {
     expect(names).not.toContain("web_search");
   });
 
-  it("omits web_fetch when sandbox network is 'none'", () => {
+  it("omits web_fetch when sandbox is enabled and network is 'none'", () => {
+    configureToolsLayer({
+      sandboxBaseConfig: { enabled: true, docker: { image: "isotopes-sandbox:latest", network: "none" } },
+    });
+    try {
+      const tools = createAgentTools({
+        ...baseOpts(),
+        agentSandboxConfig: { enabled: true, docker: { image: "isotopes-sandbox:latest", network: "none" } },
+      });
+      const names = tools.map((t) => t.name);
+      expect(names).not.toContain("web_fetch");
+    } finally {
+      void shutdownToolsLayer();
+    }
+  });
+
+  it("keeps web_fetch when sandbox is disabled even if docker.network is 'none'", () => {
     const tools = createAgentTools({
       ...baseOpts(),
       agentSandboxConfig: { enabled: false, docker: { image: "isotopes-sandbox:latest", network: "none" } },
     });
     const names = tools.map((t) => t.name);
-    expect(names).not.toContain("web_fetch");
+    expect(names).toContain("web_fetch");
   });
 });
 

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -61,6 +61,15 @@ describe("createAgentTools", () => {
     expect(names).toContain("web_fetch");
     expect(names).not.toContain("web_search");
   });
+
+  it("omits web_fetch when sandbox network is 'none'", () => {
+    const tools = createAgentTools({
+      ...baseOpts(),
+      agentSandboxConfig: { enabled: false, docker: { image: "isotopes-sandbox:latest", network: "none" } },
+    });
+    const names = tools.map((t) => t.name);
+    expect(names).not.toContain("web_fetch");
+  });
 });
 
 describe("applyToolPolicy", () => {

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -11,7 +11,7 @@ import type { AgentToolSettings } from "./types.js";
 import { HostFs, SandboxFs, type FsBridge } from "../../sandbox/fs-bridge.js";
 import { SandboxExecutor } from "../../sandbox/executor.js";
 import { type SandboxConfig } from "../../sandbox/config.js";
-import { createWebFetchTool, createWebSearchTool } from "./web.js";
+import { createWebFetchTool } from "./web.js";
 import { createReactTools, type LazyTransportContext } from "../../legacy/tools/react.js";
 import { createExecTools, ProcessRegistry } from "../../legacy/tools/exec.js";
 import type { AgentRuntime } from "../runtime.js";
@@ -334,10 +334,7 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
       ...(opts.spawnableAgentIds ? { spawnableAgentIds: opts.spawnableAgentIds } : {}),
     }));
   }
-  if (opts.settings?.web) {
-    tools.push(createWebFetchTool());
-    tools.push(createWebSearchTool());
-  }
+  tools.push(createWebFetchTool());
   if (opts.transportContext) {
     tools.push(...createReactTools(opts.transportContext));
   }

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -334,7 +334,9 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
       ...(opts.spawnableAgentIds ? { spawnableAgentIds: opts.spawnableAgentIds } : {}),
     }));
   }
-  tools.push(createWebFetchTool());
+  if (opts.agentSandboxConfig?.docker?.network !== "none") {
+    tools.push(createWebFetchTool());
+  }
   if (opts.transportContext) {
     tools.push(...createReactTools(opts.transportContext));
   }

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -334,7 +334,8 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
       ...(opts.spawnableAgentIds ? { spawnableAgentIds: opts.spawnableAgentIds } : {}),
     }));
   }
-  if (opts.agentSandboxConfig?.docker?.network !== "none") {
+  const networkIsolated = isSandboxed && opts.agentSandboxConfig?.docker?.network === "none";
+  if (!networkIsolated) {
     tools.push(createWebFetchTool());
   }
   if (opts.transportContext) {

--- a/src/agent/tools/types.ts
+++ b/src/agent/tools/types.ts
@@ -1,7 +1,6 @@
-// src/tools/types.ts — Per-agent tool settings (allow/deny + feature toggles)
+// src/tools/types.ts — Per-agent tool settings (allow/deny filters)
 
 export interface AgentToolSettings {
-  web?: boolean;
   allow?: string[];
   deny?: string[];
 }

--- a/src/agent/tools/web.test.ts
+++ b/src/agent/tools/web.test.ts
@@ -1,7 +1,5 @@
-// src/tools/web.test.ts — Tests for web fetch and search tools
-
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createWebFetchTool, createWebSearchTool, parseDuckDuckGoResults } from "./web.js";
+import { createWebFetchTool } from "./web.js";
 
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 
@@ -11,430 +9,117 @@ async function callTool(tool: AgentTool, args: unknown): Promise<string> {
   return block?.text ?? "";
 }
 
+function mockFetchHtml(html: string, contentType = "text/html"): void {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Map([["content-type", contentType]]) as unknown as Headers,
+    text: async () => html,
+  } as Response);
+}
 
-describe("web tools", () => {
+describe("createWebFetchTool", () => {
   let originalFetch: typeof global.fetch;
 
-  beforeEach(() => {
-    originalFetch = global.fetch;
+  beforeEach(() => { originalFetch = global.fetch; });
+  afterEach(() => { global.fetch = originalFetch; vi.restoreAllMocks(); });
+
+  it("returns tool with correct schema", () => {
+    const tool = createWebFetchTool();
+    expect(tool.name).toBe("web_fetch");
+    expect(tool.parameters).toBeDefined();
   });
 
-  afterEach(() => {
-    global.fetch = originalFetch;
-    vi.restoreAllMocks();
+  it("rejects empty URL", async () => {
+    const result = await callTool(createWebFetchTool(), { url: "" });
+    expect(result).toContain("[error] URL cannot be empty");
   });
 
-  describe("createWebFetchTool", () => {
-    it("returns tool with correct schema", () => {
-      const tool = createWebFetchTool();
-      expect(tool.name).toBe("web_fetch");
-      expect(tool.description).toContain("web page");
-      expect(tool.parameters.required).toContain("url");
-    });
-
-    it("returns error for empty URL", async () => {
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "" });
-      expect(result).toContain("[error]");
-      expect(result).toContain("empty");
-    });
-
-    it("returns error for invalid URL", async () => {
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "not-a-url" });
-      expect(result).toContain("[error]");
-      expect(result).toContain("Invalid URL");
-    });
-
-    it("fetches and converts HTML to text", async () => {
-      const mockHtml = `
-        <!DOCTYPE html>
-        <html>
-          <head><title>Test Page</title></head>
-          <body>
-            <script>console.log("removed");</script>
-            <style>.removed {}</style>
-            <main>
-              <h1>Main Heading</h1>
-              <p>This is a paragraph.</p>
-              <a href="https://example.com">Link text</a>
-            </main>
-          </body>
-        </html>
-      `;
-
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        headers: new Map([["content-type", "text/html"]]),
-        text: () => Promise.resolve(mockHtml),
-      });
-
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "https://example.com/page" });
-
-      expect(result).toContain("Test Page");
-      expect(result).toContain("Main Heading");
-      expect(result).toContain("This is a paragraph");
-      expect(result).toContain("Link text");
-      expect(result).not.toContain("console.log");
-      expect(result).not.toContain(".removed");
-    });
-
-    it("handles non-HTML content", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        headers: new Map([["content-type", "application/json"]]),
-        text: () => Promise.resolve('{"key": "value"}'),
-      });
-
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "https://api.example.com/data" });
-
-      expect(result).toContain('{"key": "value"}');
-    });
-
-    it("handles HTTP error", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: "Not Found",
-      });
-
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "https://example.com/missing" });
-
-      expect(result).toContain("[error]");
-      expect(result).toContain("404");
-    });
-
-    it("handles network error", async () => {
-      global.fetch = vi.fn().mockRejectedValue(new Error("Connection refused"));
-
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "https://example.com" });
-
-      expect(result).toContain("[error]");
-      expect(result).toContain("Connection refused");
-    });
-
-    it("truncates long content", async () => {
-      const longContent = "x".repeat(100000);
-      const mockHtml = `<html><body><p>${longContent}</p></body></html>`;
-
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        headers: new Map([["content-type", "text/html"]]),
-        text: () => Promise.resolve(mockHtml),
-      });
-
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "https://example.com" });
-
-      expect(result).toContain("[Content truncated");
-      expect(result.length).toBeLessThan(100000);
-    });
-
-    it("extracts content from article tags", async () => {
-      const mockHtml = `
-        <html>
-          <body>
-            <div>Noise before</div>
-            <article>
-              <h2>Article Title</h2>
-              <p>Article content here.</p>
-            </article>
-            <div>Noise after</div>
-          </body>
-        </html>
-      `;
-
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        headers: new Map([["content-type", "text/html"]]),
-        text: () => Promise.resolve(mockHtml),
-      });
-
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "https://example.com" });
-
-      expect(result).toContain("Article Title");
-      expect(result).toContain("Article content");
-    });
-
-    it("handles list items", async () => {
-      const mockHtml = `
-        <html><body>
-          <ul>
-            <li>Item 1</li>
-            <li>Item 2</li>
-            <li>Item 3</li>
-          </ul>
-        </body></html>
-      `;
-
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        headers: new Map([["content-type", "text/html"]]),
-        text: () => Promise.resolve(mockHtml),
-      });
-
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "https://example.com" });
-
-      expect(result).toContain("• Item 1");
-      expect(result).toContain("• Item 2");
-    });
-
-    it("decodes HTML entities", async () => {
-      const mockHtml = `
-        <html><body>
-          <p>Less than: &lt; Greater than: &gt; Amp: &amp;</p>
-          <p>Quote: &quot; Apostrophe: &#39;</p>
-        </body></html>
-      `;
-
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        headers: new Map([["content-type", "text/html"]]),
-        text: () => Promise.resolve(mockHtml),
-      });
-
-      const tool = createWebFetchTool();
-      const result = await callTool(tool, { url: "https://example.com" });
-
-      expect(result).toContain("Less than: <");
-      expect(result).toContain("Greater than: >");
-      expect(result).toContain("Amp: &");
-    });
+  it("rejects invalid URL", async () => {
+    const result = await callTool(createWebFetchTool(), { url: "not-a-url" });
+    expect(result).toContain("[error] Invalid URL");
   });
 
-  describe("parseDuckDuckGoResults", () => {
-    it("parses results with uddg redirect URLs", () => {
-      const html = `
-        <div class="result">
-          <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage1&amp;rut=abc">Example Page 1</a>
-          <a class="result__snippet">This is the first snippet.</a>
-        </div>
-        <div class="result">
-          <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage2&amp;rut=def">Example Page 2</a>
-          <a class="result__snippet">This is the second snippet.</a>
-        </div>
-      `;
+  it("converts HTML to markdown preserving structure", async () => {
+    mockFetchHtml(`
+      <html><body>
+        <h1>Title</h1>
+        <p>Paragraph with <a href="https://example.com">link</a>.</p>
+        <ul><li>item one</li><li>item two</li></ul>
+      </body></html>
+    `);
 
-      const results = parseDuckDuckGoResults(html, 5);
-      expect(results).toHaveLength(2);
-      expect(results[0]).toEqual({
-        title: "Example Page 1",
-        url: "https://example.com/page1",
-        snippet: "This is the first snippet.",
-      });
-      expect(results[1]).toEqual({
-        title: "Example Page 2",
-        url: "https://example.com/page2",
-        snippet: "This is the second snippet.",
-      });
-    });
-
-    it("parses results with direct URLs", () => {
-      const html = `
-        <a class="result__a" href="https://direct.example.com">Direct Link</a>
-        <a class="result__snippet">Direct snippet.</a>
-      `;
-
-      const results = parseDuckDuckGoResults(html, 5);
-      expect(results).toHaveLength(1);
-      expect(results[0].url).toBe("https://direct.example.com");
-      expect(results[0].title).toBe("Direct Link");
-    });
-
-    it("strips HTML tags from titles", () => {
-      const html = `
-        <a class="result__a" href="https://example.com"><b>Bold</b> Title</a>
-        <a class="result__snippet">Snippet text.</a>
-      `;
-
-      const results = parseDuckDuckGoResults(html, 5);
-      expect(results[0].title).toBe("Bold Title");
-    });
-
-    it("respects count limit", () => {
-      const html = `
-        <a class="result__a" href="https://example.com/1">Result 1</a>
-        <a class="result__snippet">Snippet 1</a>
-        <a class="result__a" href="https://example.com/2">Result 2</a>
-        <a class="result__snippet">Snippet 2</a>
-        <a class="result__a" href="https://example.com/3">Result 3</a>
-        <a class="result__snippet">Snippet 3</a>
-      `;
-
-      const results = parseDuckDuckGoResults(html, 2);
-      expect(results).toHaveLength(2);
-    });
-
-    it("returns empty array when no results found", () => {
-      const html = `<html><body><div class="no-results">No results</div></body></html>`;
-      const results = parseDuckDuckGoResults(html, 5);
-      expect(results).toEqual([]);
-    });
-
-    it("handles missing snippets gracefully", () => {
-      const html = `
-        <a class="result__a" href="https://example.com/1">Result 1</a>
-        <a class="result__a" href="https://example.com/2">Result 2</a>
-        <a class="result__snippet">Only one snippet</a>
-      `;
-
-      const results = parseDuckDuckGoResults(html, 5);
-      expect(results).toHaveLength(2);
-      expect(results[0].snippet).toBe("Only one snippet");
-      expect(results[1].snippet).toBe("");
-    });
-
-    it("handles span-based snippets", () => {
-      const html = `
-        <a class="result__a" href="https://example.com">Title</a>
-        <span class="result__snippet">Span-based snippet.</span>
-      `;
-
-      const results = parseDuckDuckGoResults(html, 5);
-      expect(results[0].snippet).toBe("Span-based snippet.");
-    });
-
-    it("decodes HTML entities in results", () => {
-      const html = `
-        <a class="result__a" href="https://example.com">Tom &amp; Jerry&#39;s Page</a>
-        <a class="result__snippet">A &lt;great&gt; snippet with &quot;quotes&quot;.</a>
-      `;
-
-      const results = parseDuckDuckGoResults(html, 5);
-      expect(results[0].title).toBe("Tom & Jerry's Page");
-      expect(results[0].snippet).toBe('A <great> snippet with "quotes".');
-    });
+    const result = await callTool(createWebFetchTool(), { url: "https://example.com" });
+    expect(result).toContain("# Title");
+    expect(result).toContain("[link](https://example.com)");
+    expect(result).toMatch(/[*-]\s+item one/);
+    expect(result).toMatch(/[*-]\s+item two/);
   });
 
-  describe("createWebSearchTool", () => {
-    it("returns tool with correct schema", () => {
-      const tool = createWebSearchTool();
-      expect(tool.name).toBe("web_search");
-      expect(tool.description).toContain("DuckDuckGo");
-      expect(tool.parameters.required).toContain("query");
-      expect(tool.parameters.properties).toHaveProperty("query");
-      expect(tool.parameters.properties).toHaveProperty("count");
-      expect(tool.parameters.properties).toHaveProperty("region");
-    });
+  it("returns non-HTML content as-is", async () => {
+    mockFetchHtml('{"key":"value"}', "application/json");
 
-    it("returns error for empty query", async () => {
-      const tool = createWebSearchTool();
-      const result = await callTool(tool, { query: "" });
-      expect(result).toContain("[error]");
-      expect(result).toContain("empty");
-    });
+    const result = await callTool(createWebFetchTool(), { url: "https://api.example.com/data" });
+    expect(result).toContain('{"key":"value"}');
+  });
 
-    it("fetches and parses search results", async () => {
-      const mockHtml = `
-        <html><body>
-          <div class="result">
-            <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fresult&amp;rut=abc">Example Result</a>
-            <a class="result__snippet">This is a test snippet for the search.</a>
-          </div>
-          <div class="result">
-            <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fother.example.com&amp;rut=def">Other Result</a>
-            <a class="result__snippet">Another snippet here.</a>
-          </div>
-        </body></html>
-      `;
+  it("upgrades http to https for non-localhost URLs", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
+      text: async () => "<p>x</p>",
+    } as Response);
+    global.fetch = fetchMock;
 
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve(mockHtml),
-      });
+    await callTool(createWebFetchTool(), { url: "http://example.com" });
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toBe("https://example.com/");
+  });
 
-      const tool = createWebSearchTool();
-      const result = await callTool(tool, { query: "test search" });
+  it("does NOT upgrade http for localhost", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
+      text: async () => "<p>x</p>",
+    } as Response);
+    global.fetch = fetchMock;
 
-      expect(result).toContain("Search results");
-      expect(result).toContain("Example Result");
-      expect(result).toContain("https://example.com/result");
-      expect(result).toContain("This is a test snippet");
-      expect(result).toContain("Other Result");
+    await callTool(createWebFetchTool(), { url: "http://localhost:8080/page" });
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toBe("http://localhost:8080/page");
+  });
 
-      // Verify fetch was called with correct URL
-      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(fetchCall[0]).toContain("html.duckduckgo.com/html/");
-      expect(fetchCall[0]).toContain("q=test+search");
-    });
+  it("returns error on non-2xx response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false, status: 404, statusText: "Not Found",
+      headers: new Map() as unknown as Headers,
+      text: async () => "",
+    } as Response);
 
-    it("passes region parameter as kl", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve("<html></html>"),
-      });
+    const result = await callTool(createWebFetchTool(), { url: "https://example.com/missing" });
+    expect(result).toContain("[error] Failed to fetch");
+    expect(result).toContain("404");
+  });
 
-      const tool = createWebSearchTool();
-      await callTool(tool, { query: "test", region: "us-en" });
+  it("uses honest User-Agent (not faked Chrome)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
+      text: async () => "<p>x</p>",
+    } as Response);
+    global.fetch = fetchMock;
 
-      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(fetchCall[0]).toContain("kl=us-en");
-    });
+    await callTool(createWebFetchTool(), { url: "https://example.com" });
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe("isotopes-web/0.1");
+  });
 
-    it("clamps count to valid range", async () => {
-      const mockHtml = `
-        <a class="result__a" href="https://example.com/1">R1</a>
-        <a class="result__snippet">S1</a>
-        <a class="result__a" href="https://example.com/2">R2</a>
-        <a class="result__snippet">S2</a>
-        <a class="result__a" href="https://example.com/3">R3</a>
-        <a class="result__snippet">S3</a>
-      `;
+  it("truncates content over 50KB", async () => {
+    const huge = "x".repeat(60000);
+    mockFetchHtml(`<html><body><pre>${huge}</pre></body></html>`);
 
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve(mockHtml),
-      });
-
-      const tool = createWebSearchTool();
-      const result = await callTool(tool, { query: "test", count: 2 });
-
-      // Should only show 2 results
-      expect(result).toContain("1. R1");
-      expect(result).toContain("2. R2");
-      expect(result).not.toContain("3. R3");
-    });
-
-    it("returns message when no results found", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve("<html><body>No results</body></html>"),
-      });
-
-      const tool = createWebSearchTool();
-      const result = await callTool(tool, { query: "xyznonexistent" });
-
-      expect(result).toContain("No results found");
-    });
-
-    it("handles HTTP error", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 503,
-        statusText: "Service Unavailable",
-      });
-
-      const tool = createWebSearchTool();
-      const result = await callTool(tool, { query: "test" });
-
-      expect(result).toContain("[error]");
-      expect(result).toContain("503");
-    });
-
-    it("handles network error", async () => {
-      global.fetch = vi.fn().mockRejectedValue(new Error("Network timeout"));
-
-      const tool = createWebSearchTool();
-      const result = await callTool(tool, { query: "test" });
-
-      expect(result).toContain("[error]");
-      expect(result).toContain("Network timeout");
-    });
+    const result = await callTool(createWebFetchTool(), { url: "https://example.com" });
+    expect(result).toContain("[truncated]");
+    expect(result.length).toBeLessThan(60000);
   });
 });

--- a/src/agent/tools/web.ts
+++ b/src/agent/tools/web.ts
@@ -1,34 +1,26 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "typebox";
+import { NodeHtmlMarkdown } from "node-html-markdown";
+
+const MAX_CONTENT_LENGTH = 50000;
+const REQUEST_TIMEOUT = 30000;
+const USER_AGENT = "isotopes-web/0.1";
 
 function textResult(text: string): AgentToolResult<undefined> {
   return { content: [{ type: "text", text }], details: undefined };
 }
 
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
+/** Upgrade non-localhost http URLs to https to reduce passive interception risk. */
+function upgradeToHttps(rawUrl: string): string {
+  const u = new URL(rawUrl);
+  if (u.protocol !== "http:") return u.toString();
+  if (u.hostname === "localhost" || u.hostname === "127.0.0.1" || u.hostname === "::1") return u.toString();
+  u.protocol = "https:";
+  return u.toString();
+}
 
-/** Maximum content length to return (prevent context overflow) */
-const MAX_CONTENT_LENGTH = 50000;
-
-/** User agent for HTTP requests */
-const USER_AGENT =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-
-/** Request timeout in ms */
-const REQUEST_TIMEOUT = 30000;
-
-// ---------------------------------------------------------------------------
-// Web Fetch Tool (HTTP GET + HTML to text)
-// ---------------------------------------------------------------------------
-
-/**
- * Fetch a URL and convert HTML to readable text.
- */
 async function fetchAndConvert(url: string): Promise<string> {
-  const response = await fetch(url, {
-    method: "GET",
+  const response = await fetch(upgradeToHttps(url), {
     headers: {
       "User-Agent": USER_AGENT,
       Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -42,87 +34,14 @@ async function fetchAndConvert(url: string): Promise<string> {
   }
 
   const contentType = response.headers.get("content-type") || "";
-  const html = await response.text();
+  const body = await response.text();
 
-  // If it's not HTML, return as-is (might be plain text, JSON, etc.)
   if (!contentType.includes("html")) {
-    return truncateContent(html, MAX_CONTENT_LENGTH);
+    return body.length > MAX_CONTENT_LENGTH ? body.slice(0, MAX_CONTENT_LENGTH) + "\n\n[truncated]" : body;
   }
 
-  // Convert HTML to readable text
-  const text = htmlToText(html);
-  return truncateContent(text, MAX_CONTENT_LENGTH);
-}
-
-/**
- * Convert HTML to readable plain text.
- * Extracts main content and removes boilerplate.
- */
-function htmlToText(html: string): string {
-  // Remove script, style, nav, header, footer, aside
-  let text = html
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<nav[\s\S]*?<\/nav>/gi, "")
-    .replace(/<header[\s\S]*?<\/header>/gi, "")
-    .replace(/<footer[\s\S]*?<\/footer>/gi, "")
-    .replace(/<aside[\s\S]*?<\/aside>/gi, "")
-    .replace(/<!--[\s\S]*?-->/g, "");
-
-  // Try to extract main content
-  const mainMatch = text.match(/<main[\s\S]*?<\/main>/i)
-    || text.match(/<article[\s\S]*?<\/article>/i)
-    || text.match(/<div[^>]*(?:class|id)="[^"]*(?:content|main|article)[^"]*"[\s\S]*?<\/div>/i);
-
-  if (mainMatch) {
-    text = mainMatch[0];
-  }
-
-  // Extract title
-  const titleMatch = html.match(/<title>([^<]+)<\/title>/i);
-  const title = titleMatch ? decodeHtmlEntities(titleMatch[1].trim()) : "";
-
-  // Convert HTML to plain text
-  text = text
-    // Headings to text with newlines
-    .replace(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi, "\n\n$1\n\n")
-    // Paragraphs
-    .replace(/<p[^>]*>/gi, "\n\n")
-    .replace(/<\/p>/gi, "")
-    // Line breaks
-    .replace(/<br\s*\/?>/gi, "\n")
-    // Lists
-    .replace(/<li[^>]*>/gi, "\n• ")
-    .replace(/<\/li>/gi, "")
-    // Links - keep text
-    .replace(/<a[^>]*>([\s\S]*?)<\/a>/gi, "$1")
-    // Remove remaining tags
-    .replace(/<[^>]+>/g, "")
-    // Decode entities
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)));
-
-  // Clean up whitespace
-  text = text
-    .replace(/\n{3,}/g, "\n\n")
-    .replace(/[ \t]+/g, " ")
-    .split("\n")
-    .map((line) => line.trim())
-    .join("\n")
-    .trim();
-
-  // Prepend title if found
-  if (title) {
-    text = `# ${title}\n\n${text}`;
-  }
-
-  return text;
+  const md = NodeHtmlMarkdown.translate(body);
+  return md.length > MAX_CONTENT_LENGTH ? md.slice(0, MAX_CONTENT_LENGTH) + "\n\n[truncated]" : md;
 }
 
 const webFetchSchema = Type.Object({
@@ -134,7 +53,7 @@ export function createWebFetchTool(): AgentTool<typeof webFetchSchema> {
     name: "web_fetch",
     label: "web_fetch",
     description:
-      "Fetch and read the content of a web page. Converts HTML to readable text. Use to read documentation, articles, or any URL directly.",
+      "Fetch a URL and return its content as markdown. HTML pages are converted to markdown preserving headings, links, lists, and code blocks. Non-HTML responses (JSON, plain text) are returned as-is. Truncated at 50KB.",
     parameters: webFetchSchema,
     execute: async (_id, { url }) => {
       if (!url || url.trim().length === 0) return textResult("[error] URL cannot be empty");
@@ -148,123 +67,4 @@ export function createWebFetchTool(): AgentTool<typeof webFetchSchema> {
       }
     },
   };
-}
-
-// ---------------------------------------------------------------------------
-// Web Search Tool (DuckDuckGo HTML scraping)
-// ---------------------------------------------------------------------------
-
-/** A single search result. */
-export interface SearchResult {
-  title: string;
-  url: string;
-  snippet: string;
-}
-
-/**
- * Parse DuckDuckGo HTML search results into structured data.
- */
-export function parseDuckDuckGoResults(html: string, count: number): SearchResult[] {
-  const results: SearchResult[] = [];
-
-  // Match result links: <a rel="nofollow" class="result__a" href="URL">Title</a>
-  const linkRegex = /<a[^>]*class="result__a"[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi;
-  // Match snippets: <a class="result__snippet" ...>Snippet</a> or <span class="result__snippet">...</span>
-  const snippetRegex = /<(?:a|span)[^>]*class="result__snippet"[^>]*>([\s\S]*?)<\/(?:a|span)>/gi;
-
-  const links: { url: string; title: string }[] = [];
-  let match: RegExpExecArray | null;
-
-  while ((match = linkRegex.exec(html)) !== null) {
-    let url = match[1];
-    // DuckDuckGo wraps URLs in a redirect — extract actual URL
-    const uddgMatch = url.match(/[?&]uddg=([^&]+)/);
-    if (uddgMatch) {
-      url = decodeURIComponent(uddgMatch[1]);
-    }
-    const title = decodeHtmlEntities(match[2].replace(/<[^>]+>/g, "").trim());
-    if (title && url) {
-      links.push({ url, title });
-    }
-  }
-
-  const snippets: string[] = [];
-  while ((match = snippetRegex.exec(html)) !== null) {
-    const snippet = decodeHtmlEntities(match[1].replace(/<[^>]+>/g, "").trim());
-    snippets.push(snippet);
-  }
-
-  for (let i = 0; i < Math.min(links.length, count); i++) {
-    results.push({
-      title: links[i].title,
-      url: links[i].url,
-      snippet: snippets[i] || "",
-    });
-  }
-
-  return results;
-}
-
-const webSearchSchema = Type.Object({
-  query: Type.String({ description: "Search query" }),
-  count: Type.Optional(Type.Number({ description: "Number of results (1-10, default 5)" })),
-  region: Type.Optional(Type.String({ description: "Region code (e.g., 'us-en', 'uk-en')" })),
-});
-
-export function createWebSearchTool(): AgentTool<typeof webSearchSchema> {
-  return {
-    name: "web_search",
-    label: "web_search",
-    description: "Search the web using DuckDuckGo. Returns titles, URLs, and snippets.",
-    parameters: webSearchSchema,
-    execute: async (_id, { query, count: rawCount, region }) => {
-      if (!query || query.trim().length === 0) return textResult("[error] Search query cannot be empty");
-      const count = Math.max(1, Math.min(10, rawCount ?? 5));
-      const params = new URLSearchParams({ q: query });
-      if (region) params.set("kl", region);
-      const url = `https://html.duckduckgo.com/html/?${params.toString()}`;
-      try {
-        const response = await fetch(url, {
-          method: "GET",
-          headers: { "User-Agent": USER_AGENT, Accept: "text/html" },
-          signal: AbortSignal.timeout(REQUEST_TIMEOUT),
-          redirect: "follow",
-        });
-        if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        const html = await response.text();
-        const results = parseDuckDuckGoResults(html, count);
-        if (results.length === 0) return textResult(`No results found for "${query}"`);
-        const formatted = results
-          .map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.snippet}`)
-          .join("\n\n");
-        return textResult(`Search results for "${query}":\n\n${formatted}`);
-      } catch (error) {
-        const err = error instanceof Error ? error.message : String(error);
-        return textResult(`[error] Search failed: ${err}`);
-      }
-    },
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)));
-}
-
-function truncateContent(content: string, maxLength: number): string {
-  if (content.length <= maxLength) {
-    return content;
-  }
-  return content.slice(0, maxLength) + "\n\n[Content truncated - original length: " + content.length + " chars]";
 }

--- a/tests/e2e-smoke.test.ts
+++ b/tests/e2e-smoke.test.ts
@@ -157,7 +157,6 @@ describe("full tool wiring", () => {
       workspacePath: tmpDir,
       agentId: "test",
       processRegistry: new ProcessRegistry(),
-      settings: { web: true },
     });
     const names = new Set(all.map((t) => t.name));
 
@@ -167,7 +166,6 @@ describe("full tool wiring", () => {
     expect(names.has("ls")).toBe(true);
     expect(names.has("exec")).toBe(true);
     expect(names.has("web_fetch")).toBe(true);
-    expect(names.has("web_search")).toBe(true);
     expect(names.has("get_current_time")).toBe(true);
     expect(names.has("process_list")).toBe(true);
     expect(names.has("process_kill")).toBe(true);


### PR DESCRIPTION
## Why

Inspired by Claude Code: \`web_fetch\` should return **markdown** (preserving headings, links, lists, code blocks), not plain text. Our previous hand-written HTML→text was both brittle and information-lossy.

\`web_search\` was a DuckDuckGo HTML scraper with no fallback, no provider config, and a silent failure mode (\"No results\" looks identical to \"parse failed\"). Removing it now; #719 tracks the proper provider-pluggable replacement.

## Changes

- **web_fetch**: HTML → markdown via \`node-html-markdown\`. Drop the 70-line hand-written htmlToText (script/style/nav strip + main/article extraction + entity decode + tag remove — the library does all this correctly).
- **web_fetch polish** (from claw-code): honest User-Agent (\`isotopes-web/0.1\`, not faked Chrome), HTTPS upgrade for non-localhost http URLs.
- **Drop \`settings.web\` flag**: was a dead toggle — never plumbed from YAML, so web tools were never actually registered. Now web_fetch registers unconditionally.
- **Delete web_search**: tool + DDG parser + tests. See #719 for the replacement plan.

## Numbers

- \`web.ts\`: 270 → 75 lines
- \`web.test.ts\`: 440 → 130 lines (rewritten — covers HTML→md, HTTPS upgrade, UA, truncation)
- Total: -640 / +211 lines, +1 dep

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (813 / 813 passing)

Refs #719