### PR TITLE
refactor: #623 — fold legacy/commands into src/gateway

### DIFF
--- a/src/gateway/commands.test.ts
+++ b/src/gateway/commands.test.ts
@@ -1,10 +1,8 @@
-// src/commands/slash-commands.test.ts — Tests for slash command handler
-
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { SlashCommandHandler, type CommandContext } from "./slash-commands.js";
-import { createMockSessionStore } from "../../test-helpers.js";
-import type { AgentRuntime } from "../../agent/runtime.js";
-import type { AgentConfig } from "../../agent/types.js";
+import { SlashCommandHandler, type CommandContext } from "./commands.js";
+import { createMockSessionStore } from "../test-helpers.js";
+import type { AgentRuntime } from "../agent/runtime.js";
+import type { AgentConfig } from "../agent/types.js";
 
 interface FakeAgent {
   id: string;

--- a/src/gateway/commands.ts
+++ b/src/gateway/commands.ts
@@ -1,9 +1,6 @@
-// src/commands/slash-commands.ts — Slash command handler for admin operations
-// Parses and dispatches /status, /reload, /model commands from chat messages.
-
-import type { SessionStore } from "../../sessions/types.js";
-import type { AgentRuntime } from "../../agent/runtime.js";
-import { createLogger } from "../../logging/logger.js";
+import type { SessionStore } from "../sessions/types.js";
+import type { AgentRuntime } from "../agent/runtime.js";
+import { createLogger } from "../logging/logger.js";
 
 const log = createLogger("commands");
 
@@ -20,9 +17,9 @@ export interface CommandContext {
   sessionStore: SessionStore;
   /** The agent ID this message was routed to */
   agentId: string;
-  /** Discord user ID of the invoker */
+  /** Stable user ID of the invoker (transport-specific) */
   userId: string;
-  /** Discord username of the invoker */
+  /** Display name of the invoker (transport-specific) */
   username: string;
   /** Current session ID (if available) */
   sessionId?: string;

--- a/src/legacy/plugins/discord/discord.ts
+++ b/src/legacy/plugins/discord/discord.ts
@@ -31,7 +31,7 @@ import { buildSessionKey } from "../../../gateway/session-keys.js";
 import { ChannelHistoryBuffer, buildHistoryContext } from "../../../gateway/channel-history.js";
 import { DedupeCache } from "../../../gateway/dedupe.js";
 import { InboundDebouncer } from "../../../gateway/debounce.js";
-import { SlashCommandHandler } from "../../commands/slash-commands.js";
+import { SlashCommandHandler } from "../../../gateway/commands.js";
 
 const log = loggers.discord;
 


### PR DESCRIPTION
Part of #623.

## Summary
\`slash-commands\` is an inbound-message decoder — parses \`/foo args\` from chat text, decides whether to short-circuit into the admin handler or pass through to the agent. Same family as \`gateway/mention.ts\` (parses @-mentions) and \`gateway/dedupe.ts\` (filters duplicates).

Folded into \`src/gateway/commands.ts\` instead of a top-level \`src/commands/\` (the strawman in #623). Rationale posted as a comment on #623.

## Changes
- \`src/legacy/commands/slash-commands{,.test}.ts\` → \`src/gateway/commands{,.test}.ts\`
- Drop \`slash-\` prefix from filename (the \`gateway/\` directory + \`SlashCommandHandler\` class name already convey it)
- Drop "Discord user ID" / "Discord username" comments — the type is platform-agnostic, only the comments were Discord-specific
- Drop stale path-banner header comments
- Update Discord transport import path
- \`src/legacy/commands/\` directory is gone

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (830/830 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)