### PR TITLE
refactor(agent): unified Executor abstraction + drop broken background exec (#722, #734)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,6 @@ pnpm test:integration
 - `plugins/` — Plugin system (`hooks.ts`, `manager.ts`, `tool-registry.ts`, `ui-registry.ts`, `discovery.ts`, `api.ts`).
 - `plugins/discord/` — Discord transport: channels, threads, DMs, mention handling, per-account `agentBindings`, `ThreadBindingManager`, message metadata, reply directives.
 - `plugins/http/` — REST API server using raw Node `http` (no Express); routes for chat, sessions, cron, logs, status.
-- `tools/exec.ts` — Shell exec tool (`exec`, `process_list`, `process_kill`).
 - `version.ts` — Build version constant.
 
 ### Key patterns

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -126,23 +126,13 @@ docker exec -it isotopes-sandbox-<agent-id> claude
 Credentials must be mounted into the container (e.g. via `docker.binds`) —
 they are not forwarded from the host automatically.
 
-## Background processes
-
-`exec` with `background: true` works in sandbox mode: the host spawns a
-`docker exec -i <ctr> sh -c <cmd>` child and tracks the host-side
-`ChildProcess`. `process_kill` sends SIGTERM to that child, which docker
-forwards into the container (default `--sig-proxy=true`).
-
 ## Verifying
 
 After enabling and building the image:
 
 1. Trigger any agent → ask it to run `whoami` and `cat /etc/os-release`.
    You should see `agent` and `Debian`, not your host user / macOS.
-2. Run `exec` with `background: true sleep 30`, then `process_list` (status
-   running) and `docker exec <ctr> ps -ef` (sleep visible). Then
-   `process_kill` and confirm status moves to `exited`.
-3. Stop isotopes (Ctrl+C). `docker ps -a | grep isotopes-sandbox-` should
+2. Stop isotopes (Ctrl+C). `docker ps -a | grep isotopes-sandbox-` should
    be empty — `SandboxExecutor.cleanup()` runs in the SIGINT/SIGTERM
    handlers.
 

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -9,7 +9,6 @@ export interface ExecResult {
 export interface ExecOptions {
   /** Working directory. Sandbox honors at container-create time, not per-call. */
   workspacePath?: string;
-  /** Hard deadline in ms; rejects on expiry. */
   timeout?: number;
   stdin?: Buffer | string;
 }
@@ -17,7 +16,6 @@ export interface ExecOptions {
 /**
  * Per-agent command execution. HostExecutor runs on the host process;
  * SandboxExecutor.bind(agentId) runs inside the agent's container.
- * Tools take an Executor and don't know which backend they got.
  */
 export interface Executor {
   execute(argv: string[], opts?: ExecOptions): Promise<ExecResult>;

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -7,11 +7,10 @@ export interface ExecResult {
 }
 
 export interface ExecOptions {
-  /** Working directory for the command. Sandbox honors at container-create time, not per-call. */
+  /** Working directory. Sandbox honors at container-create time, not per-call. */
   workspacePath?: string;
-  /** Hard deadline in milliseconds; rejects if exceeded. */
+  /** Hard deadline in ms; rejects on expiry. */
   timeout?: number;
-  /** Bytes piped to stdin. */
   stdin?: Buffer | string;
 }
 
@@ -21,7 +20,6 @@ export interface ExecOptions {
  * Tools take an Executor and don't know which backend they got.
  */
 export interface Executor {
-  /** Run argv synchronously; returns once the process exits. */
   execute(argv: string[], opts?: ExecOptions): Promise<ExecResult>;
 
   /**

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -1,0 +1,34 @@
+export interface ExecResult {
+  exitCode: number;
+  stdout: Buffer;
+  stderr: Buffer;
+  /** True iff stdout or stderr was capped at EXEC_MAX_OUTPUT_BYTES. */
+  truncated?: boolean;
+}
+
+export interface ExecOptions {
+  /** Working directory for the command. Sandbox honors at container-create time, not per-call. */
+  workspacePath?: string;
+  /** Hard deadline in milliseconds; rejects if exceeded. */
+  timeout?: number;
+  /** Bytes piped to stdin. */
+  stdin?: Buffer | string;
+}
+
+/**
+ * Per-agent command execution. HostExecutor runs on the host process;
+ * SandboxExecutor.bind(agentId) runs inside the agent's container.
+ * Tools take an Executor and don't know which backend they got.
+ */
+export interface Executor {
+  /** Run argv synchronously; returns once the process exits. */
+  execute(argv: string[], opts?: ExecOptions): Promise<ExecResult>;
+
+  /**
+   * Returns the host-side argv to spawn for this command. HostExecutor
+   * returns argv as-is; SandboxExecutor prepends `docker exec -i <ctr>`.
+   * Used by background-process tracking — caller spawns the returned argv
+   * itself so it can keep the ChildProcess handle.
+   */
+  buildExecArgv(argv: string[], opts?: ExecOptions): Promise<string[]>;
+}

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -1,3 +1,6 @@
+/** Cap collected stdout/stderr per `execute()` call to prevent OOM from runaway commands. */
+export const EXEC_MAX_OUTPUT_BYTES = 100 * 1024;
+
 export interface ExecResult {
   exitCode: number;
   stdout: Buffer;

--- a/src/agent/host-executor.ts
+++ b/src/agent/host-executor.ts
@@ -3,10 +3,7 @@ import type { Executor, ExecOptions, ExecResult } from "./executor.js";
 
 const EXEC_MAX_OUTPUT_BYTES = 100 * 1024;
 
-/**
- * Runs commands in the host process. Used for non-sandboxed agents.
- * Thin wrapper over child_process.spawn — host = trust model.
- */
+/** Thin wrapper over child_process.spawn — host = trust model, no cwd jail / env scrub. */
 export class HostExecutor implements Executor {
   async execute(argv: string[], opts?: ExecOptions): Promise<ExecResult> {
     if (argv.length === 0) {

--- a/src/agent/host-executor.ts
+++ b/src/agent/host-executor.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import type { Executor, ExecOptions, ExecResult } from "./executor.js";
+
+const EXEC_MAX_OUTPUT_BYTES = 100 * 1024;
+
+/**
+ * Runs commands in the host process. Used for non-sandboxed agents.
+ * Thin wrapper over child_process.spawn — host = trust model.
+ */
+export class HostExecutor implements Executor {
+  async execute(argv: string[], opts?: ExecOptions): Promise<ExecResult> {
+    if (argv.length === 0) {
+      return { exitCode: 1, stdout: Buffer.alloc(0), stderr: Buffer.from("argv is empty") };
+    }
+
+    return new Promise<ExecResult>((resolve, reject) => {
+      const child = spawn(argv[0], argv.slice(1), {
+        cwd: opts?.workspacePath,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      let stdoutTruncated = false;
+      let stderrTruncated = false;
+
+      const collect = (chunks: Buffer[], chunk: Buffer, getBytes: () => number, setBytes: (n: number) => void, setTruncated: (b: boolean) => void): void => {
+        const bytes = getBytes();
+        if (bytes >= EXEC_MAX_OUTPUT_BYTES) { setTruncated(true); return; }
+        if (bytes + chunk.length > EXEC_MAX_OUTPUT_BYTES) {
+          chunks.push(chunk.subarray(0, EXEC_MAX_OUTPUT_BYTES - bytes));
+          setBytes(EXEC_MAX_OUTPUT_BYTES);
+          setTruncated(true);
+        } else {
+          chunks.push(chunk);
+          setBytes(bytes + chunk.length);
+        }
+      };
+
+      child.stdout?.on("data", (chunk: Buffer) =>
+        collect(stdoutChunks, chunk, () => stdoutBytes, (n) => { stdoutBytes = n; }, (b) => { stdoutTruncated = b; }));
+      child.stderr?.on("data", (chunk: Buffer) =>
+        collect(stderrChunks, chunk, () => stderrBytes, (n) => { stderrBytes = n; }, (b) => { stderrTruncated = b; }));
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let timedOut = false;
+      if (opts?.timeout) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGTERM");
+          reject(new Error(`Host execution timed out after ${opts.timeout}ms`));
+        }, opts.timeout);
+      }
+
+      child.on("error", (err) => {
+        if (timer) clearTimeout(timer);
+        reject(err);
+      });
+
+      child.on("close", (code) => {
+        if (timer) clearTimeout(timer);
+        if (timedOut) return;  // already rejected by timer
+        const truncMarker = Buffer.from(`\n[output truncated at ${EXEC_MAX_OUTPUT_BYTES} bytes]`, "utf8");
+        const stdout = stdoutTruncated ? Buffer.concat([...stdoutChunks, truncMarker]) : Buffer.concat(stdoutChunks);
+        const stderr = stderrTruncated ? Buffer.concat([...stderrChunks, truncMarker]) : Buffer.concat(stderrChunks);
+        resolve({
+          exitCode: code ?? 0,
+          stdout,
+          stderr,
+          ...(stdoutTruncated || stderrTruncated ? { truncated: true } : {}),
+        });
+      });
+
+      if (opts?.stdin !== undefined) {
+        child.stdin?.end(opts.stdin);
+      } else {
+        child.stdin?.end();
+      }
+    });
+  }
+
+  async buildExecArgv(argv: string[]): Promise<string[]> {
+    return argv;
+  }
+}

--- a/src/agent/host-executor.ts
+++ b/src/agent/host-executor.ts
@@ -1,7 +1,5 @@
 import { spawn } from "node:child_process";
-import type { Executor, ExecOptions, ExecResult } from "./executor.js";
-
-const EXEC_MAX_OUTPUT_BYTES = 100 * 1024;
+import { EXEC_MAX_OUTPUT_BYTES, type Executor, type ExecOptions, type ExecResult } from "./executor.js";
 
 /** Thin wrapper over child_process.spawn — host = trust model, no cwd jail / env scrub. */
 export class HostExecutor implements Executor {

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -36,7 +36,6 @@ import { seedWorkspaceTemplates } from "./workspace/templates.js";
 import { reconcileWorkspaceState } from "./workspace/state.js";
 import { createAgentTools } from "./tools/index.js";
 import { LazyTransportContext } from "../gateway/transport-context.js";
-import { ProcessRegistry } from "./tools/exec.js";
 import type { DefaultSessionStore } from "./runners/pi/session-store.js";
 
 const log = createLogger("agents:runtime");
@@ -82,7 +81,6 @@ export interface AddAgentResult {
   /** null when the runner has no workspace (e.g. claude). */
   workspacePath: string | null;
   tools: AgentTool[];
-  processRegistry: ProcessRegistry;
   transportContext?: LazyTransportContext;
 }
 
@@ -224,7 +222,7 @@ export class AgentRuntime {
     };
     this.registerRunner(agentConfig.id, new ClaudeRunner(), { spawnable: agentConfig.spawnable === true });
     log.info(`Added agent: ${agent.id} (runner: claude)`);
-    return { agent, workspacePath: null, processRegistry: new ProcessRegistry(), tools: [] };
+    return { agent, workspacePath: null, tools: [] };
   }
 
   private async registerPi(
@@ -250,13 +248,11 @@ export class AgentRuntime {
     await reconcileWorkspaceState(workspacePath);
     await ensureWorkspaceStructure(workspacePath);
 
-    const processRegistry = new ProcessRegistry();
     const tools: AgentTool[] = createAgentTools({
       workspacePath,
       settings: agentConfig.toolSettings,
       parentAgentId: agentConfig.id,
       agentId: agentConfig.id,
-      processRegistry,
       agentSandboxConfig: agentConfig.sandbox,
       transportContext,
       runtime: this,
@@ -284,7 +280,6 @@ export class AgentRuntime {
     return {
       agent,
       workspacePath,
-      processRegistry,
       tools,
       ...(transportContext ? { transportContext } : {}),
     };

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -36,7 +36,7 @@ import { seedWorkspaceTemplates } from "./workspace/templates.js";
 import { reconcileWorkspaceState } from "./workspace/state.js";
 import { createAgentTools } from "./tools/index.js";
 import { LazyTransportContext } from "../gateway/transport-context.js";
-import { ProcessRegistry } from "../legacy/tools/exec.js";
+import { ProcessRegistry } from "./tools/exec.js";
 import type { DefaultSessionStore } from "./runners/pi/session-store.js";
 
 const log = createLogger("agents:runtime");

--- a/src/agent/tools/exec.test.ts
+++ b/src/agent/tools/exec.test.ts
@@ -39,6 +39,7 @@ function createFakeChild(delayMs: number, exitCode = 0): ChildProcess {
       if (!child._killed) {
         child._killed = true;
         child.emit("exit", signal === "SIGTERM" ? 137 : exitCode, signal ?? null);
+        child.emit("close", signal === "SIGTERM" ? 137 : exitCode, signal ?? null);
       }
       return true;
     }),
@@ -49,6 +50,7 @@ function createFakeChild(delayMs: number, exitCode = 0): ChildProcess {
       if (!child._killed) {
         child._killed = true;
         child.emit("exit", exitCode, null);
+        child.emit("close", exitCode, null);
       }
     }, delayMs);
   }
@@ -58,6 +60,17 @@ function createFakeChild(delayMs: number, exitCode = 0): ChildProcess {
 
 /** Mapping of command patterns to fake child behavior. */
 function fakeChildForCommand(cmd: string): ChildProcess {
+  // Strip "sh -c " wrapper — every command now goes through `sh -c` via Executor.
+  if (cmd.startsWith("sh -c ")) cmd = cmd.slice(6);
+  // Crude shell `>&2` redirect — emit on stderr instead of stdout
+  if (cmd.includes(">&2")) {
+    const text = cmd.replace(/\s*>&2\s*$/, "").replace(/^echo\s+/, "");
+    const child = createFakeChild(0, 0);
+    process.nextTick(() => {
+      child.stderr!.emit("data", Buffer.from(text + "\n"));
+    });
+    return child;
+  }
   if (cmd.startsWith("echo ")) {
     const text = cmd.slice(5);
     const child = createFakeChild(0, 0);
@@ -101,6 +114,7 @@ import {
   createProcessKillTool,
   createExecTools,
 } from "./exec.js";
+import { HostExecutor } from "../host-executor.js";
 
 // ---------------------------------------------------------------------------
 // ProcessRegistry
@@ -118,7 +132,7 @@ describe("ProcessRegistry", () => {
   });
 
   it("spawns a process and assigns an id", () => {
-    const info = registry.spawn("echo hello", process.cwd());
+    const info = registry.spawn("echo hello", ["sh", "-c", "echo hello"], process.cwd());
     expect(info.process_id).toBe("proc_1");
     expect(info.command).toBe("echo hello");
     expect(info.status).toBe("running");
@@ -126,26 +140,26 @@ describe("ProcessRegistry", () => {
   });
 
   it("assigns incrementing ids", () => {
-    const a = registry.spawn("echo a", process.cwd());
-    const b = registry.spawn("echo b", process.cwd());
+    const a = registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
+    const b = registry.spawn("echo b", ["sh", "-c", "echo b"], process.cwd());
     expect(a.process_id).toBe("proc_1");
     expect(b.process_id).toBe("proc_2");
   });
 
   it("lists all processes", () => {
-    registry.spawn("echo a", process.cwd());
-    registry.spawn("echo b", process.cwd());
+    registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
+    registry.spawn("echo b", ["sh", "-c", "echo b"], process.cwd());
     expect(registry.list()).toHaveLength(2);
   });
 
   it("gets process by id", () => {
-    const info = registry.spawn("echo test", process.cwd());
+    const info = registry.spawn("echo test", ["sh", "-c", "echo test"], process.cwd());
     expect(registry.get(info.process_id)).toBe(info);
     expect(registry.get("nonexistent")).toBeUndefined();
   });
 
   it("kills a running process", () => {
-    const info = registry.spawn("sleep 60", process.cwd());
+    const info = registry.spawn("sleep 60", ["sh", "-c", "sleep 60"], process.cwd());
     expect(registry.kill(info.process_id)).toBe(true);
     expect(info.status).toBe("exited");
   });
@@ -155,15 +169,15 @@ describe("ProcessRegistry", () => {
   });
 
   it("clears all processes", () => {
-    registry.spawn("echo a", process.cwd());
-    registry.spawn("echo b", process.cwd());
+    registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
+    registry.spawn("echo b", ["sh", "-c", "echo b"], process.cwd());
     registry.clear();
     expect(registry.list()).toHaveLength(0);
   });
 
   it("tracks completed process count", async () => {
-    const a = registry.spawn("echo a", process.cwd());
-    const b = registry.spawn("sleep 60", process.cwd());
+    const a = registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
+    const b = registry.spawn("sleep 60", ["sh", "-c", "sleep 60"], process.cwd());
 
     // Wait for first process to complete
     await new Promise((r) => setTimeout(r, 100));
@@ -173,8 +187,8 @@ describe("ProcessRegistry", () => {
   });
 
   it("cleans up completed processes manually", async () => {
-    registry.spawn("echo a", process.cwd());
-    registry.spawn("echo b", process.cwd());
+    registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
+    registry.spawn("echo b", ["sh", "-c", "echo b"], process.cwd());
     
     // Wait for processes to complete
     await new Promise((r) => setTimeout(r, 100));
@@ -189,11 +203,11 @@ describe("ProcessRegistry", () => {
     const smallRegistry = new ProcessRegistry({ maxCompleted: 2 });
     
     // Spawn 3 processes that complete immediately
-    smallRegistry.spawn("echo 1", process.cwd());
+    smallRegistry.spawn("echo 1", ["sh", "-c", "echo 1"], process.cwd());
     await new Promise((r) => setTimeout(r, 50));
-    smallRegistry.spawn("echo 2", process.cwd());
+    smallRegistry.spawn("echo 2", ["sh", "-c", "echo 2"], process.cwd());
     await new Promise((r) => setTimeout(r, 50));
-    smallRegistry.spawn("echo 3", process.cwd());
+    smallRegistry.spawn("echo 3", ["sh", "-c", "echo 3"], process.cwd());
     await new Promise((r) => setTimeout(r, 100));
     
     // Should have evicted oldest, keeping only 2
@@ -208,9 +222,11 @@ describe("ProcessRegistry", () => {
 
 describe("exec tool", () => {
   let registry: ProcessRegistry;
+  let executor: HostExecutor;
 
   beforeEach(() => {
     registry = new ProcessRegistry();
+    executor = new HostExecutor();
   });
 
   afterEach(() => {
@@ -218,20 +234,20 @@ describe("exec tool", () => {
   });
 
   it("returns tool with correct schema", () => {
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     expect(tool.name).toBe("exec");
     expect(tool.parameters).toBeDefined();
   });
 
   it("executes a basic command", async () => {
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     const result = JSON.parse(await callTool(tool, { command: "echo hello" }));
     expect(result.stdout.trim()).toBe("hello");
     expect(result.exit_code).toBe(0);
   });
 
   it("captures stderr", async () => {
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     const result = JSON.parse(
       await callTool(tool, { command: "echo err >&2" }),
     );
@@ -240,19 +256,19 @@ describe("exec tool", () => {
   });
 
   it("returns non-zero exit code on failure", async () => {
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     const result = JSON.parse(await callTool(tool, { command: "exit 42" }));
     expect(result.exit_code).not.toBe(0);
   });
 
   it("returns error for empty command", async () => {
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     const result = JSON.parse(await callTool(tool, { command: "" }));
     expect(result.error).toContain("must not be empty");
   });
 
   it("times out with custom timeout", async () => {
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     const result = JSON.parse(
       await callTool(tool, { command: "sleep 10", timeout: 1 }),
     );
@@ -263,7 +279,7 @@ describe("exec tool", () => {
   it("clamps timeout to max 300s", async () => {
     // We can't easily test the actual clamping without waiting, but we can
     // verify the tool doesn't reject large values
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     expect(tool.parameters).toBeDefined();
   });
 
@@ -272,7 +288,7 @@ describe("exec tool", () => {
   // ---------------------------------------------------------------------------
 
   it("runs a command in background mode", async () => {
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     const result = JSON.parse(
       await callTool(tool, { command: "sleep 60", background: true }),
     );
@@ -284,7 +300,7 @@ describe("exec tool", () => {
   });
 
   it("background process appears in registry", async () => {
-    const tool = createExecTool({ registry });
+    const tool = createExecTool({ registry, executor });
     await callTool(tool, { command: "sleep 60", background: true });
     expect(registry.list()).toHaveLength(1);
   });
@@ -317,8 +333,8 @@ describe("process_list tool", () => {
   });
 
   it("lists running and exited processes", async () => {
-    registry.spawn("sleep 60", process.cwd());
-    const shortProc = registry.spawn("echo done", process.cwd());
+    registry.spawn("sleep 60", ["sh", "-c", "sleep 60"], process.cwd());
+    const shortProc = registry.spawn("echo done", ["sh", "-c", "echo done"], process.cwd());
 
     // Wait a bit for the echo to finish
     await new Promise((resolve) => setTimeout(resolve, 200));
@@ -342,7 +358,7 @@ describe("process_list tool", () => {
   });
 
   it("does not expose internal _proc field", async () => {
-    registry.spawn("echo hello", process.cwd());
+    registry.spawn("echo hello", ["sh", "-c", "echo hello"], process.cwd());
     const tool = createProcessListTool(registry);
     const result = JSON.parse(await callTool(tool, {}));
     expect(result.processes[0]._proc).toBeUndefined();
@@ -365,7 +381,7 @@ describe("process_kill tool", () => {
   });
 
   it("kills a running process", async () => {
-    const info = registry.spawn("sleep 60", process.cwd());
+    const info = registry.spawn("sleep 60", ["sh", "-c", "sleep 60"], process.cwd());
     const tool = createProcessKillTool(registry);
     const result = JSON.parse(
       await callTool(tool, { process_id: info.process_id }),
@@ -377,7 +393,7 @@ describe("process_kill tool", () => {
   });
 
   it("handles killing an already exited process", async () => {
-    const info = registry.spawn("echo fast", process.cwd());
+    const info = registry.spawn("echo fast", ["sh", "-c", "echo fast"], process.cwd());
     await new Promise((resolve) => setTimeout(resolve, 200));
 
     const tool = createProcessKillTool(registry);
@@ -409,8 +425,10 @@ describe("process_kill tool", () => {
 // ---------------------------------------------------------------------------
 
 describe("createExecTools", () => {
+  const executor = new HostExecutor();
+
   it("returns all three tools", () => {
-    const tools = createExecTools();
+    const tools = createExecTools({ executor });
     const names = tools.map((t) => t.name);
     expect(names).toContain("exec");
     expect(names).toContain("process_list");
@@ -419,7 +437,7 @@ describe("createExecTools", () => {
   });
 
   it("shares registry across tools", async () => {
-    const tools = createExecTools();
+    const tools = createExecTools({ executor });
     const execHandler = (args: unknown) => callTool(tools.find((t) => t.name === "exec")!, args);
     const listHandler = (args: unknown) => callTool(tools.find((t) => t.name === "process_list")!, args);
     const killHandler = (args: unknown) => callTool(tools.find((t) => t.name === "process_kill")!, args);
@@ -446,8 +464,8 @@ describe("createExecTools", () => {
     const registry1 = new ProcessRegistry();
     const registry2 = new ProcessRegistry();
 
-    const tools1 = createExecTools({ registry: registry1 });
-    const tools2 = createExecTools({ registry: registry2 });
+    const tools1 = createExecTools({ registry: registry1, executor });
+    const tools2 = createExecTools({ registry: registry2, executor });
 
     const exec1 = (args: unknown) => callTool(tools1.find((t) => t.name === "exec")!, args);
     const list1 = (args: unknown) => callTool(tools1.find((t) => t.name === "process_list")!, args);
@@ -484,8 +502,8 @@ describe("createExecTools", () => {
     const registry1 = new ProcessRegistry();
     const registry2 = new ProcessRegistry();
 
-    const tools1 = createExecTools({ registry: registry1 });
-    const tools2 = createExecTools({ registry: registry2 });
+    const tools1 = createExecTools({ registry: registry1, executor });
+    const tools2 = createExecTools({ registry: registry2, executor });
 
     const exec1 = (args: unknown) => callTool(tools1.find((t) => t.name === "exec")!, args);
     const kill2 = (args: unknown) => callTool(tools2.find((t) => t.name === "process_kill")!, args);
@@ -514,147 +532,91 @@ describe("createExecTools", () => {
   });
 });
 
+
 // ---------------------------------------------------------------------------
-// Sandbox routing
+// Executor delegation
 // ---------------------------------------------------------------------------
 
-import type { SandboxExecutor } from "../../sandbox/executor.js";
-import type { SandboxConfig } from "../../sandbox/config.js";
+import type { Executor } from "../executor.js";
 
-function makeMockSandboxExecutor(overrides?: Partial<SandboxExecutor>): SandboxExecutor {
+function makeMockExecutor(overrides?: Partial<Executor>): Executor {
   return {
-    execute: vi.fn(async () => ({ exitCode: 0, stdout: "sandboxed-out", stderr: "" })),
-    buildExecArgv: vi.fn(async (_id: string, cmd: string[]) => [
-      "docker", "exec", "-i", "ctr-1", ...cmd,
-    ]),
-    cleanup: vi.fn(async () => {}),
+    execute: vi.fn(async () => ({
+      exitCode: 0,
+      stdout: Buffer.from("mocked-out"),
+      stderr: Buffer.alloc(0),
+    })),
+    buildExecArgv: vi.fn(async (argv: string[]) => ["docker", "exec", "-i", "ctr-1", ...argv]),
     ...overrides,
-  } as unknown as SandboxExecutor;
+  };
 }
 
-const sandboxConfig: SandboxConfig = {
-  enabled: true,
-  workspaceAccess: "rw",
-  docker: { image: "isotopes-sandbox:latest" },
-};
-
-describe("exec tool sandbox routing", () => {
-  it("routes foreground exec through SandboxExecutor.execute when sandboxed", async () => {
-    const executor = makeMockSandboxExecutor();
-    const tool = createExecTool({
-      cwd: "/ws",
-      sandboxExecutor: executor,
-      agentId: "agent-1",
-      agentSandboxConfig: sandboxConfig,
-    });
+describe("createExecTool — Executor delegation", () => {
+  it("foreground exec wraps command in sh -c and delegates to executor.execute", async () => {
+    const executor = makeMockExecutor();
+    const registry = new ProcessRegistry();
+    const tool = createExecTool({ cwd: "/ws", registry, executor });
 
     const result = JSON.parse(await callTool(tool, { command: "echo hi" }) as string);
 
     expect(executor.execute).toHaveBeenCalledWith(
-      "agent-1",
       ["sh", "-c", "echo hi"],
-      { workspacePath: "/ws", timeout: expect.any(Number), allowedWorkspaces: undefined },
+      { workspacePath: "/ws", timeout: expect.any(Number) },
     );
-    expect(result.stdout).toBe("sandboxed-out");
+    expect(result.stdout).toBe("mocked-out");
     expect(result.exit_code).toBe(0);
   });
 
-  it("returns timeout JSON (not throw) when sandbox execute reports timeout", async () => {
-    const executor = makeMockSandboxExecutor({
-      execute: vi.fn(async () => {
-        throw new Error("Sandbox execution timed out after 1000ms");
-      }),
-    });
-    const tool = createExecTool({
-      cwd: "/ws",
-      sandboxExecutor: executor,
-      agentId: "agent-1",
-      agentSandboxConfig: sandboxConfig,
-    });
-
-    const result = JSON.parse(await callTool(tool, { command: "sleep 9999", timeout: 1 }) as string);
-    expect(result.exit_code).toBe(124);
-    expect(result.error).toMatch(/timed out/);
-  });
-
-  it("returns sandbox-error JSON (not throw) when container creation fails", async () => {
-    const executor = makeMockSandboxExecutor({
-      execute: vi.fn(async () => {
-        throw new Error("docker daemon not running");
-      }),
-    });
-    const tool = createExecTool({
-      cwd: "/ws",
-      sandboxExecutor: executor,
-      agentId: "agent-1",
-      agentSandboxConfig: sandboxConfig,
-    });
-
-    const result = JSON.parse(await callTool(tool, { command: "ls" }) as string);
-    expect(result.exit_code).toBe(1);
-    expect(result.stderr).toMatch(/sandbox error/);
-  });
-
-  it("routes background exec through SandboxExecutor.buildExecArgv", async () => {
-    const executor = makeMockSandboxExecutor();
+  it("background exec calls buildExecArgv and registers the returned argv", async () => {
+    const executor = makeMockExecutor();
     const registry = new ProcessRegistry();
     const spawnSpy = vi.spyOn(registry, "spawn");
-    const tool = createExecTool({
-      cwd: "/ws",
-      registry,
-      sandboxExecutor: executor,
-      agentId: "agent-1",
-      agentSandboxConfig: sandboxConfig,
-    });
+    const tool = createExecTool({ cwd: "/ws", registry, executor });
 
     const result = JSON.parse(await callTool(tool, { command: "sleep 3", background: true }) as string);
 
     expect(executor.buildExecArgv).toHaveBeenCalledWith(
-      "agent-1",
       ["sh", "-c", "sleep 3"],
-      { workspacePath: "/ws", allowedWorkspaces: undefined },
+      { workspacePath: "/ws" },
     );
-    expect(spawnSpy).toHaveBeenCalledWith("sleep 3", "/ws", {
-      argv: ["docker", "exec", "-i", "ctr-1", "sh", "-c", "sleep 3"],
-    });
+    expect(spawnSpy).toHaveBeenCalledWith(
+      "sleep 3",
+      ["docker", "exec", "-i", "ctr-1", "sh", "-c", "sleep 3"],
+      "/ws",
+    );
     expect(result.process_id).toBe("proc_1");
     expect(result.status).toBe("running");
 
     registry.clear();
   });
 
-  it("returns sandbox-error JSON when buildExecArgv fails (background)", async () => {
-    const executor = makeMockSandboxExecutor({
-      buildExecArgv: vi.fn(async () => {
-        throw new Error("docker daemon not running");
-      }),
+  it("returns timeout JSON when executor reports timed out", async () => {
+    const executor = makeMockExecutor({
+      execute: vi.fn(async () => { throw new Error("Sandbox execution timed out after 1000ms"); }),
     });
-    const registry = new ProcessRegistry();
-    const tool = createExecTool({
-      cwd: "/ws",
-      registry,
-      sandboxExecutor: executor,
-      agentId: "agent-1",
-      agentSandboxConfig: sandboxConfig,
-    });
-
-    const result = JSON.parse(await callTool(tool, { command: "sleep 3", background: true }) as string);
-    expect(result.exit_code).toBe(1);
-    expect(result.error).toMatch(/Sandbox container creation failed/);
+    const tool = createExecTool({ cwd: "/ws", registry: new ProcessRegistry(), executor });
+    const result = JSON.parse(await callTool(tool, { command: "sleep 9999", timeout: 1 }) as string);
+    expect(result.exit_code).toBe(124);
+    expect(result.error).toMatch(/timed out/);
   });
 
-  it("falls back to host when sandbox config is disabled", async () => {
-    const executor = makeMockSandboxExecutor();
-    const tool = createExecTool({
-      cwd: "/tmp",
-      sandboxExecutor: executor,
-      agentId: "agent-1",
-      agentSandboxConfig: { enabled: false },
+  it("returns exec-error JSON when executor throws", async () => {
+    const executor = makeMockExecutor({
+      execute: vi.fn(async () => { throw new Error("docker daemon not running"); }),
     });
+    const tool = createExecTool({ cwd: "/ws", registry: new ProcessRegistry(), executor });
+    const result = JSON.parse(await callTool(tool, { command: "ls" }) as string);
+    expect(result.exit_code).toBe(1);
+    expect(result.stderr).toMatch(/exec error/);
+  });
 
-    const result = JSON.parse(await callTool(tool, { command: "echo host" }) as string);
-    expect(executor.execute).not.toHaveBeenCalled();
-    expect(result.stdout).toContain("host");
-    expect(result.exit_code).toBe(0);
+  it("returns error JSON when buildExecArgv fails (background)", async () => {
+    const executor = makeMockExecutor({
+      buildExecArgv: vi.fn(async () => { throw new Error("docker daemon not running"); }),
+    });
+    const tool = createExecTool({ cwd: "/ws", registry: new ProcessRegistry(), executor });
+    const result = JSON.parse(await callTool(tool, { command: "sleep 3", background: true }) as string);
+    expect(result.exit_code).toBe(1);
+    expect(result.error).toMatch(/Background exec failed/);
   });
 });

--- a/src/agent/tools/exec.test.ts
+++ b/src/agent/tools/exec.test.ts
@@ -1,8 +1,4 @@
-// src/tools/exec.test.ts — Tests for exec + process tools
-
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { EventEmitter } from "node:events";
-import type { ChildProcess } from "node:child_process";
+import { describe, it, expect, vi } from "vitest";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 
 async function callTool(tool: AgentTool, args: unknown): Promise<string> {
@@ -13,530 +9,12 @@ async function callTool(tool: AgentTool, args: unknown): Promise<string> {
 
 vi.mock("../logging/logger.js", () => ({
   createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
   }),
 }));
 
-// ---------------------------------------------------------------------------
-// Mock child_process — avoid real process spawning on macOS (exit 143/144)
-// CI (Linux) validates real spawn; these tests verify registry/tool logic.
-// ---------------------------------------------------------------------------
-
-/** Create a fake ChildProcess that auto-exits after `delayMs`. */
-function createFakeChild(delayMs: number, exitCode = 0): ChildProcess {
-  const child = new EventEmitter() as ChildProcess & { _killed: boolean };
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
-  Object.assign(child, {
-    stdout,
-    stderr,
-    pid: Math.floor(Math.random() * 90000) + 10000,
-    _killed: false,
-    kill: vi.fn((signal?: string) => {
-      if (!child._killed) {
-        child._killed = true;
-        child.emit("exit", signal === "SIGTERM" ? 137 : exitCode, signal ?? null);
-        child.emit("close", signal === "SIGTERM" ? 137 : exitCode, signal ?? null);
-      }
-      return true;
-    }),
-  });
-
-  if (delayMs >= 0) {
-    setTimeout(() => {
-      if (!child._killed) {
-        child._killed = true;
-        child.emit("exit", exitCode, null);
-        child.emit("close", exitCode, null);
-      }
-    }, delayMs);
-  }
-
-  return child;
-}
-
-/** Mapping of command patterns to fake child behavior. */
-function fakeChildForCommand(cmd: string): ChildProcess {
-  // Strip "sh -c " wrapper — every command now goes through `sh -c` via Executor.
-  if (cmd.startsWith("sh -c ")) cmd = cmd.slice(6);
-  // Crude shell `>&2` redirect — emit on stderr instead of stdout
-  if (cmd.includes(">&2")) {
-    const text = cmd.replace(/\s*>&2\s*$/, "").replace(/^echo\s+/, "");
-    const child = createFakeChild(0, 0);
-    process.nextTick(() => {
-      child.stderr!.emit("data", Buffer.from(text + "\n"));
-    });
-    return child;
-  }
-  if (cmd.startsWith("echo ")) {
-    const text = cmd.slice(5);
-    const child = createFakeChild(0, 0);
-    // Emit stdout on next tick so listeners can attach
-    process.nextTick(() => {
-      child.stdout!.emit("data", Buffer.from(text + "\n"));
-    });
-    return child;
-  }
-  if (cmd.startsWith("sleep ")) {
-    // Keep alive for 10s (tests kill or clear before that)
-    return createFakeChild(10_000, 0);
-  }
-  if (cmd === "exit 42") {
-    return createFakeChild(0, 42);
-  }
-  // default: instant success
-  return createFakeChild(0, 0);
-}
-
-vi.mock("node:child_process", async (importOriginal) => {
-  const orig = await importOriginal<typeof import("node:child_process")>();
-  // Only mock spawn on macOS where process-group signals kill the vitest worker.
-  // CI (Linux) continues to use real spawn for full integration coverage.
-  if (process.platform !== "darwin") return orig;
-  return {
-    ...orig,
-    spawn: vi.fn(
-      (command: string, args: string[], _opts?: Record<string, unknown>) => {
-        const fullCmd = args.length === 0 ? command : `${command} ${args.join(" ")}`;
-        return fakeChildForCommand(fullCmd);
-      },
-    ),
-  };
-});
-
-import {
-  ProcessRegistry,
-  createExecTool,
-  createProcessListTool,
-  createProcessKillTool,
-  createExecTools,
-} from "./exec.js";
+import { createExecTool, createExecTools } from "./exec.js";
 import { HostExecutor } from "../host-executor.js";
-
-// ---------------------------------------------------------------------------
-// ProcessRegistry
-// ---------------------------------------------------------------------------
-
-describe("ProcessRegistry", () => {
-  let registry: ProcessRegistry;
-
-  beforeEach(() => {
-    registry = new ProcessRegistry();
-  });
-
-  afterEach(() => {
-    registry.clear();
-  });
-
-  it("spawns a process and assigns an id", () => {
-    const info = registry.spawn("echo hello", ["sh", "-c", "echo hello"], process.cwd());
-    expect(info.process_id).toBe("proc_1");
-    expect(info.command).toBe("echo hello");
-    expect(info.status).toBe("running");
-    expect(info.start_time).toBeDefined();
-  });
-
-  it("assigns incrementing ids", () => {
-    const a = registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
-    const b = registry.spawn("echo b", ["sh", "-c", "echo b"], process.cwd());
-    expect(a.process_id).toBe("proc_1");
-    expect(b.process_id).toBe("proc_2");
-  });
-
-  it("lists all processes", () => {
-    registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
-    registry.spawn("echo b", ["sh", "-c", "echo b"], process.cwd());
-    expect(registry.list()).toHaveLength(2);
-  });
-
-  it("gets process by id", () => {
-    const info = registry.spawn("echo test", ["sh", "-c", "echo test"], process.cwd());
-    expect(registry.get(info.process_id)).toBe(info);
-    expect(registry.get("nonexistent")).toBeUndefined();
-  });
-
-  it("kills a running process", () => {
-    const info = registry.spawn("sleep 60", ["sh", "-c", "sleep 60"], process.cwd());
-    expect(registry.kill(info.process_id)).toBe(true);
-    expect(info.status).toBe("exited");
-  });
-
-  it("returns false when killing a nonexistent process", () => {
-    expect(registry.kill("proc_999")).toBe(false);
-  });
-
-  it("clears all processes", () => {
-    registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
-    registry.spawn("echo b", ["sh", "-c", "echo b"], process.cwd());
-    registry.clear();
-    expect(registry.list()).toHaveLength(0);
-  });
-
-  it("tracks completed process count", async () => {
-    const a = registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
-    const b = registry.spawn("sleep 60", ["sh", "-c", "sleep 60"], process.cwd());
-
-    // Wait for first process to complete
-    await new Promise((r) => setTimeout(r, 100));
-    expect(a.status).toBe("exited");
-    expect(b.status).toBe("running");
-    expect(registry.getCompletedCount()).toBe(1);
-  });
-
-  it("cleans up completed processes manually", async () => {
-    registry.spawn("echo a", ["sh", "-c", "echo a"], process.cwd());
-    registry.spawn("echo b", ["sh", "-c", "echo b"], process.cwd());
-    
-    // Wait for processes to complete
-    await new Promise((r) => setTimeout(r, 100));
-    expect(registry.getCompletedCount()).toBe(2);
-    
-    const removed = registry.cleanup();
-    expect(removed).toBe(2);
-    expect(registry.list()).toHaveLength(0);
-  });
-
-  it("evicts oldest completed processes when maxCompleted exceeded", async () => {
-    const smallRegistry = new ProcessRegistry({ maxCompleted: 2 });
-    
-    // Spawn 3 processes that complete immediately
-    smallRegistry.spawn("echo 1", ["sh", "-c", "echo 1"], process.cwd());
-    await new Promise((r) => setTimeout(r, 50));
-    smallRegistry.spawn("echo 2", ["sh", "-c", "echo 2"], process.cwd());
-    await new Promise((r) => setTimeout(r, 50));
-    smallRegistry.spawn("echo 3", ["sh", "-c", "echo 3"], process.cwd());
-    await new Promise((r) => setTimeout(r, 100));
-    
-    // Should have evicted oldest, keeping only 2
-    expect(smallRegistry.getCompletedCount()).toBeLessThanOrEqual(2);
-    smallRegistry.clear();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// exec tool — foreground
-// ---------------------------------------------------------------------------
-
-describe("exec tool", () => {
-  let registry: ProcessRegistry;
-  let executor: HostExecutor;
-
-  beforeEach(() => {
-    registry = new ProcessRegistry();
-    executor = new HostExecutor();
-  });
-
-  afterEach(() => {
-    registry.clear();
-  });
-
-  it("returns tool with correct schema", () => {
-    const tool = createExecTool({ registry, executor });
-    expect(tool.name).toBe("exec");
-    expect(tool.parameters).toBeDefined();
-  });
-
-  it("executes a basic command", async () => {
-    const tool = createExecTool({ registry, executor });
-    const result = JSON.parse(await callTool(tool, { command: "echo hello" }));
-    expect(result.stdout.trim()).toBe("hello");
-    expect(result.exit_code).toBe(0);
-  });
-
-  it("captures stderr", async () => {
-    const tool = createExecTool({ registry, executor });
-    const result = JSON.parse(
-      await callTool(tool, { command: "echo err >&2" }),
-    );
-    expect(result.stderr.trim()).toBe("err");
-    expect(result.exit_code).toBe(0);
-  });
-
-  it("returns non-zero exit code on failure", async () => {
-    const tool = createExecTool({ registry, executor });
-    const result = JSON.parse(await callTool(tool, { command: "exit 42" }));
-    expect(result.exit_code).not.toBe(0);
-  });
-
-  it("returns error for empty command", async () => {
-    const tool = createExecTool({ registry, executor });
-    const result = JSON.parse(await callTool(tool, { command: "" }));
-    expect(result.error).toContain("must not be empty");
-  });
-
-  it("times out with custom timeout", async () => {
-    const tool = createExecTool({ registry, executor });
-    const result = JSON.parse(
-      await callTool(tool, { command: "sleep 10", timeout: 1 }),
-    );
-    expect(result.error).toContain("timed out");
-    expect(result.exit_code).toBe(124);
-  }, 10_000);
-
-  it("clamps timeout to max 300s", async () => {
-    // We can't easily test the actual clamping without waiting, but we can
-    // verify the tool doesn't reject large values
-    const tool = createExecTool({ registry, executor });
-    expect(tool.parameters).toBeDefined();
-  });
-
-  // ---------------------------------------------------------------------------
-  // exec tool — background
-  // ---------------------------------------------------------------------------
-
-  it("runs a command in background mode", async () => {
-    const tool = createExecTool({ registry, executor });
-    const result = JSON.parse(
-      await callTool(tool, { command: "sleep 60", background: true }),
-    );
-
-    expect(result.process_id).toBe("proc_1");
-    expect(result.status).toBe("running");
-    expect(result.command).toBe("sleep 60");
-    expect(result.start_time).toBeDefined();
-  });
-
-  it("background process appears in registry", async () => {
-    const tool = createExecTool({ registry, executor });
-    await callTool(tool, { command: "sleep 60", background: true });
-    expect(registry.list()).toHaveLength(1);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// process_list tool
-// ---------------------------------------------------------------------------
-
-describe("process_list tool", () => {
-  let registry: ProcessRegistry;
-
-  beforeEach(() => {
-    registry = new ProcessRegistry();
-  });
-
-  afterEach(() => {
-    registry.clear();
-  });
-
-  it("returns tool with correct schema", () => {
-    const tool = createProcessListTool(registry);
-    expect(tool.name).toBe("process_list");
-  });
-
-  it("returns empty list when no processes", async () => {
-    const tool = createProcessListTool(registry);
-    const result = JSON.parse(await callTool(tool, {}));
-    expect(result.processes).toEqual([]);
-  });
-
-  it("lists running and exited processes", async () => {
-    registry.spawn("sleep 60", ["sh", "-c", "sleep 60"], process.cwd());
-    const shortProc = registry.spawn("echo done", ["sh", "-c", "echo done"], process.cwd());
-
-    // Wait a bit for the echo to finish
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    const tool = createProcessListTool(registry);
-    const result = JSON.parse(await callTool(tool, {}));
-
-    expect(result.processes).toHaveLength(2);
-
-    const running = result.processes.find(
-      (p: { status: string }) => p.status === "running",
-    );
-    const exited = result.processes.find(
-      (p: { process_id: string }) => p.process_id === shortProc.process_id,
-    );
-
-    expect(running).toBeDefined();
-    expect(exited).toBeDefined();
-    expect(exited.status).toBe("exited");
-    expect(exited.exit_code).toBe(0);
-  });
-
-  it("does not expose internal _proc field", async () => {
-    registry.spawn("echo hello", ["sh", "-c", "echo hello"], process.cwd());
-    const tool = createProcessListTool(registry);
-    const result = JSON.parse(await callTool(tool, {}));
-    expect(result.processes[0]._proc).toBeUndefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// process_kill tool
-// ---------------------------------------------------------------------------
-
-describe("process_kill tool", () => {
-  let registry: ProcessRegistry;
-
-  beforeEach(() => {
-    registry = new ProcessRegistry();
-  });
-
-  afterEach(() => {
-    registry.clear();
-  });
-
-  it("kills a running process", async () => {
-    const info = registry.spawn("sleep 60", ["sh", "-c", "sleep 60"], process.cwd());
-    const tool = createProcessKillTool(registry);
-    const result = JSON.parse(
-      await callTool(tool, { process_id: info.process_id }),
-    );
-
-    expect(result.success).toBe(true);
-    expect(result.process_id).toBe(info.process_id);
-    expect(result.was_running).toBe(true);
-  });
-
-  it("handles killing an already exited process", async () => {
-    const info = registry.spawn("echo fast", ["sh", "-c", "echo fast"], process.cwd());
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    const tool = createProcessKillTool(registry);
-    const result = JSON.parse(
-      await callTool(tool, { process_id: info.process_id }),
-    );
-
-    expect(result.success).toBe(true);
-    expect(result.was_running).toBe(false);
-  });
-
-  it("returns error for unknown process_id", async () => {
-    const tool = createProcessKillTool(registry);
-    const result = JSON.parse(
-      await callTool(tool, { process_id: "proc_999" }),
-    );
-    expect(result.error).toContain("Process not found");
-  });
-
-  it("returns error when process_id is missing", async () => {
-    const tool = createProcessKillTool(registry);
-    const result = JSON.parse(await callTool(tool, {}));
-    expect(result.error).toContain("process_id is required");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// createExecTools factory
-// ---------------------------------------------------------------------------
-
-describe("createExecTools", () => {
-  const executor = new HostExecutor();
-
-  it("returns all three tools", () => {
-    const tools = createExecTools({ executor });
-    const names = tools.map((t) => t.name);
-    expect(names).toContain("exec");
-    expect(names).toContain("process_list");
-    expect(names).toContain("process_kill");
-    expect(tools).toHaveLength(3);
-  });
-
-  it("shares registry across tools", async () => {
-    const tools = createExecTools({ executor });
-    const execHandler = (args: unknown) => callTool(tools.find((t) => t.name === "exec")!, args);
-    const listHandler = (args: unknown) => callTool(tools.find((t) => t.name === "process_list")!, args);
-    const killHandler = (args: unknown) => callTool(tools.find((t) => t.name === "process_kill")!, args);
-
-    // Start a background process
-    const execResult = JSON.parse(
-      await execHandler({ command: "sleep 60", background: true }),
-    );
-
-    // List should show it
-    const listResult = JSON.parse(await listHandler({}));
-    expect(listResult.processes).toHaveLength(1);
-    expect(listResult.processes[0].process_id).toBe(execResult.process_id);
-
-    // Kill it
-    const killResult = JSON.parse(
-      await killHandler({ process_id: execResult.process_id }),
-    );
-    expect(killResult.success).toBe(true);
-  });
-
-  it("isolates processes between separate registries", async () => {
-    // Simulate two agents with separate registries
-    const registry1 = new ProcessRegistry();
-    const registry2 = new ProcessRegistry();
-
-    const tools1 = createExecTools({ registry: registry1, executor });
-    const tools2 = createExecTools({ registry: registry2, executor });
-
-    const exec1 = (args: unknown) => callTool(tools1.find((t) => t.name === "exec")!, args);
-    const list1 = (args: unknown) => callTool(tools1.find((t) => t.name === "process_list")!, args);
-
-    const exec2 = (args: unknown) => callTool(tools2.find((t) => t.name === "exec")!, args);
-    const list2 = (args: unknown) => callTool(tools2.find((t) => t.name === "process_list")!, args);
-
-    // Agent 1 starts a process
-    const result1 = JSON.parse(
-      await exec1({ command: "sleep 60", background: true }),
-    );
-
-    // Agent 2 starts a process
-    const result2 = JSON.parse(
-      await exec2({ command: "sleep 60", background: true }),
-    );
-
-    // Each agent should only see their own process
-    const list1Result = JSON.parse(await list1({}));
-    const list2Result = JSON.parse(await list2({}));
-
-    expect(list1Result.processes).toHaveLength(1);
-    expect(list1Result.processes[0].process_id).toBe(result1.process_id);
-
-    expect(list2Result.processes).toHaveLength(1);
-    expect(list2Result.processes[0].process_id).toBe(result2.process_id);
-
-    // Cleanup
-    registry1.clear();
-    registry2.clear();
-  });
-
-  it("prevents one registry from killing another registry's processes", async () => {
-    const registry1 = new ProcessRegistry();
-    const registry2 = new ProcessRegistry();
-
-    const tools1 = createExecTools({ registry: registry1, executor });
-    const tools2 = createExecTools({ registry: registry2, executor });
-
-    const exec1 = (args: unknown) => callTool(tools1.find((t) => t.name === "exec")!, args);
-    const kill2 = (args: unknown) => callTool(tools2.find((t) => t.name === "process_kill")!, args);
-
-    // Agent 1 starts a process
-    const result1 = JSON.parse(
-      await exec1({ command: "sleep 60", background: true }),
-    );
-
-    // Agent 2 tries to kill Agent 1's process
-    const killResult = JSON.parse(
-      await kill2({ process_id: result1.process_id }),
-    );
-
-    // Should fail because the process doesn't exist in registry2
-    expect(killResult.error).toContain("Process not found");
-
-    // Verify Agent 1's process is still alive
-    const info = registry1.get(result1.process_id);
-    expect(info).toBeDefined();
-    expect(info!.status).toBe("running");
-
-    // Cleanup
-    registry1.clear();
-    registry2.clear();
-  });
-});
-
-
-// ---------------------------------------------------------------------------
-// Executor delegation
-// ---------------------------------------------------------------------------
-
 import type { Executor } from "../executor.js";
 
 function makeMockExecutor(overrides?: Partial<Executor>): Executor {
@@ -546,18 +24,22 @@ function makeMockExecutor(overrides?: Partial<Executor>): Executor {
       stdout: Buffer.from("mocked-out"),
       stderr: Buffer.alloc(0),
     })),
-    buildExecArgv: vi.fn(async (argv: string[]) => ["docker", "exec", "-i", "ctr-1", ...argv]),
+    buildExecArgv: vi.fn(async (argv: string[]) => argv),
     ...overrides,
   };
 }
 
-describe("createExecTool — Executor delegation", () => {
-  it("foreground exec wraps command in sh -c and delegates to executor.execute", async () => {
-    const executor = makeMockExecutor();
-    const registry = new ProcessRegistry();
-    const tool = createExecTool({ cwd: "/ws", registry, executor });
+describe("createExecTool", () => {
+  it("returns a tool with correct schema", () => {
+    const tool = createExecTool({ executor: makeMockExecutor() });
+    expect(tool.name).toBe("exec");
+    expect(tool.parameters).toBeDefined();
+  });
 
-    const result = JSON.parse(await callTool(tool, { command: "echo hi" }) as string);
+  it("wraps command in sh -c and delegates to executor.execute", async () => {
+    const executor = makeMockExecutor();
+    const tool = createExecTool({ cwd: "/ws", executor });
+    const result = JSON.parse(await callTool(tool, { command: "echo hi" }));
 
     expect(executor.execute).toHaveBeenCalledWith(
       ["sh", "-c", "echo hi"],
@@ -567,35 +49,18 @@ describe("createExecTool — Executor delegation", () => {
     expect(result.exit_code).toBe(0);
   });
 
-  it("background exec calls buildExecArgv and registers the returned argv", async () => {
-    const executor = makeMockExecutor();
-    const registry = new ProcessRegistry();
-    const spawnSpy = vi.spyOn(registry, "spawn");
-    const tool = createExecTool({ cwd: "/ws", registry, executor });
-
-    const result = JSON.parse(await callTool(tool, { command: "sleep 3", background: true }) as string);
-
-    expect(executor.buildExecArgv).toHaveBeenCalledWith(
-      ["sh", "-c", "sleep 3"],
-      { workspacePath: "/ws" },
-    );
-    expect(spawnSpy).toHaveBeenCalledWith(
-      "sleep 3",
-      ["docker", "exec", "-i", "ctr-1", "sh", "-c", "sleep 3"],
-      "/ws",
-    );
-    expect(result.process_id).toBe("proc_1");
-    expect(result.status).toBe("running");
-
-    registry.clear();
+  it("returns error for empty command", async () => {
+    const tool = createExecTool({ executor: makeMockExecutor() });
+    const result = JSON.parse(await callTool(tool, { command: "" }));
+    expect(result.error).toContain("must not be empty");
   });
 
   it("returns timeout JSON when executor reports timed out", async () => {
     const executor = makeMockExecutor({
       execute: vi.fn(async () => { throw new Error("Sandbox execution timed out after 1000ms"); }),
     });
-    const tool = createExecTool({ cwd: "/ws", registry: new ProcessRegistry(), executor });
-    const result = JSON.parse(await callTool(tool, { command: "sleep 9999", timeout: 1 }) as string);
+    const tool = createExecTool({ cwd: "/ws", executor });
+    const result = JSON.parse(await callTool(tool, { command: "sleep 9999", timeout: 1 }));
     expect(result.exit_code).toBe(124);
     expect(result.error).toMatch(/timed out/);
   });
@@ -604,19 +69,38 @@ describe("createExecTool — Executor delegation", () => {
     const executor = makeMockExecutor({
       execute: vi.fn(async () => { throw new Error("docker daemon not running"); }),
     });
-    const tool = createExecTool({ cwd: "/ws", registry: new ProcessRegistry(), executor });
-    const result = JSON.parse(await callTool(tool, { command: "ls" }) as string);
+    const tool = createExecTool({ cwd: "/ws", executor });
+    const result = JSON.parse(await callTool(tool, { command: "ls" }));
     expect(result.exit_code).toBe(1);
     expect(result.stderr).toMatch(/exec error/);
   });
+});
 
-  it("returns error JSON when buildExecArgv fails (background)", async () => {
-    const executor = makeMockExecutor({
-      buildExecArgv: vi.fn(async () => { throw new Error("docker daemon not running"); }),
-    });
-    const tool = createExecTool({ cwd: "/ws", registry: new ProcessRegistry(), executor });
-    const result = JSON.parse(await callTool(tool, { command: "sleep 3", background: true }) as string);
-    expect(result.exit_code).toBe(1);
-    expect(result.error).toMatch(/Background exec failed/);
+describe("createExecTools", () => {
+  it("returns just the exec tool", () => {
+    const tools = createExecTools({ executor: makeMockExecutor() });
+    expect(tools.map((t) => t.name)).toEqual(["exec"]);
+  });
+});
+
+describe("HostExecutor + createExecTool integration", () => {
+  it("runs a real command end-to-end", async () => {
+    const tool = createExecTool({ executor: new HostExecutor() });
+    const result = JSON.parse(await callTool(tool, { command: "echo hello" }));
+    expect(result.stdout.trim()).toBe("hello");
+    expect(result.exit_code).toBe(0);
+  });
+
+  it("captures stderr", async () => {
+    const tool = createExecTool({ executor: new HostExecutor() });
+    const result = JSON.parse(await callTool(tool, { command: "echo err >&2" }));
+    expect(result.stderr.trim()).toBe("err");
+    expect(result.exit_code).toBe(0);
+  });
+
+  it("reports non-zero exit code", async () => {
+    const tool = createExecTool({ executor: new HostExecutor() });
+    const result = JSON.parse(await callTool(tool, { command: "exit 42" }));
+    expect(result.exit_code).toBe(42);
   });
 });

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -44,7 +44,7 @@ export function createExecTool(options: ExecToolOptions): AgentTool<typeof execS
       }
 
       const argv = ["sh", "-c", command];
-      const timeoutMs = Math.max((timeoutSec ?? DEFAULT_TIMEOUT_SEC) * 1000, 1000);
+      const timeoutMs = (timeoutSec ?? DEFAULT_TIMEOUT_SEC) * 1000;
 
       try {
         const result = await executor.execute(argv, { workspacePath: cwd, timeout: timeoutMs });

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -101,7 +101,6 @@ export class ProcessRegistry {
     return true;
   }
 
-  /** Clear all processes (for testing). */
   clear(): void {
     for (const info of this.processes.values()) {
       if (info.status === "running") {
@@ -120,7 +119,6 @@ export class ProcessRegistry {
     return count;
   }
 
-  /** Manually remove all completed processes. */
   cleanup(): number {
     const toRemove: string[] = [];
     for (const [id, info] of this.processes.entries()) {
@@ -148,11 +146,10 @@ export class ProcessRegistry {
 }
 
 export interface ExecToolOptions {
-  /** Working directory for the command (host or container). */
+  /** Working directory (host or container). */
   cwd?: string;
-  /** Per-agent executor — host or sandbox-bound. Required. */
+  /** Per-agent executor. Required. */
   executor: Executor;
-  /** ProcessRegistry instance for background process tracking. */
   registry?: ProcessRegistry;
 }
 

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -23,10 +23,6 @@ export interface ProcessInfo {
   _proc: ChildProcess;
 }
 
-/**
- * Tracks background processes the exec tool spawns. One registry per agent.
- * Auto-evicts oldest completed entries past `maxCompleted` (#296).
- */
 export class ProcessRegistry {
   private processes = new Map<string, ProcessInfo>();
   private nextId = 1;
@@ -36,7 +32,6 @@ export class ProcessRegistry {
     this.maxCompleted = options?.maxCompleted ?? DEFAULT_MAX_COMPLETED;
   }
 
-  /** Spawn argv as a tracked background process. argv comes from Executor.buildExecArgv. */
   spawn(command: string, argv: string[], cwd: string): ProcessInfo {
     const id = `proc_${this.nextId++}`;
     const child = spawn(argv[0], argv.slice(1), {

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -5,8 +5,7 @@ import type { Executor } from "../executor.js";
 
 const log = createLogger("tools:exec");
 
-const DEFAULT_TIMEOUT_SEC = 30;
-const MAX_TIMEOUT_MS = 300_000;
+const DEFAULT_TIMEOUT_SEC = 1800;
 
 export interface ExecToolOptions {
   /** Working directory (host or container). */
@@ -22,7 +21,7 @@ function jsonResult(value: unknown): AgentToolResult<undefined> {
 const execSchema = Type.Object({
   command: Type.String({ description: "The shell command to execute" }),
   timeout: Type.Optional(Type.Number({
-    description: "Timeout in seconds (default 30, max 300).",
+    description: "Timeout in seconds (default 1800 = 30 min). No upper limit — pass higher values for known-long tasks.",
   })),
 });
 
@@ -35,7 +34,7 @@ export function createExecTool(options: ExecToolOptions): AgentTool<typeof execS
     label: "exec",
     description:
       "Execute a shell command. Returns stdout, stderr, and exit_code. " +
-      "Default timeout: 30s, max: 300s. " +
+      "Default timeout: 30 min, no upper limit. " +
       "For long-running commands, use shell backgrounding (`cmd > /tmp/log 2>&1 &`) and `kill <pid>` to manage them.",
     parameters: execSchema,
     execute: async (_id, params: Static<typeof execSchema>) => {
@@ -45,10 +44,7 @@ export function createExecTool(options: ExecToolOptions): AgentTool<typeof execS
       }
 
       const argv = ["sh", "-c", command];
-      const timeoutMs = Math.min(
-        Math.max((timeoutSec ?? DEFAULT_TIMEOUT_SEC) * 1000, 1000),
-        MAX_TIMEOUT_MS,
-      );
+      const timeoutMs = Math.max((timeoutSec ?? DEFAULT_TIMEOUT_SEC) * 1000, 1000);
 
       try {
         const result = await executor.execute(argv, { workspacePath: cwd, timeout: timeoutMs });

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -1,4 +1,3 @@
-import { spawn, type ChildProcess } from "node:child_process";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type, type Static } from "typebox";
 import { createLogger } from "../../logging/logger.js";
@@ -8,149 +7,12 @@ const log = createLogger("tools:exec");
 
 const DEFAULT_TIMEOUT_SEC = 30;
 const MAX_TIMEOUT_MS = 300_000;
-const MAX_OUTPUT_BYTES = 100 * 1024;
-const DEFAULT_MAX_COMPLETED = 100;
-
-export interface ProcessInfo {
-  process_id: string;
-  command: string;
-  status: "running" | "exited";
-  start_time: string;
-  exit_code: number | null;
-  stdout: string;
-  stderr: string;
-  /** Internal reference to the child process (not serialised). */
-  _proc: ChildProcess;
-}
-
-export class ProcessRegistry {
-  private processes = new Map<string, ProcessInfo>();
-  private nextId = 1;
-  private maxCompleted: number;
-
-  constructor(options?: { maxCompleted?: number }) {
-    this.maxCompleted = options?.maxCompleted ?? DEFAULT_MAX_COMPLETED;
-  }
-
-  spawn(command: string, argv: string[], cwd: string): ProcessInfo {
-    const id = `proc_${this.nextId++}`;
-    const child = spawn(argv[0], argv.slice(1), {
-      cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-      detached: false,
-    });
-
-    const info: ProcessInfo = {
-      process_id: id,
-      command,
-      status: "running",
-      start_time: new Date().toISOString(),
-      exit_code: null,
-      stdout: "",
-      stderr: "",
-      _proc: child,
-    };
-
-    child.stdout?.on("data", (chunk: Buffer) => {
-      if (info.stdout.length < MAX_OUTPUT_BYTES) {
-        info.stdout += chunk.toString().slice(0, MAX_OUTPUT_BYTES - info.stdout.length);
-      }
-    });
-    child.stderr?.on("data", (chunk: Buffer) => {
-      if (info.stderr.length < MAX_OUTPUT_BYTES) {
-        info.stderr += chunk.toString().slice(0, MAX_OUTPUT_BYTES - info.stderr.length);
-      }
-    });
-
-    child.on("exit", (code) => {
-      info.status = "exited";
-      info.exit_code = code ?? 1;
-      this.evictOldestCompleted();
-    });
-
-    child.on("error", (err) => {
-      info.status = "exited";
-      info.exit_code = 1;
-      info.stderr += `\n[spawn error] ${err.message}`;
-      this.evictOldestCompleted();
-    });
-
-    this.processes.set(id, info);
-    return info;
-  }
-
-  get(id: string): ProcessInfo | undefined {
-    return this.processes.get(id);
-  }
-
-  list(): ProcessInfo[] {
-    return Array.from(this.processes.values());
-  }
-
-  kill(id: string): boolean {
-    const info = this.processes.get(id);
-    if (!info) return false;
-
-    if (info.status === "running") {
-      try { info._proc.kill("SIGTERM"); }
-      catch { /* may have already exited between check and kill */ }
-      info.status = "exited";
-      info.exit_code = info.exit_code ?? 137;
-    }
-
-    return true;
-  }
-
-  clear(): void {
-    for (const info of this.processes.values()) {
-      if (info.status === "running") {
-        try { info._proc.kill("SIGTERM"); } catch { /* ignore */ }
-      }
-    }
-    this.processes.clear();
-    this.nextId = 1;
-  }
-
-  getCompletedCount(): number {
-    let count = 0;
-    for (const info of this.processes.values()) {
-      if (info.status === "exited") count++;
-    }
-    return count;
-  }
-
-  cleanup(): number {
-    const toRemove: string[] = [];
-    for (const [id, info] of this.processes.entries()) {
-      if (info.status === "exited") toRemove.push(id);
-    }
-    for (const id of toRemove) this.processes.delete(id);
-    return toRemove.length;
-  }
-
-  private evictOldestCompleted(): void {
-    const completed: Array<{ id: string; startTime: number }> = [];
-    for (const [id, info] of this.processes.entries()) {
-      if (info.status === "exited") {
-        completed.push({ id, startTime: new Date(info.start_time).getTime() });
-      }
-    }
-    if (completed.length <= this.maxCompleted) return;
-    completed.sort((a, b) => a.startTime - b.startTime);
-    const toRemove = completed.length - this.maxCompleted;
-    for (let i = 0; i < toRemove; i++) {
-      this.processes.delete(completed[i].id);
-      log.debug(`Evicted completed process ${completed[i].id}`);
-    }
-  }
-}
 
 export interface ExecToolOptions {
   /** Working directory (host or container). */
   cwd?: string;
   /** Per-agent executor. Required. */
   executor: Executor;
-  registry?: ProcessRegistry;
 }
 
 function jsonResult(value: unknown): AgentToolResult<undefined> {
@@ -160,16 +22,12 @@ function jsonResult(value: unknown): AgentToolResult<undefined> {
 const execSchema = Type.Object({
   command: Type.String({ description: "The shell command to execute" }),
   timeout: Type.Optional(Type.Number({
-    description: "Timeout in seconds (default 30, max 300). Ignored for background processes.",
-  })),
-  background: Type.Optional(Type.Boolean({
-    description: "If true, run the command in the background and return a process_id immediately.",
+    description: "Timeout in seconds (default 30, max 300).",
   })),
 });
 
 export function createExecTool(options: ExecToolOptions): AgentTool<typeof execSchema> {
   const cwd = options.cwd ?? process.cwd();
-  const registry = options.registry ?? new ProcessRegistry();
   const { executor } = options;
 
   return {
@@ -177,39 +35,16 @@ export function createExecTool(options: ExecToolOptions): AgentTool<typeof execS
     label: "exec",
     description:
       "Execute a shell command. Returns stdout, stderr, and exit_code. " +
-      "Set background=true for long-running processes (returns immediately with process_id). " +
-      "Default timeout: 30s, max: 300s.",
+      "Default timeout: 30s, max: 300s. " +
+      "For long-running commands, use shell backgrounding (`cmd > /tmp/log 2>&1 &`) and `kill <pid>` to manage them.",
     parameters: execSchema,
     execute: async (_id, params: Static<typeof execSchema>) => {
-      const { command, timeout: timeoutSec, background } = params;
+      const { command, timeout: timeoutSec } = params;
       if (!command || command.trim().length === 0) {
         return jsonResult({ error: "Command must not be empty" });
       }
 
       const argv = ["sh", "-c", command];
-
-      if (background) {
-        let spawnArgv: string[];
-        try {
-          spawnArgv = await executor.buildExecArgv(argv, { workspacePath: cwd });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          log.warn("buildExecArgv failed for background exec", { command, error: msg });
-          return jsonResult({
-            stdout: "", stderr: `[exec error] ${msg}`, exit_code: 1,
-            error: `Background exec failed: ${msg}`,
-          });
-        }
-        const info = registry.spawn(command, spawnArgv, cwd);
-        log.info("Background process started", { processId: info.process_id, command, cwd });
-        return jsonResult({
-          process_id: info.process_id,
-          command: info.command,
-          status: "running",
-          start_time: info.start_time,
-        });
-      }
-
       const timeoutMs = Math.min(
         Math.max((timeoutSec ?? DEFAULT_TIMEOUT_SEC) * 1000, 1000),
         MAX_TIMEOUT_MS,
@@ -242,60 +77,6 @@ export function createExecTool(options: ExecToolOptions): AgentTool<typeof execS
   };
 }
 
-const processListSchema = Type.Object({});
-
-export function createProcessListTool(registry: ProcessRegistry): AgentTool<typeof processListSchema> {
-  return {
-    name: "process_list",
-    label: "process_list",
-    description:
-      "List all background processes started by the agent. " +
-      "Shows process_id, command, status, start_time, and exit_code.",
-    parameters: processListSchema,
-    execute: async () => {
-      const processes = registry.list().map((p) => ({
-        process_id: p.process_id,
-        command: p.command,
-        status: p.status,
-        start_time: p.start_time,
-        exit_code: p.exit_code,
-      }));
-      log.info("Process list requested", { count: processes.length });
-      return jsonResult({ processes });
-    },
-  };
-}
-
-const processKillSchema = Type.Object({
-  process_id: Type.String({ description: "The process_id returned by exec with background=true" }),
-});
-
-export function createProcessKillTool(registry: ProcessRegistry): AgentTool<typeof processKillSchema> {
-  return {
-    name: "process_kill",
-    label: "process_kill",
-    description:
-      "Kill a background process by its process_id. " +
-      "Returns success or error if the process is not found.",
-    parameters: processKillSchema,
-    execute: async (_id, { process_id }) => {
-      if (!process_id) return jsonResult({ error: "process_id is required" });
-      const info = registry.get(process_id);
-      if (!info) return jsonResult({ error: `Process not found: ${process_id}` });
-      const wasRunning = info.status === "running";
-      registry.kill(process_id);
-      log.info("Process killed", { processId: process_id, wasRunning });
-      return jsonResult({ success: true, process_id, was_running: wasRunning });
-    },
-  };
-}
-
 export function createExecTools(options: ExecToolOptions): AgentTool[] {
-  const registry = options.registry ?? new ProcessRegistry();
-  const execOptions = { ...options, registry };
-  return [
-    createExecTool(execOptions),
-    createProcessListTool(registry),
-    createProcessKillTool(registry),
-  ];
+  return [createExecTool(options)];
 }

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -1,33 +1,15 @@
-// src/tools/exec.ts — Shell execution and background process management tools
-
 import { spawn, type ChildProcess } from "node:child_process";
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type, type Static } from "typebox";
 import { createLogger } from "../../logging/logger.js";
-import type { SandboxExecutor } from "../../sandbox/executor.js";
-import type { SandboxConfig } from "../../sandbox/config.js";
+import type { Executor } from "../executor.js";
 
-const execAsync = promisify(exec);
 const log = createLogger("tools:exec");
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** Default timeout for foreground exec in seconds. */
 const DEFAULT_TIMEOUT_SEC = 30;
-
-/** Maximum allowed timeout in milliseconds. */
 const MAX_TIMEOUT_MS = 300_000;
-
-/** Maximum output size in bytes (100 KB). */
 const MAX_OUTPUT_BYTES = 100 * 1024;
-
-// ---------------------------------------------------------------------------
-// ProcessRegistry — tracks background processes
-// ---------------------------------------------------------------------------
+const DEFAULT_MAX_COMPLETED = 100;
 
 export interface ProcessInfo {
   process_id: string;
@@ -41,15 +23,9 @@ export interface ProcessInfo {
   _proc: ChildProcess;
 }
 
-/** Default maximum number of completed processes to retain. */
-const DEFAULT_MAX_COMPLETED = 100;
-
 /**
- * ProcessRegistry — singleton that tracks background processes spawned by
- * the exec tool. Each agent workspace gets its own registry instance.
- *
- * Automatically evicts oldest completed processes when maxCompleted is exceeded
- * to prevent unbounded memory growth (#296).
+ * Tracks background processes the exec tool spawns. One registry per agent.
+ * Auto-evicts oldest completed entries past `maxCompleted` (#296).
  */
 export class ProcessRegistry {
   private processes = new Map<string, ProcessInfo>();
@@ -60,25 +36,14 @@ export class ProcessRegistry {
     this.maxCompleted = options?.maxCompleted ?? DEFAULT_MAX_COMPLETED;
   }
 
-  /** Spawn a background process and register it. */
-  spawn(command: string, cwd: string, options?: { argv?: string[] }): ProcessInfo {
+  /** Spawn argv as a tracked background process. argv comes from Executor.buildExecArgv. */
+  spawn(command: string, argv: string[], cwd: string): ProcessInfo {
     const id = `proc_${this.nextId++}`;
-
-    // If argv is provided (sandbox path), spawn that directly so stdout/stderr
-    // pipes and SIGTERM kill flow through the host child handle. Otherwise
-    // fall back to the host shell.
-    const child = options?.argv && options.argv.length > 0
-      ? spawn(options.argv[0], options.argv.slice(1), {
-          cwd,
-          stdio: ["ignore", "pipe", "pipe"],
-          detached: false,
-        })
-      : spawn(command, [], {
-          cwd,
-          stdio: ["ignore", "pipe", "pipe"],
-          detached: false,
-          shell: true,
-        });
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: false,
+    });
 
     const info: ProcessInfo = {
       process_id: id,
@@ -91,7 +56,6 @@ export class ProcessRegistry {
       _proc: child,
     };
 
-    // Capture output (truncated to MAX_OUTPUT_BYTES)
     child.stdout?.on("data", (chunk: Buffer) => {
       if (info.stdout.length < MAX_OUTPUT_BYTES) {
         info.stdout += chunk.toString().slice(0, MAX_OUTPUT_BYTES - info.stdout.length);
@@ -120,27 +84,21 @@ export class ProcessRegistry {
     return info;
   }
 
-  /** Get a process by ID. */
   get(id: string): ProcessInfo | undefined {
     return this.processes.get(id);
   }
 
-  /** List all tracked processes. */
   list(): ProcessInfo[] {
     return Array.from(this.processes.values());
   }
 
-  /** Kill a process by ID. Returns true if killed, false if not found. */
   kill(id: string): boolean {
     const info = this.processes.get(id);
     if (!info) return false;
 
     if (info.status === "running") {
-      try {
-        info._proc.kill("SIGTERM");
-      } catch {
-        // Process may have already exited between status check and kill
-      }
+      try { info._proc.kill("SIGTERM"); }
+      catch { /* may have already exited between check and kill */ }
       info.status = "exited";
       info.exit_code = info.exit_code ?? 137;
     }
@@ -152,18 +110,13 @@ export class ProcessRegistry {
   clear(): void {
     for (const info of this.processes.values()) {
       if (info.status === "running") {
-        try {
-          info._proc.kill("SIGTERM");
-        } catch {
-          // ignore
-        }
+        try { info._proc.kill("SIGTERM"); } catch { /* ignore */ }
       }
     }
     this.processes.clear();
     this.nextId = 1;
   }
 
-  /** Get count of completed (exited) processes. */
   getCompletedCount(): number {
     let count = 0;
     for (const info of this.processes.values()) {
@@ -176,20 +129,12 @@ export class ProcessRegistry {
   cleanup(): number {
     const toRemove: string[] = [];
     for (const [id, info] of this.processes.entries()) {
-      if (info.status === "exited") {
-        toRemove.push(id);
-      }
+      if (info.status === "exited") toRemove.push(id);
     }
-    for (const id of toRemove) {
-      this.processes.delete(id);
-    }
+    for (const id of toRemove) this.processes.delete(id);
     return toRemove.length;
   }
 
-  /**
-   * Evict oldest completed processes if count exceeds maxCompleted.
-   * Called automatically when a process exits.
-   */
   private evictOldestCompleted(): void {
     const completed: Array<{ id: string; startTime: number }> = [];
     for (const [id, info] of this.processes.entries()) {
@@ -197,13 +142,8 @@ export class ProcessRegistry {
         completed.push({ id, startTime: new Date(info.start_time).getTime() });
       }
     }
-
     if (completed.length <= this.maxCompleted) return;
-
-    // Sort by start time (oldest first)
     completed.sort((a, b) => a.startTime - b.startTime);
-
-    // Remove oldest until we're at maxCompleted
     const toRemove = completed.length - this.maxCompleted;
     for (let i = 0; i < toRemove; i++) {
       this.processes.delete(completed[i].id);
@@ -212,23 +152,13 @@ export class ProcessRegistry {
   }
 }
 
-// ---------------------------------------------------------------------------
-// exec tool
-// ---------------------------------------------------------------------------
-
 export interface ExecToolOptions {
-  /** Working directory for command execution. */
+  /** Working directory for the command (host or container). */
   cwd?: string;
+  /** Per-agent executor — host or sandbox-bound. Required. */
+  executor: Executor;
   /** ProcessRegistry instance for background process tracking. */
   registry?: ProcessRegistry;
-  /** Optional sandbox executor — when provided alongside agentId and
-   *  agentSandboxConfig, exec routes through a Docker container instead
-   *  of running on the host. */
-  sandboxExecutor?: SandboxExecutor;
-  /** Agent ID owning this exec tool (required for sandbox routing). */
-  agentId?: string;
-  /** Resolved sandbox config for this agent. Required for sandbox routing. */
-  agentSandboxConfig?: SandboxConfig;
 }
 
 function jsonResult(value: unknown): AgentToolResult<undefined> {
@@ -245,13 +175,10 @@ const execSchema = Type.Object({
   })),
 });
 
-export function createExecTool(options: ExecToolOptions = {}): AgentTool<typeof execSchema> {
-  const { cwd = process.cwd() } = options;
+export function createExecTool(options: ExecToolOptions): AgentTool<typeof execSchema> {
+  const cwd = options.cwd ?? process.cwd();
   const registry = options.registry ?? new ProcessRegistry();
-  const { sandboxExecutor, agentId, agentSandboxConfig } = options;
-
-  const useSandbox = (): boolean =>
-    !!(sandboxExecutor && agentId && agentSandboxConfig?.enabled);
+  const { executor } = options;
 
   return {
     name: "exec",
@@ -267,22 +194,22 @@ export function createExecTool(options: ExecToolOptions = {}): AgentTool<typeof 
         return jsonResult({ error: "Command must not be empty" });
       }
 
+      const argv = ["sh", "-c", command];
+
       if (background) {
-        let argv: string[] | undefined;
-        if (useSandbox()) {
-          try {
-            argv = await sandboxExecutor!.buildExecArgv(agentId!, ["sh", "-c", command], { workspacePath: cwd });
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            log.warn("Sandbox container creation failed for background exec", { command, error: msg });
-            return jsonResult({
-              stdout: "", stderr: `[sandbox error] ${msg}`, exit_code: 1,
-              error: `Sandbox container creation failed: ${msg}`,
-            });
-          }
+        let spawnArgv: string[];
+        try {
+          spawnArgv = await executor.buildExecArgv(argv, { workspacePath: cwd });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log.warn("buildExecArgv failed for background exec", { command, error: msg });
+          return jsonResult({
+            stdout: "", stderr: `[exec error] ${msg}`, exit_code: 1,
+            error: `Background exec failed: ${msg}`,
+          });
         }
-        const info = registry.spawn(command, cwd, argv ? { argv } : undefined);
-        log.info("Background process started", { processId: info.process_id, command, cwd, sandboxed: !!argv });
+        const info = registry.spawn(command, spawnArgv, cwd);
+        log.info("Background process started", { processId: info.process_id, command, cwd });
         return jsonResult({
           process_id: info.process_id,
           command: info.command,
@@ -296,67 +223,32 @@ export function createExecTool(options: ExecToolOptions = {}): AgentTool<typeof 
         MAX_TIMEOUT_MS,
       );
 
-      if (useSandbox()) {
-        try {
-          const result = await sandboxExecutor!.execute(
-            agentId!,
-            ["sh", "-c", command],
-            { workspacePath: cwd, timeout: timeoutMs },
-          );
-          log.info("Command executed (sandbox)", { command, cwd, exitCode: result.exitCode });
-          return jsonResult({
-            stdout: result.stdout.toString("utf8"),
-            stderr: result.stderr.toString("utf8"),
-            exit_code: result.exitCode,
-          });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("timed out")) {
-            log.warn("Command timed out (sandbox)", { command, timeoutMs });
-            return jsonResult({
-              stdout: "", stderr: "", exit_code: 124,
-              error: `Command timed out after ${timeoutMs / 1000}s`,
-            });
-          }
-          log.warn("Sandbox exec failed", { command, error: msg });
-          return jsonResult({
-            stdout: "", stderr: `[sandbox error] ${msg}`, exit_code: 1,
-            error: `Sandbox exec failed: ${msg}`,
-          });
-        }
-      }
-
       try {
-        const { stdout, stderr } = await execAsync(command, {
-          cwd, timeout: timeoutMs, maxBuffer: MAX_OUTPUT_BYTES,
+        const result = await executor.execute(argv, { workspacePath: cwd, timeout: timeoutMs });
+        log.info("Command executed", { command, cwd, exitCode: result.exitCode });
+        return jsonResult({
+          stdout: result.stdout.toString("utf8"),
+          stderr: result.stderr.toString("utf8"),
+          exit_code: result.exitCode,
         });
-        log.info("Command executed", { command, cwd, exitCode: 0 });
-        return jsonResult({ stdout: stdout || "", stderr: stderr || "", exit_code: 0 });
-      } catch (error) {
-        const err = error as {
-          message?: string; code?: number; signal?: string;
-          stdout?: string; stderr?: string;
-        };
-        if (err.signal === "SIGTERM") {
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("timed out")) {
           log.warn("Command timed out", { command, timeoutMs });
           return jsonResult({
-            stdout: err.stdout || "", stderr: err.stderr || "", exit_code: 124,
+            stdout: "", stderr: "", exit_code: 124,
             error: `Command timed out after ${timeoutMs / 1000}s`,
           });
         }
-        const exitCode = typeof err.code === "number" ? err.code : 1;
-        log.info("Command failed", { command, exitCode });
+        log.warn("Exec failed", { command, error: msg });
         return jsonResult({
-          stdout: err.stdout || "", stderr: err.stderr || "", exit_code: exitCode,
+          stdout: "", stderr: `[exec error] ${msg}`, exit_code: 1,
+          error: `Exec failed: ${msg}`,
         });
       }
     },
   };
 }
-
-// ---------------------------------------------------------------------------
-// process_list tool
-// ---------------------------------------------------------------------------
 
 const processListSchema = Type.Object({});
 
@@ -382,10 +274,6 @@ export function createProcessListTool(registry: ProcessRegistry): AgentTool<type
   };
 }
 
-// ---------------------------------------------------------------------------
-// process_kill tool
-// ---------------------------------------------------------------------------
-
 const processKillSchema = Type.Object({
   process_id: Type.String({ description: "The process_id returned by exec with background=true" }),
 });
@@ -410,11 +298,7 @@ export function createProcessKillTool(registry: ProcessRegistry): AgentTool<type
   };
 }
 
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
-
-export function createExecTools(options: ExecToolOptions = {}): AgentTool[] {
+export function createExecTools(options: ExecToolOptions): AgentTool[] {
   const registry = options.registry ?? new ProcessRegistry();
   const execOptions = { ...options, registry };
   return [
@@ -423,4 +307,3 @@ export function createExecTools(options: ExecToolOptions = {}): AgentTool[] {
     createProcessKillTool(registry),
   ];
 }
-

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -63,7 +63,7 @@ describe("createAgentTools", () => {
 
 describe("applyToolPolicy", () => {
   const noopExecutor = { execute: async () => ({ exitCode: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) }), buildExecArgv: async (a: string[]) => a };
-  const tools = [createTimeTool(), createWebFetchTool({ executor: noopExecutor })];
+  const tools = [createTimeTool(), createWebFetchTool(noopExecutor)];
 
   it("returns all tools when policy is undefined", () => {
     expect(applyToolPolicy(tools)).toHaveLength(2);

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -3,11 +3,9 @@ import {
   createTimeTool,
   createAgentTools,
   applyToolPolicy,
-  configureToolsLayer,
-  shutdownToolsLayer,
 } from "./index.js";
 import { createWebFetchTool } from "./web.js";
-import { ProcessRegistry } from "../../legacy/tools/exec.js";
+import { ProcessRegistry } from "./exec.js";
 
 function getText(result: { content: Array<{ type: string; text?: string }> }): string {
   const block = result.content.find((c) => c.type === "text");
@@ -63,35 +61,11 @@ describe("createAgentTools", () => {
     expect(names).toContain("web_fetch");
     expect(names).not.toContain("web_search");
   });
-
-  it("omits web_fetch when sandbox is enabled and network is 'none'", () => {
-    configureToolsLayer({
-      sandboxBaseConfig: { enabled: true, docker: { image: "isotopes-sandbox:latest", network: "none" } },
-    });
-    try {
-      const tools = createAgentTools({
-        ...baseOpts(),
-        agentSandboxConfig: { enabled: true, docker: { image: "isotopes-sandbox:latest", network: "none" } },
-      });
-      const names = tools.map((t) => t.name);
-      expect(names).not.toContain("web_fetch");
-    } finally {
-      void shutdownToolsLayer();
-    }
-  });
-
-  it("keeps web_fetch when sandbox is disabled even if docker.network is 'none'", () => {
-    const tools = createAgentTools({
-      ...baseOpts(),
-      agentSandboxConfig: { enabled: false, docker: { image: "isotopes-sandbox:latest", network: "none" } },
-    });
-    const names = tools.map((t) => t.name);
-    expect(names).toContain("web_fetch");
-  });
 });
 
 describe("applyToolPolicy", () => {
-  const tools = [createTimeTool(), createWebFetchTool()];
+  const noopExecutor = { execute: async () => ({ exitCode: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) }), buildExecArgv: async (a: string[]) => a };
+  const tools = [createTimeTool(), createWebFetchTool({ executor: noopExecutor })];
 
   it("returns all tools when policy is undefined", () => {
     expect(applyToolPolicy(tools)).toHaveLength(2);

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -5,7 +5,6 @@ import {
   applyToolPolicy,
 } from "./index.js";
 import { createWebFetchTool } from "./web.js";
-import { ProcessRegistry } from "./exec.js";
 
 function getText(result: { content: Array<{ type: string; text?: string }> }): string {
   const block = result.content.find((c) => c.type === "text");
@@ -41,7 +40,6 @@ describe("createAgentTools", () => {
   const baseOpts = () => ({
     workspacePath: "/tmp/ws",
     agentId: "test",
-    processRegistry: new ProcessRegistry(),
   });
 
   it("registers fs tools + time + exec by default", () => {

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -14,7 +14,9 @@ import { type SandboxConfig } from "../../sandbox/config.js";
 import { createWebFetchTool } from "./web.js";
 import { createReactTools } from "./react.js";
 import type { LazyTransportContext } from "../../gateway/transport-context.js";
-import { createExecTools, ProcessRegistry } from "../../legacy/tools/exec.js";
+import { createExecTools, ProcessRegistry } from "./exec.js";
+import { HostExecutor } from "../host-executor.js";
+import type { Executor } from "../executor.js";
 import type { AgentRuntime } from "../runtime.js";
 import { RunValidationError } from "../types.js";
 import type { RunRequest } from "../types.js";
@@ -308,6 +310,9 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
   if (isSandboxed && opts.agentSandboxConfig) {
     sandboxExecutor!.registerAgent(opts.agentId, opts.agentSandboxConfig);
   }
+  const executor: Executor = isSandboxed
+    ? sandboxExecutor!.bind(opts.agentId)
+    : new HostExecutor();
   const fs: FsBridge = isSandboxed
     ? new SandboxFs(sandboxExecutor!, opts.agentId)
     : new HostFs();
@@ -321,10 +326,8 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
     createTimeTool(),
     ...createExecTools({
       cwd: opts.workspacePath,
+      executor,
       registry: opts.processRegistry,
-      sandboxExecutor: sandboxExecutor,
-      agentId: opts.agentId,
-      agentSandboxConfig: opts.agentSandboxConfig,
     }),
   ];
   if (spawnAgentEnabled && opts.runtime && opts.parentAgentId) {
@@ -335,10 +338,7 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
       ...(opts.spawnableAgentIds ? { spawnableAgentIds: opts.spawnableAgentIds } : {}),
     }));
   }
-  const networkIsolated = isSandboxed && opts.agentSandboxConfig?.docker?.network === "none";
-  if (!networkIsolated) {
-    tools.push(createWebFetchTool());
-  }
+  tools.push(createWebFetchTool({ executor }));
   if (opts.transportContext) {
     tools.push(...createReactTools(opts.transportContext));
   }

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -14,7 +14,7 @@ import { type SandboxConfig } from "../../sandbox/config.js";
 import { createWebFetchTool } from "./web.js";
 import { createReactTools } from "./react.js";
 import type { LazyTransportContext } from "../../gateway/transport-context.js";
-import { createExecTools, ProcessRegistry } from "./exec.js";
+import { createExecTools } from "./exec.js";
 import { HostExecutor } from "../host-executor.js";
 import type { Executor } from "../executor.js";
 import type { AgentRuntime } from "../runtime.js";
@@ -275,7 +275,6 @@ export interface CreateAgentToolsOptions {
   /** Pre-computed list of registered agent ids the LLM can address. */
   spawnableAgentIds?: string[];
   transportContext?: LazyTransportContext;
-  processRegistry: ProcessRegistry;
   agentSandboxConfig?: SandboxConfig;
 }
 
@@ -327,7 +326,6 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
     ...createExecTools({
       cwd: opts.workspacePath,
       executor,
-      registry: opts.processRegistry,
     }),
   ];
   if (spawnAgentEnabled && opts.runtime && opts.parentAgentId) {

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -336,7 +336,7 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
       ...(opts.spawnableAgentIds ? { spawnableAgentIds: opts.spawnableAgentIds } : {}),
     }));
   }
-  tools.push(createWebFetchTool({ executor }));
+  tools.push(createWebFetchTool(executor));
   if (opts.transportContext) {
     tools.push(...createReactTools(opts.transportContext));
   }

--- a/src/agent/tools/web.test.ts
+++ b/src/agent/tools/web.test.ts
@@ -27,24 +27,24 @@ function curlResponse(status: number, contentType: string, body: string): string
 
 describe("createWebFetchTool", () => {
   it("returns tool with correct schema", () => {
-    const tool = createWebFetchTool({ executor: mockExecutor("") });
+    const tool = createWebFetchTool(mockExecutor(""));
     expect(tool.name).toBe("web_fetch");
     expect(tool.parameters).toBeDefined();
   });
 
   it("rejects empty URL", async () => {
-    const result = await callTool(createWebFetchTool({ executor: mockExecutor("") }), { url: "" });
+    const result = await callTool(createWebFetchTool(mockExecutor("")), { url: "" });
     expect(result).toContain("[error] URL cannot be empty");
   });
 
   it("rejects invalid URL", async () => {
-    const result = await callTool(createWebFetchTool({ executor: mockExecutor("") }), { url: "not-a-url" });
+    const result = await callTool(createWebFetchTool(mockExecutor("")), { url: "not-a-url" });
     expect(result).toContain("[error] Invalid URL");
   });
 
   it("converts HTML to markdown preserving structure", async () => {
     const html = `<html><body><h1>Title</h1><p>Paragraph with <a href="https://example.com">link</a>.</p><ul><li>item one</li><li>item two</li></ul></body></html>`;
-    const tool = createWebFetchTool({ executor: mockExecutor(curlResponse(200, "text/html", html)) });
+    const tool = createWebFetchTool(mockExecutor(curlResponse(200, "text/html", html)));
 
     const result = await callTool(tool, { url: "https://example.com" });
     expect(result).toContain("# Title");
@@ -54,9 +54,7 @@ describe("createWebFetchTool", () => {
   });
 
   it("returns non-HTML content as-is", async () => {
-    const tool = createWebFetchTool({
-      executor: mockExecutor(curlResponse(200, "application/json", '{"key":"value"}')),
-    });
+    const tool = createWebFetchTool(mockExecutor(curlResponse(200, "application/json", '{"key":"value"}')));
     const result = await callTool(tool, { url: "https://api.example.com/data" });
     expect(result).toContain('{"key":"value"}');
   });
@@ -69,7 +67,7 @@ describe("createWebFetchTool", () => {
     }));
     const executor: Executor = { execute: exec, buildExecArgv: async (a) => a };
 
-    await callTool(createWebFetchTool({ executor }), { url: "http://example.com" });
+    await callTool(createWebFetchTool(executor), { url: "http://example.com" });
     const argv = exec.mock.calls[0][0] as string[];
     expect(argv[argv.length - 1]).toBe("https://example.com/");
   });
@@ -82,7 +80,7 @@ describe("createWebFetchTool", () => {
     }));
     const executor: Executor = { execute: exec, buildExecArgv: async (a) => a };
 
-    await callTool(createWebFetchTool({ executor }), { url: "http://localhost:8080/page" });
+    await callTool(createWebFetchTool(executor), { url: "http://localhost:8080/page" });
     const argv = exec.mock.calls[0][0] as string[];
     expect(argv[argv.length - 1]).toBe("http://localhost:8080/page");
   });
@@ -95,7 +93,7 @@ describe("createWebFetchTool", () => {
     }));
     const executor: Executor = { execute: exec, buildExecArgv: async (a) => a };
 
-    await callTool(createWebFetchTool({ executor }), { url: "https://example.com" });
+    await callTool(createWebFetchTool(executor), { url: "https://example.com" });
     const argv = exec.mock.calls[0][0] as string[];
     expect(argv).toContain("curl");
     const uaIdx = argv.indexOf("-A");
@@ -104,18 +102,14 @@ describe("createWebFetchTool", () => {
   });
 
   it("returns error for HTTP 4xx/5xx", async () => {
-    const tool = createWebFetchTool({
-      executor: mockExecutor(curlResponse(404, "text/html", "")),
-    });
+    const tool = createWebFetchTool(mockExecutor(curlResponse(404, "text/html", "")));
     const result = await callTool(tool, { url: "https://example.com/missing" });
     expect(result).toContain("[error] Failed to fetch");
     expect(result).toContain("404");
   });
 
   it("returns error when curl exits non-zero", async () => {
-    const tool = createWebFetchTool({
-      executor: mockExecutor("", { exitCode: 6, stderr: "Could not resolve host" }),
-    });
+    const tool = createWebFetchTool(mockExecutor("", { exitCode: 6, stderr: "Could not resolve host" }));
     const result = await callTool(tool, { url: "https://nonexistent.invalid" });
     expect(result).toContain("[error] Failed to fetch");
     expect(result).toContain("Could not resolve host");
@@ -123,9 +117,7 @@ describe("createWebFetchTool", () => {
 
   it("truncates content over 50KB", async () => {
     const huge = "x".repeat(60000);
-    const tool = createWebFetchTool({
-      executor: mockExecutor(curlResponse(200, "text/html", `<pre>${huge}</pre>`)),
-    });
+    const tool = createWebFetchTool(mockExecutor(curlResponse(200, "text/html", `<pre>${huge}</pre>`)));
     const result = await callTool(tool, { url: "https://example.com" });
     expect(result).toContain("[truncated]");
     expect(result.length).toBeLessThan(60000);

--- a/src/agent/tools/web.test.ts
+++ b/src/agent/tools/web.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createWebFetchTool } from "./web.js";
+import type { Executor } from "../executor.js";
 
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 
@@ -9,47 +10,43 @@ async function callTool(tool: AgentTool, args: unknown): Promise<string> {
   return block?.text ?? "";
 }
 
-function mockFetchHtml(html: string, contentType = "text/html"): void {
-  global.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    headers: new Map([["content-type", contentType]]) as unknown as Headers,
-    text: async () => html,
-  } as Response);
+function mockExecutor(curlStdout: string, opts?: { exitCode?: number; stderr?: string }): Executor {
+  return {
+    execute: vi.fn(async () => ({
+      exitCode: opts?.exitCode ?? 0,
+      stdout: Buffer.from(curlStdout),
+      stderr: Buffer.from(opts?.stderr ?? ""),
+    })),
+    buildExecArgv: vi.fn(async (a: string[]) => a),
+  };
+}
+
+function curlResponse(status: number, contentType: string, body: string): string {
+  return `HTTP/1.1 ${status} OK\r\nContent-Type: ${contentType}\r\nContent-Length: ${body.length}\r\n\r\n${body}`;
 }
 
 describe("createWebFetchTool", () => {
-  let originalFetch: typeof global.fetch;
-
-  beforeEach(() => { originalFetch = global.fetch; });
-  afterEach(() => { global.fetch = originalFetch; vi.restoreAllMocks(); });
-
   it("returns tool with correct schema", () => {
-    const tool = createWebFetchTool();
+    const tool = createWebFetchTool({ executor: mockExecutor("") });
     expect(tool.name).toBe("web_fetch");
     expect(tool.parameters).toBeDefined();
   });
 
   it("rejects empty URL", async () => {
-    const result = await callTool(createWebFetchTool(), { url: "" });
+    const result = await callTool(createWebFetchTool({ executor: mockExecutor("") }), { url: "" });
     expect(result).toContain("[error] URL cannot be empty");
   });
 
   it("rejects invalid URL", async () => {
-    const result = await callTool(createWebFetchTool(), { url: "not-a-url" });
+    const result = await callTool(createWebFetchTool({ executor: mockExecutor("") }), { url: "not-a-url" });
     expect(result).toContain("[error] Invalid URL");
   });
 
   it("converts HTML to markdown preserving structure", async () => {
-    mockFetchHtml(`
-      <html><body>
-        <h1>Title</h1>
-        <p>Paragraph with <a href="https://example.com">link</a>.</p>
-        <ul><li>item one</li><li>item two</li></ul>
-      </body></html>
-    `);
+    const html = `<html><body><h1>Title</h1><p>Paragraph with <a href="https://example.com">link</a>.</p><ul><li>item one</li><li>item two</li></ul></body></html>`;
+    const tool = createWebFetchTool({ executor: mockExecutor(curlResponse(200, "text/html", html)) });
 
-    const result = await callTool(createWebFetchTool(), { url: "https://example.com" });
+    const result = await callTool(tool, { url: "https://example.com" });
     expect(result).toContain("# Title");
     expect(result).toContain("[link](https://example.com)");
     expect(result).toMatch(/[*-]\s+item one/);
@@ -57,68 +54,79 @@ describe("createWebFetchTool", () => {
   });
 
   it("returns non-HTML content as-is", async () => {
-    mockFetchHtml('{"key":"value"}', "application/json");
-
-    const result = await callTool(createWebFetchTool(), { url: "https://api.example.com/data" });
+    const tool = createWebFetchTool({
+      executor: mockExecutor(curlResponse(200, "application/json", '{"key":"value"}')),
+    });
+    const result = await callTool(tool, { url: "https://api.example.com/data" });
     expect(result).toContain('{"key":"value"}');
   });
 
-  it("upgrades http to https for non-localhost URLs", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true, status: 200,
-      headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
-      text: async () => "<p>x</p>",
-    } as Response);
-    global.fetch = fetchMock;
+  it("upgrades http to https for non-localhost URLs in the curl argv", async () => {
+    const exec = vi.fn<(argv: string[], opts?: unknown) => Promise<{ exitCode: number; stdout: Buffer; stderr: Buffer }>>(async () => ({
+      exitCode: 0,
+      stdout: Buffer.from(curlResponse(200, "text/html", "<p>x</p>")),
+      stderr: Buffer.alloc(0),
+    }));
+    const executor: Executor = { execute: exec, buildExecArgv: async (a) => a };
 
-    await callTool(createWebFetchTool(), { url: "http://example.com" });
-    const calledUrl = fetchMock.mock.calls[0][0] as string;
-    expect(calledUrl).toBe("https://example.com/");
+    await callTool(createWebFetchTool({ executor }), { url: "http://example.com" });
+    const argv = exec.mock.calls[0][0] as string[];
+    expect(argv[argv.length - 1]).toBe("https://example.com/");
   });
 
   it("does NOT upgrade http for localhost", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true, status: 200,
-      headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
-      text: async () => "<p>x</p>",
-    } as Response);
-    global.fetch = fetchMock;
+    const exec = vi.fn<(argv: string[], opts?: unknown) => Promise<{ exitCode: number; stdout: Buffer; stderr: Buffer }>>(async () => ({
+      exitCode: 0,
+      stdout: Buffer.from(curlResponse(200, "text/html", "<p>x</p>")),
+      stderr: Buffer.alloc(0),
+    }));
+    const executor: Executor = { execute: exec, buildExecArgv: async (a) => a };
 
-    await callTool(createWebFetchTool(), { url: "http://localhost:8080/page" });
-    const calledUrl = fetchMock.mock.calls[0][0] as string;
-    expect(calledUrl).toBe("http://localhost:8080/page");
+    await callTool(createWebFetchTool({ executor }), { url: "http://localhost:8080/page" });
+    const argv = exec.mock.calls[0][0] as string[];
+    expect(argv[argv.length - 1]).toBe("http://localhost:8080/page");
   });
 
-  it("returns error on non-2xx response", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false, status: 404, statusText: "Not Found",
-      headers: new Map() as unknown as Headers,
-      text: async () => "",
-    } as Response);
+  it("uses curl with honest User-Agent", async () => {
+    const exec = vi.fn<(argv: string[], opts?: unknown) => Promise<{ exitCode: number; stdout: Buffer; stderr: Buffer }>>(async () => ({
+      exitCode: 0,
+      stdout: Buffer.from(curlResponse(200, "text/html", "<p>x</p>")),
+      stderr: Buffer.alloc(0),
+    }));
+    const executor: Executor = { execute: exec, buildExecArgv: async (a) => a };
 
-    const result = await callTool(createWebFetchTool(), { url: "https://example.com/missing" });
+    await callTool(createWebFetchTool({ executor }), { url: "https://example.com" });
+    const argv = exec.mock.calls[0][0] as string[];
+    expect(argv).toContain("curl");
+    const uaIdx = argv.indexOf("-A");
+    expect(uaIdx).toBeGreaterThan(-1);
+    expect(argv[uaIdx + 1]).toBe("isotopes-web/0.1");
+  });
+
+  it("returns error for HTTP 4xx/5xx", async () => {
+    const tool = createWebFetchTool({
+      executor: mockExecutor(curlResponse(404, "text/html", "")),
+    });
+    const result = await callTool(tool, { url: "https://example.com/missing" });
     expect(result).toContain("[error] Failed to fetch");
     expect(result).toContain("404");
   });
 
-  it("uses honest User-Agent (not faked Chrome)", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true, status: 200,
-      headers: new Map([["content-type", "text/html"]]) as unknown as Headers,
-      text: async () => "<p>x</p>",
-    } as Response);
-    global.fetch = fetchMock;
-
-    await callTool(createWebFetchTool(), { url: "https://example.com" });
-    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
-    expect(headers["User-Agent"]).toBe("isotopes-web/0.1");
+  it("returns error when curl exits non-zero", async () => {
+    const tool = createWebFetchTool({
+      executor: mockExecutor("", { exitCode: 6, stderr: "Could not resolve host" }),
+    });
+    const result = await callTool(tool, { url: "https://nonexistent.invalid" });
+    expect(result).toContain("[error] Failed to fetch");
+    expect(result).toContain("Could not resolve host");
   });
 
   it("truncates content over 50KB", async () => {
     const huge = "x".repeat(60000);
-    mockFetchHtml(`<html><body><pre>${huge}</pre></body></html>`);
-
-    const result = await callTool(createWebFetchTool(), { url: "https://example.com" });
+    const tool = createWebFetchTool({
+      executor: mockExecutor(curlResponse(200, "text/html", `<pre>${huge}</pre>`)),
+    });
+    const result = await callTool(tool, { url: "https://example.com" });
     expect(result).toContain("[truncated]");
     expect(result.length).toBeLessThan(60000);
   });

--- a/src/agent/tools/web.ts
+++ b/src/agent/tools/web.ts
@@ -21,13 +21,11 @@ function upgradeToHttps(rawUrl: string): string {
 }
 
 /**
- * Split `curl -i` output into the *final* response headers + body.
- * After redirects, curl emits one header block per hop separated by a
- * blank line; the last block belongs to the final response.
+ * Split `curl -i` output into the final response headers + body. After
+ * redirects, curl emits one header block per hop separated by a blank line;
+ * the last block belongs to the final response.
  */
 function parseCurlIResponse(raw: string): { headers: string; body: string } {
-  // Each header block ends with an empty line: \r\n\r\n or \n\n.
-  // Split on the first blank line to peel one block at a time, keep the last.
   const normalized = raw.replace(/\r\n/g, "\n");
   const parts: string[] = [];
   let rest = normalized;
@@ -36,10 +34,8 @@ function parseCurlIResponse(raw: string): { headers: string; body: string } {
     if (idx === -1) break;
     const head = rest.slice(0, idx);
     rest = rest.slice(idx + 2);
-    // Header blocks start with HTTP/<version>; if the chunk doesn't, we've
-    // entered the body — push remainder back as body.
+    // Once we hit a chunk that's not a header block, body has started.
     if (!/^HTTP\/[0-9.]+\s/i.test(head)) {
-      // Reattach the chunk that didn't look like headers
       rest = head + "\n\n" + rest;
       break;
     }

--- a/src/agent/tools/web.ts
+++ b/src/agent/tools/web.ts
@@ -84,12 +84,7 @@ const webFetchSchema = Type.Object({
   url: Type.String({ description: "The URL to fetch" }),
 });
 
-export interface WebFetchToolOptions {
-  executor: Executor;
-}
-
-export function createWebFetchTool(options: WebFetchToolOptions): AgentTool<typeof webFetchSchema> {
-  const { executor } = options;
+export function createWebFetchTool(executor: Executor): AgentTool<typeof webFetchSchema> {
   return {
     name: "web_fetch",
     label: "web_fetch",

--- a/src/agent/tools/web.ts
+++ b/src/agent/tools/web.ts
@@ -1,9 +1,10 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "typebox";
 import { NodeHtmlMarkdown } from "node-html-markdown";
+import type { Executor } from "../executor.js";
 
 const MAX_CONTENT_LENGTH = 50000;
-const REQUEST_TIMEOUT = 30000;
+const REQUEST_TIMEOUT_SEC = 30;
 const USER_AGENT = "isotopes-web/0.1";
 
 function textResult(text: string): AgentToolResult<undefined> {
@@ -19,36 +20,80 @@ function upgradeToHttps(rawUrl: string): string {
   return u.toString();
 }
 
-async function fetchAndConvert(url: string): Promise<string> {
-  const response = await fetch(upgradeToHttps(url), {
-    headers: {
-      "User-Agent": USER_AGENT,
-      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-    },
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT),
-    redirect: "follow",
-  });
+/**
+ * Split `curl -i` output into the *final* response headers + body.
+ * After redirects, curl emits one header block per hop separated by a
+ * blank line; the last block belongs to the final response.
+ */
+function parseCurlIResponse(raw: string): { headers: string; body: string } {
+  // Each header block ends with an empty line: \r\n\r\n or \n\n.
+  // Split on the first blank line to peel one block at a time, keep the last.
+  const normalized = raw.replace(/\r\n/g, "\n");
+  const parts: string[] = [];
+  let rest = normalized;
+  while (true) {
+    const idx = rest.indexOf("\n\n");
+    if (idx === -1) break;
+    const head = rest.slice(0, idx);
+    rest = rest.slice(idx + 2);
+    // Header blocks start with HTTP/<version>; if the chunk doesn't, we've
+    // entered the body — push remainder back as body.
+    if (!/^HTTP\/[0-9.]+\s/i.test(head)) {
+      // Reattach the chunk that didn't look like headers
+      rest = head + "\n\n" + rest;
+      break;
+    }
+    parts.push(head);
+  }
+  const headers = parts[parts.length - 1] ?? "";
+  return { headers, body: rest };
+}
 
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+async function fetchAndConvert(executor: Executor, url: string): Promise<string> {
+  const finalUrl = upgradeToHttps(url);
+  const argv = [
+    "curl",
+    "-sS",
+    "-L",
+    "-i",
+    "--max-time", String(REQUEST_TIMEOUT_SEC),
+    "-A", USER_AGENT,
+    "-H", "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    finalUrl,
+  ];
+
+  const result = await executor.execute(argv, { timeout: (REQUEST_TIMEOUT_SEC + 5) * 1000 });
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.toString("utf8").trim();
+    throw new Error(`curl exit ${result.exitCode}: ${stderr || "no stderr"}`);
   }
 
-  const contentType = response.headers.get("content-type") || "";
-  const body = await response.text();
+  const raw = result.stdout.toString("utf8");
+  const { headers, body } = parseCurlIResponse(raw);
 
-  if (!contentType.includes("html")) {
-    return body.length > MAX_CONTENT_LENGTH ? body.slice(0, MAX_CONTENT_LENGTH) + "\n\n[truncated]" : body;
+  const statusMatch = headers.match(/^HTTP\/[0-9.]+\s+(\d+)\s*([^\n]*)/i);
+  const status = statusMatch ? parseInt(statusMatch[1], 10) : 0;
+  if (!status || status >= 400) {
+    throw new Error(`HTTP ${status || "?"}${statusMatch?.[2] ? `: ${statusMatch[2].trim()}` : ""}`);
   }
 
-  const md = NodeHtmlMarkdown.translate(body);
-  return md.length > MAX_CONTENT_LENGTH ? md.slice(0, MAX_CONTENT_LENGTH) + "\n\n[truncated]" : md;
+  const isHtml = /content-type:\s*[^\n]*html/i.test(headers);
+  const content = isHtml ? NodeHtmlMarkdown.translate(body) : body;
+  return content.length > MAX_CONTENT_LENGTH
+    ? content.slice(0, MAX_CONTENT_LENGTH) + "\n\n[truncated]"
+    : content;
 }
 
 const webFetchSchema = Type.Object({
   url: Type.String({ description: "The URL to fetch" }),
 });
 
-export function createWebFetchTool(): AgentTool<typeof webFetchSchema> {
+export interface WebFetchToolOptions {
+  executor: Executor;
+}
+
+export function createWebFetchTool(options: WebFetchToolOptions): AgentTool<typeof webFetchSchema> {
+  const { executor } = options;
   return {
     name: "web_fetch",
     label: "web_fetch",
@@ -59,7 +104,7 @@ export function createWebFetchTool(): AgentTool<typeof webFetchSchema> {
       if (!url || url.trim().length === 0) return textResult("[error] URL cannot be empty");
       try { new URL(url); } catch { return textResult(`[error] Invalid URL: ${url}`); }
       try {
-        const content = await fetchAndConvert(url);
+        const content = await fetchAndConvert(executor, url);
         return textResult(`Content from ${url}:\n\n${content}`);
       } catch (error) {
         const err = error instanceof Error ? error.message : String(error);

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { SessionStoreManager } from "./agent/runners/pi/session-store.js";
 import { createLogger } from "./logging/logger.js";
 import { LazyTransportContext } from "./gateway/transport-context.js";
-import { ProcessRegistry } from "./legacy/tools/exec.js";
+import { ProcessRegistry } from "./agent/tools/exec.js";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { configureToolsLayer, shutdownToolsLayer } from "./agent/tools/index.js";
 import {

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,6 @@ import path from "node:path";
 import { SessionStoreManager } from "./agent/runners/pi/session-store.js";
 import { createLogger } from "./logging/logger.js";
 import { LazyTransportContext } from "./gateway/transport-context.js";
-import { ProcessRegistry } from "./agent/tools/exec.js";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { configureToolsLayer, shutdownToolsLayer } from "./agent/tools/index.js";
 import {
@@ -58,7 +57,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
 
   const agentWorkspaces = new Map<string, string>();
   const transportContexts = new Map<string, LazyTransportContext>();
-  const processRegistries = new Map<string, ProcessRegistry>();
   const toolRegistries = new Map<string, AgentTool[]>();
 
   const sandboxBaseConfig = config.sandbox
@@ -86,7 +84,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
 
     if (result.workspacePath !== null) agentWorkspaces.set(result.agent.id, result.workspacePath);
     transportContexts.set(result.agent.id, transportCtx);
-    processRegistries.set(result.agent.id, result.processRegistry);
     if (result.tools.length > 0) toolRegistries.set(result.agent.id, result.tools);
   }
 
@@ -264,10 +261,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     await pluginManager.shutdown();
     await apiServer.stop();
     sessionStoreManager.destroyAll();
-
-    for (const registry of processRegistries.values()) {
-      registry.clear();
-    }
 
     try {
       await shutdownToolsLayer();

--- a/src/legacy/tools/index.ts
+++ b/src/legacy/tools/index.ts
@@ -1,8 +1,0 @@
-export {
-  ProcessRegistry,
-  createExecTool,
-  createProcessListTool,
-  createProcessKillTool,
-  createExecTools,
-} from "./exec.js";
-export type { ExecToolOptions, ProcessInfo } from "./exec.js";

--- a/src/sandbox/container.test.ts
+++ b/src/sandbox/container.test.ts
@@ -304,16 +304,16 @@ describe("ContainerManager", () => {
       expect(result.stdout.toString("utf8")).toBe("你好");
     });
 
-    it("flags truncation and appends marker when output exceeds 1MB", async () => {
-      // Generate 1.5 MB of output to overflow EXEC_MAX_OUTPUT_BYTES (1 MB).
-      const huge = "x".repeat(1024 * 1024 + 512 * 1024);
+    it("flags truncation and appends marker when output exceeds 100KB", async () => {
+      const cap = 100 * 1024;
+      const huge = "x".repeat(cap + 50 * 1024);
       mockSpawn.mockReturnValue(fakeChild({ code: 0, stdout: huge }));
 
       const result = await manager.exec("abc123", ["cat", "/big/file"]);
 
       expect(result.truncated).toBe(true);
-      expect(result.stdout.length).toBe(1024 * 1024 + "\n[output truncated at 1048576 bytes]".length);
-      expect(result.stdout.toString("utf8").endsWith("[output truncated at 1048576 bytes]")).toBe(true);
+      expect(result.stdout.length).toBe(cap + `\n[output truncated at ${cap} bytes]`.length);
+      expect(result.stdout.toString("utf8").endsWith(`[output truncated at ${cap} bytes]`)).toBe(true);
     });
 
   });

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -1,11 +1,9 @@
 import { spawn } from "node:child_process";
 import { createLogger } from "../logging/logger.js";
+import { EXEC_MAX_OUTPUT_BYTES } from "../agent/executor.js";
 import type { DockerConfig, Mount, WorkspaceAccess } from "./config.js";
 
 const log = createLogger("sandbox:container");
-
-/** Cap collected stdout/stderr per `exec()` call to prevent OOM from runaway commands. */
-const EXEC_MAX_OUTPUT_BYTES = 100 * 1024;
 
 export type ContainerStatus = "created" | "running" | "paused" | "exited";
 

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -5,7 +5,7 @@ import type { DockerConfig, Mount, WorkspaceAccess } from "./config.js";
 const log = createLogger("sandbox:container");
 
 /** Cap collected stdout/stderr per `exec()` call to prevent OOM from runaway commands. */
-const EXEC_MAX_OUTPUT_BYTES = 1024 * 1024;
+const EXEC_MAX_OUTPUT_BYTES = 100 * 1024;
 
 export type ContainerStatus = "created" | "running" | "paused" | "exited";
 
@@ -17,13 +17,8 @@ export interface ContainerInfo {
   createdAt: Date;
 }
 
-export interface ExecResult {
-  exitCode: number;
-  stdout: Buffer;
-  stderr: Buffer;
-  /** True iff stdout or stderr was capped at EXEC_MAX_OUTPUT_BYTES. */
-  truncated?: boolean;
-}
+import type { ExecResult } from "../agent/executor.js";
+export type { ExecResult };
 
 /** Wraps the `docker` CLI rather than the API to avoid heavy SDK deps. Stateless — DockerConfig is per-call. */
 export class ContainerManager {

--- a/src/sandbox/container.ts
+++ b/src/sandbox/container.ts
@@ -18,7 +18,6 @@ export interface ContainerInfo {
 }
 
 import type { ExecResult } from "../agent/executor.js";
-export type { ExecResult };
 
 /** Wraps the `docker` CLI rather than the API to avoid heavy SDK deps. Stateless — DockerConfig is per-call. */
 export class ContainerManager {

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -1,19 +1,15 @@
 // src/sandbox/executor.ts — Per-agent container lifecycle + command routing.
 
 import { createLogger } from "../logging/logger.js";
-import { ContainerManager, type ContainerInfo, type ExecResult } from "./container.js";
+import { ContainerManager, type ContainerInfo } from "./container.js";
+import type { Executor, ExecOptions, ExecResult } from "../agent/executor.js";
 import { type DockerConfig, type Mount, type SandboxConfig, type WorkspaceAccess } from "./config.js";
 
 const log = createLogger("sandbox:executor");
 
-export interface SandboxExecOptions {
-  workspacePath?: string;
-  timeout?: number;
-  stdin?: Buffer | string;
-}
-
 /**
  * Lazily creates one container per agent and routes commands through it.
+ * Use `bind(agentId)` to get a per-agent Executor for tool consumption.
  */
 export class SandboxExecutor {
   private containers: Map<string, ContainerInfo> = new Map();
@@ -37,10 +33,18 @@ export class SandboxExecutor {
     if (config.workspaceAccess) this.agentWorkspaceAccess.set(agentId, config.workspaceAccess);
   }
 
+  /** Returns a per-agent Executor that routes through this agent's container. */
+  bind(agentId: string): Executor {
+    return {
+      execute: (argv, opts) => this.execute(agentId, argv, opts),
+      buildExecArgv: (argv, opts) => this.buildExecArgv(agentId, argv, opts),
+    };
+  }
+
   async execute(
     agentId: string,
     command: string[],
-    options?: SandboxExecOptions,
+    options?: ExecOptions,
   ): Promise<ExecResult> {
     const container = await this.ensureContainer(agentId, options?.workspacePath);
     const execOpts = options?.stdin !== undefined ? { stdin: options.stdin } : undefined;
@@ -53,7 +57,7 @@ export class SandboxExecutor {
   async buildExecArgv(
     agentId: string,
     command: string[],
-    options?: SandboxExecOptions,
+    options?: ExecOptions,
   ): Promise<string[]> {
     const container = await this.ensureContainer(agentId, options?.workspacePath);
     return this.containerManager.buildExecArgv(container.id, command);

--- a/src/sandbox/fs-bridge.ts
+++ b/src/sandbox/fs-bridge.ts
@@ -2,7 +2,7 @@
 // HostFs (node:fs) for non-sandbox; SandboxFs (all ops via docker exec) for sandbox.
 
 import fs from "node:fs/promises";
-import type { ExecResult } from "./container.js";
+import type { ExecResult } from "../agent/executor.js";
 import type { SandboxExecutor } from "./executor.js";
 
 export type FsErrorCode = "ENOENT" | "EACCES" | "EEXIST" | "EISDIR" | "ENOTDIR" | "EUNKNOWN";

--- a/tests/e2e-smoke.test.ts
+++ b/tests/e2e-smoke.test.ts
@@ -12,7 +12,7 @@ import {
   createAgentTools,
   applyToolPolicy,
 } from "../src/agent/tools/index.js";
-import { createExecTools, ProcessRegistry } from "../src/agent/tools/exec.js";
+import { createExecTools } from "../src/agent/tools/exec.js";
 import { createWebFetchTool } from "../src/agent/tools/web.js";
 import { HostExecutor } from "../src/agent/host-executor.js";
 
@@ -52,7 +52,7 @@ describe("workspace context", () => {
 
 describe("read tool (SDK)", () => {
   it("reads a file from the workspace", async () => {
-    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test", processRegistry: new ProcessRegistry() });
+    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test" });
     const result = await callTool(findTool(tools, "read"), { path: "hello.txt" });
     expect(result).toContain("Hello, world!");
   });
@@ -63,7 +63,7 @@ describe("edit tool (SDK)", () => {
     const editFile = path.join(tmpDir, "editable.txt");
     await fs.writeFile(editFile, "foo bar baz\n");
 
-    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test", processRegistry: new ProcessRegistry() });
+    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test" });
     await callTool(findTool(tools, "edit"), {
       path: editFile,
       edits: [{ oldText: "bar", newText: "qux" }],
@@ -117,7 +117,7 @@ describe("NO_REPLY suppression", () => {
 
 describe("tool policy deny", () => {
   it("removes denied tools", () => {
-    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test", processRegistry: new ProcessRegistry() });
+    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test" });
     const filtered = applyToolPolicy(tools, { deny: ["read"] });
     const names = filtered.map((t) => t.name);
     expect(names).not.toContain("read");
@@ -128,20 +128,17 @@ describe("tool policy deny", () => {
   it("exec tool denied via policy is not present", () => {
     const execTools = createExecTools({ cwd: tmpDir, executor: new HostExecutor() });
     const filtered = applyToolPolicy(execTools, { deny: ["exec"] });
-    const names = filtered.map((t) => t.name);
-    expect(names).not.toContain("exec");
-    expect(names).toContain("process_list");
-    expect(names).toContain("process_kill");
+    expect(filtered).toHaveLength(0);
   });
 
   it("allow list restricts to only specified tools", () => {
-    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test", processRegistry: new ProcessRegistry() });
+    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test" });
     const filtered = applyToolPolicy(tools, { allow: ["read", "edit"] });
     expect(filtered.map((t) => t.name).sort()).toEqual(["edit", "read"]);
   });
 
   it("deny takes precedence over allow", () => {
-    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test", processRegistry: new ProcessRegistry() });
+    const tools = createAgentTools({ workspacePath: tmpDir, agentId: "test" });
     const filtered = applyToolPolicy(tools, {
       allow: ["read", "edit"],
       deny: ["edit"],
@@ -157,7 +154,7 @@ describe("full tool wiring", () => {
     const all = createAgentTools({
       workspacePath: tmpDir,
       agentId: "test",
-      processRegistry: new ProcessRegistry(),
+      
     });
     const names = new Set(all.map((t) => t.name));
 
@@ -168,8 +165,6 @@ describe("full tool wiring", () => {
     expect(names.has("exec")).toBe(true);
     expect(names.has("web_fetch")).toBe(true);
     expect(names.has("get_current_time")).toBe(true);
-    expect(names.has("process_list")).toBe(true);
-    expect(names.has("process_kill")).toBe(true);
 
     // Smoke: execute a couple of tools end-to-end
     const readResult = await callTool(findTool(all, "read"), { path: "SOUL.md" });

--- a/tests/e2e-smoke.test.ts
+++ b/tests/e2e-smoke.test.ts
@@ -12,8 +12,9 @@ import {
   createAgentTools,
   applyToolPolicy,
 } from "../src/agent/tools/index.js";
-import { createExecTools, ProcessRegistry } from "../src/legacy/tools/exec.js";
+import { createExecTools, ProcessRegistry } from "../src/agent/tools/exec.js";
 import { createWebFetchTool } from "../src/agent/tools/web.js";
+import { HostExecutor } from "../src/agent/host-executor.js";
 
 async function callTool(tool: AgentTool, args: unknown): Promise<string> {
   const result: AgentToolResult<unknown> = await tool.execute("test-call", args as never);
@@ -74,14 +75,14 @@ describe("edit tool (SDK)", () => {
 
 describe("exec tool", () => {
   it("runs a shell command and returns stdout", async () => {
-    const tools = createExecTools({ cwd: tmpDir });
+    const tools = createExecTools({ cwd: tmpDir, executor: new HostExecutor() });
     const result = JSON.parse(await callTool(findTool(tools, "exec"), { command: "echo hello" }));
     expect(result.exit_code).toBe(0);
     expect(result.stdout.trim()).toBe("hello");
   });
 
   it("reports non-zero exit codes", async () => {
-    const tools = createExecTools({ cwd: tmpDir });
+    const tools = createExecTools({ cwd: tmpDir, executor: new HostExecutor() });
     const result = JSON.parse(await callTool(findTool(tools, "exec"), { command: "exit 42" }));
     expect(result.exit_code).not.toBe(0);
   });
@@ -89,13 +90,13 @@ describe("exec tool", () => {
 
 describe("web_fetch tool", () => {
   it("fetches a URL and returns content", async () => {
-    const tool = createWebFetchTool();
+    const tool = createWebFetchTool({ executor: new HostExecutor() });
     const result = await callTool(tool, { url: "https://httpbin.org/get" });
     expect(result).toContain("httpbin.org");
   }, 30_000);
 
   it("returns error for invalid URL", async () => {
-    const tool = createWebFetchTool();
+    const tool = createWebFetchTool({ executor: new HostExecutor() });
     const result = await callTool(tool, { url: "not-a-url" });
     expect(result).toContain("[error]");
   });
@@ -125,7 +126,7 @@ describe("tool policy deny", () => {
   });
 
   it("exec tool denied via policy is not present", () => {
-    const execTools = createExecTools({ cwd: tmpDir });
+    const execTools = createExecTools({ cwd: tmpDir, executor: new HostExecutor() });
     const filtered = applyToolPolicy(execTools, { deny: ["exec"] });
     const names = filtered.map((t) => t.name);
     expect(names).not.toContain("exec");

--- a/tests/e2e-smoke.test.ts
+++ b/tests/e2e-smoke.test.ts
@@ -90,13 +90,13 @@ describe("exec tool", () => {
 
 describe("web_fetch tool", () => {
   it("fetches a URL and returns content", async () => {
-    const tool = createWebFetchTool({ executor: new HostExecutor() });
+    const tool = createWebFetchTool(new HostExecutor());
     const result = await callTool(tool, { url: "https://httpbin.org/get" });
     expect(result).toContain("httpbin.org");
   }, 30_000);
 
   it("returns error for invalid URL", async () => {
-    const tool = createWebFetchTool({ executor: new HostExecutor() });
+    const tool = createWebFetchTool(new HostExecutor());
     const result = await callTool(tool, { url: "not-a-url" });
     expect(result).toContain("[error]");
   });


### PR DESCRIPTION
Implements the Executor design from #722 and removes the broken background-exec mode (#734).

## Why

Tools that run commands (\`exec\`, \`web_fetch\`) used to branch host-vs-sandbox internally. Any tool author who forgot the branching silently bypassed the sandbox — exactly what happened with \`web_fetch\` in #720, where host \`fetch\` sailed past \`docker --network: none\`.

Symmetric with FsBridge: tools take an \`Executor\` and don't know whether they got a host or sandbox backend.

## Architecture

\`\`\`
                per-agent contract           shared infra
filesystem:     HostFs / SandboxFs           SandboxExecutor (containers)
exec:           HostExecutor / .bind(id)     SandboxExecutor (containers)
                ─────────── Executor ───────────
\`\`\`

- New \`Executor\` interface in \`src/agent/executor.ts\`
- \`HostExecutor\` (\`src/agent/host-executor.ts\`) — \`node:child_process.spawn\`
- \`SandboxExecutor.bind(agentId): Executor\` — per-agent adapter
- \`createAgentTools\` picks an executor per agent and passes it to tools

## Tools

- **\`exec.ts\`**: foreground only. Wraps in \`[\"sh\", \"-c\", cmd]\` → \`executor.execute()\`. Background mode + ProcessRegistry deleted (see below).
- **\`web.ts\`**: replaces \`node:fetch\` with \`[\"curl\", \"-sS\", \"-L\", \"-i\", ...]\` through executor. Markdown conversion stays on host.

## Side effects

- \`src/legacy/tools/\` directory entirely removed
- **Background exec deleted**: \`exec({background:true})\`, \`process_list\`, \`process_kill\`, \`ProcessRegistry\` — all gone. The kill was broken (sh wrapper doesn't forward signals; details in #734) and zero user code referenced it. **Closes #734.** Agents that want long-running commands use native shell: \`exec(\"cmd > /tmp/log 2>&1 &\"); exec(\"kill <pid>\")\`.
- **Exec output cap unified at 100KB** (was 100KB host / 1MB sandbox). The 1MB sandbox value was a bug — 1MB ≈ 250K tokens, larger than a 200K context window. **Closes #705.**
- Drops the #720 \"omit web_fetch when network: none\" patch — sandbox routing handles it correctly now (docker network=none rejects curl at the docker layer)
- HostExecutor reject-on-timeout flag prevents the close handler from resolving with the SIGTERM exit code after a timeout fires
- ExecResult type single-source-of-truth in \`src/agent/executor.ts\`

## Migration

\`createExecTool\` / \`createExecTools\` / \`createWebFetchTool\` now require an \`executor\` field. \`processRegistry\` field removed everywhere. No external consumers — only test files and internal wiring needed updating.

## Follow-ups (not blocking)

- **#733** (P3): \`parseCurlIResponse\` mis-parses bodies whose first line is a literal \`HTTP/x.x\` — silent wrong content for one fetch, no crash, very low probability

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (754 / 754 passing — 27 fewer than before because the deleted ProcessRegistry tests went with it)
- New: Executor delegation tests in exec.test.ts (foreground mock + HostExecutor end-to-end)
- New: web.test.ts mocks executor returning curl-style HTTP/1.1 responses

Refs #722, closes #705, closes #734.