### PR TITLE
refactor(config): audit, delete dead fields, drop object-form agents, rewrite example.yaml

### DIFF
--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -1,6 +1,7 @@
 # Isotopes — Example Configuration
 # Copy to ~/.isotopes/isotopes.yaml and customize.
 # Commented values show defaults — uncomment only when you need to change them.
+# Every field in this file is consumed by the runtime; no dead options.
 
 # =============================================================================
 # PROVIDER — single global LLM provider (required)
@@ -16,72 +17,74 @@ provider:
 
 # =============================================================================
 # AGENTS — at least one is required
+#
 # Two equivalent forms:
 #   1) array form (shown below)
 #   2) object form with shared defaults:
 #        agents:
 #          defaults:
 #            tools:
-#              cli: false
-#            compaction:
-#              mode: safeguard
+#              deny: ["shell"]
 #            sandbox:
-#              mode: off
+#              enabled: true
 #          list:
 #            - id: main
 #            - id: helper
-#              model: claude-sonnet-4.5     # per-agent model override
+#              model: claude-sonnet-4.6
 # =============================================================================
 agents:
   - id: main
-    # model: claude-sonnet-4.5              # falls back to provider.defaultModel when omitted
-    # workspace: workspace-main             # absolute or relative to ISOTOPES_HOME
-    # allowedWorkspaces:                    # extra dirs subagents may cwd into
-    #   - /path/to/repo
-    # heartbeatInterval: 0                  # ms; 0 = disabled (legacy field)
-    # heartbeatPrompt: "what's next?"       # custom heartbeat prompt
-    # heartbeat:                            # periodic wake-up (#191)
-    #   enabled: false
-    #   intervalSeconds: 300                # 5 min default
+    # runner: pi                            # pi (default) | claude
+    # enabled: true                         # set false to skip loading this agent
+    # spawnable: false                      # set true to let other agents spawn this one
+    # sessionPolicy: parent-reuse           # parent-reuse (default) | always-new
+    # workspace: workspace-main             # absolute path or relative to ISOTOPES_HOME (default: workspace-<id>/)
+    # model: claude-sonnet-4.6              # falls back to provider.defaultModel when omitted
+    #
     # tools:                                # per-agent override (see global "tools" below)
-    #   cli: true
-    # compaction:                           # per-agent override
-    #   mode: aggressive
+    #   allow: ["read", "write"]            # if non-empty, ONLY these tools are exposed
+    #   deny: ["shell"]                     # always-blocked tools (wins over allow)
+    #
     # sandbox:                              # per-agent override (see global "sandbox" below)
     #   enabled: true
-    # cron:                                 # per-agent scheduled prompts (#193)
+    #
+    # heartbeat:                            # periodic wake-up
+    #   enabled: false
+    #   intervalSeconds: 300                # 5 min default
+    #
+    # cron:                                 # per-agent scheduled prompts
     #   tasks:
     #     - name: morning-standup
-    #       schedule: "0 9 * * 1-5"
-    #       channel: discord:channel-id
+    #       schedule: "0 9 * * 1-5"         # cron expression
+    #       channel: discord:channel-id     # delivery target (currently informational — see #730)
     #       prompt: "Post the daily standup."
-    #       enabled: true
+    #       enabled: true                   # default true
 
 # =============================================================================
 # TOOLS — global default tool policy (per-agent override under agents.<id>.tools)
 # =============================================================================
 # tools:
-#   cli: false                       # allow shell execution
-#   fs:
-#     workspaceOnly: true            # restrict file tools to workspace dir
-#   allow: []                        # if non-empty, ONLY these tools are exposed
-#   deny: []                         # always-blocked tools (wins over allow)
+#   allow: []                       # if non-empty, ONLY these tools are exposed
+#   deny: []                        # always-blocked tools (wins over allow)
 
 # =============================================================================
-# COMPACTION — context window management (default applied to all agents)
+# SANDBOX — Docker-isolated tool execution (default for all agents)
 # =============================================================================
-compaction:
-  mode: safeguard                    # off | safeguard | aggressive
-  # contextWindow: 128000            # token budget
-  # threshold: 0.8                   # safeguard default 0.8, aggressive default 0.5
-  # preserveRecent: 10               # recent messages to keep verbatim
-
-# =============================================================================
-# SESSION — session lifecycle
-# =============================================================================
-# session:
-#   ttl: 86400                       # 24h
-#   cleanupInterval: 3600            # 1h sweep
+# sandbox:
+#   enabled: false                    # true to route exec/file tools through Docker
+#   workspaceAccess: rw               # rw | ro
+#   mounts:                           # extra host paths to expose inside container
+#     - host: /Users/me/data
+#       container: /data
+#       readOnly: true                # default false
+#   docker:
+#     image: isotopes-sandbox:latest
+#     network: bridge                 # bridge | host | none
+#     extraHosts: []
+#     cpuLimit: 1.0
+#     memoryLimit: 512m
+#     pidsLimit: 256
+#     noNewPrivileges: true           # default true; only set false if a tool legitimately needs setuid
 
 # =============================================================================
 # CHANNELS — Discord transport + per-guild settings
@@ -109,6 +112,7 @@ channels:
         #   "bot-user-id": main
         # adminUsers:                    # discord user ids allowed to run /slash commands
         #   - "user-id"
+        # replyToMode: reply             # how the bot addresses messages
 
         threadBindings:
           enabled: true
@@ -116,27 +120,17 @@ channels:
           # sendFarewell: false
           # farewellMessage: "Bye!"
 
-        # subagentStreaming:             # M8: stream subagent output to Discord
-        #   enabled: true
-        #   showToolCalls: true
-
         # context:                       # all fields optional, defaults shown
-        #   historyTurns: 20
         #   channelHistory: true
         #   channelHistoryLimit: 20
         #   dedupe: true
         #   debounce: false
         #   debounceWindowMs: 1500
-        #   pruning:
-        #     protectRecent: 3
-        #     headChars: 1500
-        #     tailChars: 1500
 
         # guilds:                        # per-guild runtime overrides
         #   "1480866703880487034":       # guild id
         #     requireMention: false      # respond to all messages in this guild
         #     context:                   # per-guild context overrides
-        #       historyTurns: 30
         #       channelHistory: true
         #       channelHistoryLimit: 50
 
@@ -146,40 +140,18 @@ channels:
       #   defaultAgentId: helper
 
 # =============================================================================
-# Built-in runners (claude / subagent) live alongside user agents — both are
-# enabled and spawnable by default. Override only if you need to opt out.
-# =============================================================================
-# - id: claude
-#   enabled: false
-# - id: subagent
-#   spawnable: false
-
-# =============================================================================
 # CRON — channel-level scheduled jobs (per-agent cron lives under agents.<id>.cron)
 # =============================================================================
 # cron:
 #   - name: daily-report
 #     expression: "0 9 * * *"
 #     agentId: main
-#     enabled: true
+#     enabled: true                   # default true
 #     action:
 #       type: prompt                  # prompt | message | callback
 #       prompt: "Generate daily report"
 #     # action: { type: message, content: "Good morning!" }
 #     # action: { type: callback, handler: generateReport }
-
-# =============================================================================
-# SANDBOX — Docker-isolated code execution (default for all agents)
-# =============================================================================
-# sandbox:
-#   enabled: false                    # true to route exec/file tools through Docker
-#   workspaceAccess: rw               # rw | ro
-#   docker:
-#     image: isotopes-sandbox:latest
-#     network: bridge                 # bridge | host | none
-#     extraHosts: []
-#     cpuLimit: 1.0
-#     memoryLimit: 512m
 
 # =============================================================================
 # PLUGINS — optional plugin configurations (keyed by plugin id)

--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -17,20 +17,6 @@ provider:
 
 # =============================================================================
 # AGENTS — at least one is required
-#
-# Two equivalent forms:
-#   1) array form (shown below)
-#   2) object form with shared defaults:
-#        agents:
-#          defaults:
-#            tools:
-#              deny: ["shell"]
-#            sandbox:
-#              enabled: true
-#          list:
-#            - id: main
-#            - id: helper
-#              model: claude-sonnet-4.6
 # =============================================================================
 agents:
   - id: main

--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -98,7 +98,6 @@ channels:
         #   "bot-user-id": main
         # adminUsers:                    # discord user ids allowed to run /slash commands
         #   - "user-id"
-        # replyToMode: reply             # how the bot addresses messages
 
         threadBindings:
           enabled: true

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -22,7 +22,6 @@ import {
 import {
   toAgentConfig,
   type AgentConfigFile,
-  type AgentDefaultsConfigFile,
   type SandboxConfigFile,
   type AgentToolsConfigFile,
   type ProviderConfigFile,
@@ -70,7 +69,6 @@ export interface AgentRuntimeOptions {
 
 export interface AddAgentOptions {
   agentFile: AgentConfigFile;
-  agentDefaults?: AgentDefaultsConfigFile;
   provider?: ProviderConfigFile;
   globalTools?: AgentToolsConfigFile;
   sandbox?: SandboxConfigFile;
@@ -210,8 +208,8 @@ export class AgentRuntime {
 
   /** Single registration entry point. Branches on agent.runner. */
   async register(opts: AddAgentOptions): Promise<AddAgentResult> {
-    const { agentFile, agentDefaults, provider, globalTools, sandbox } = opts;
-    const agentConfig = toAgentConfig(agentFile, agentDefaults, provider, globalTools, sandbox);
+    const { agentFile, provider, globalTools, sandbox } = opts;
+    const agentConfig = toAgentConfig(agentFile, provider, globalTools, sandbox);
     return agentConfig.runner === "claude"
       ? this.registerClaude(agentConfig)
       : this.registerPi(agentConfig, opts);

--- a/src/app.ts
+++ b/src/app.ts
@@ -61,9 +61,8 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   const processRegistries = new Map<string, ProcessRegistry>();
   const toolRegistries = new Map<string, AgentTool[]>();
 
-  const baseSandboxFile = config.sandbox;
-  const sandboxBaseConfig = baseSandboxFile
-    ? resolveSandboxConfigFromFile("<agents-defaults>", undefined, baseSandboxFile)
+  const sandboxBaseConfig = config.sandbox
+    ? resolveSandboxConfigFromFile("<global>", undefined, config.sandbox)
     : undefined;
   configureToolsLayer({ sandboxBaseConfig });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -61,7 +61,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
   const processRegistries = new Map<string, ProcessRegistry>();
   const toolRegistries = new Map<string, AgentTool[]>();
 
-  const baseSandboxFile = config.agentDefaults?.sandbox ?? config.sandbox;
+  const baseSandboxFile = config.sandbox;
   const sandboxBaseConfig = baseSandboxFile
     ? resolveSandboxConfigFromFile("<agents-defaults>", undefined, baseSandboxFile)
     : undefined;
@@ -77,7 +77,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     const sessionStore = await sessionStoreManager.getOrCreate(agentFile.id);
     const result = await agentRuntime.register({
       agentFile,
-      agentDefaults: config.agentDefaults,
       provider: config.provider,
       globalTools: config.tools,
       sandbox: config.sandbox,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -155,70 +155,6 @@ agents:
       expect(config.agents[0].id).toBe("assistant");
     });
 
-    it("loads object-form agents with defaults", async () => {
-      const configPath = path.join(tempDir, "defaults.yaml");
-      await fs.writeFile(
-        configPath,
-        `
-provider:
-  type: anthropic
-  baseUrl: https://proxy.example.com
-  defaultModel: claude-sonnet
-
-agents:
-  defaults:
-    tools:
-      deny: [shell]
-  list:
-    - id: major
-    - id: tachikoma
-      model: claude-opus-4.5
-`,
-      );
-
-      const config = await loadConfig(configPath);
-
-      // agents should be normalized to array
-      expect(Array.isArray(config.agents)).toBe(true);
-      expect(config.agents[0].id).toBe("major");
-      expect(config.agents[1].id).toBe("tachikoma");
-      expect(config.agents[1].model).toBe("claude-opus-4.5");
-
-      // agentDefaults should be extracted
-      expect(config.agentDefaults).toBeDefined();
-      expect(config.agentDefaults?.tools?.deny).toEqual(["shell"]);
-    });
-
-    it("legacy array form still works and agentDefaults is undefined", async () => {
-      const configPath = path.join(tempDir, "legacy.yaml");
-      await fs.writeFile(
-        configPath,
-        `
-agents:
-  - id: test
-`,
-      );
-
-      const config = await loadConfig(configPath);
-
-      expect(Array.isArray(config.agents)).toBe(true);
-      expect(config.agentDefaults).toBeUndefined();
-    });
-
-    it("throws when agents object form has no list", async () => {
-      const configPath = path.join(tempDir, "bad-obj.yaml");
-      await fs.writeFile(
-        configPath,
-        `
-agents:
-  defaults:
-    provider:
-      type: openai
-`,
-      );
-
-      await expect(loadConfig(configPath)).rejects.toThrow();
-    });
     it("loads agent workspace path from config", async () => {
       const configPath = path.join(tempDir, "workspace.yaml");
       await fs.writeFile(
@@ -256,7 +192,7 @@ agents:
       const agentFile = { id: "test" };
       const defaultProvider = { type: "openai" as const, defaultModel: "gpt-4" };
 
-      const config = toAgentConfig(agentFile, undefined, defaultProvider);
+      const config = toAgentConfig(agentFile, defaultProvider);
 
       expect(config.model).toBe("gpt-4");
     });
@@ -265,7 +201,7 @@ agents:
       const agentFile = { id: "test", model: "claude-3" };
       const defaultProvider = { type: "openai" as const, defaultModel: "gpt-4" };
 
-      const config = toAgentConfig(agentFile, undefined, defaultProvider);
+      const config = toAgentConfig(agentFile, defaultProvider);
 
       expect(config.model).toBe("claude-3");
     });
@@ -280,18 +216,9 @@ agents:
         id: "test",
         tools: { allow: ["read"] },
       };
-      const config = toAgentConfig(agentFile, undefined, undefined, {
+      const config = toAgentConfig(agentFile, undefined, {
         deny: ["exec"],
       });
-
-      expect(config.toolSettings?.allow).toEqual(["read"]);
-    });
-
-    it("inherits tools from agentDefaults", () => {
-      const agentFile = { id: "test" };
-      const defaults = { tools: { allow: ["read"] } };
-
-      const config = toAgentConfig(agentFile, defaults);
 
       expect(config.toolSettings?.allow).toEqual(["read"]);
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,23 +1,12 @@
-// src/config.ts — Configuration loading for Isotopes
-// Loads agent and runtime configuration from YAML/JSON files.
-
 import fs from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
-import type { ProviderType } from "./agent/types.js";
-import type {
-  AgentConfig,
-} from "./agent/types.js";
+import type { ProviderType, AgentConfig } from "./agent/types.js";
 import type { AgentToolSettings } from "./agent/tools/types.js";
 import type { ChannelsConfig } from "./gateway/types.js";
 import type { CronActionConfig } from "./automation/types.js";
 import { resolveSandboxConfig, type SandboxConfig } from "./sandbox/config.js";
 import type { PluginConfigEntry } from "./legacy/plugins/types.js";
-
-
-// ---------------------------------------------------------------------------
-// Config schema
-// ---------------------------------------------------------------------------
 
 export interface ProviderConfigFile {
   type: ProviderType;
@@ -27,51 +16,45 @@ export interface ProviderConfigFile {
   headers?: Record<string, string>;
 }
 
-/** Heartbeat configuration in config file */
 export interface HeartbeatConfigFile {
-  /** Enable heartbeat for this agent. Default: false */
   enabled?: boolean;
-  /** Interval in seconds between heartbeat triggers. Default: 300 (5 min) */
+  /** Default: 300 (5 min) */
   intervalSeconds?: number;
 }
 
-/** Per-agent cron task configuration (#193) */
 export interface CronTaskConfigFile {
   name: string;
-  /** Cron expression (e.g., "0 * * * *" = every hour) */
+  /** Cron expression, e.g. "0 * * * *" */
   schedule: string;
-  /** Channel/session key to send prompt to */
   channel: string;
-  /** Message to trigger agent with */
   prompt: string;
-  /** Whether this task is enabled. Default: true */
+  /** Default: true */
   enabled?: boolean;
 }
 
-/** Agent configuration in config file */
 export interface AgentConfigFile {
   id: string;
-  /** Runner backend. Default "pi". */
+  /** Default: "pi" */
   runner?: "pi" | "claude";
-  /** Default true. */
+  /** Default: true */
   enabled?: boolean;
-  /** Absolute or ISOTOPES_HOME-relative. Omitted → workspace-{id}/. */
+  /** Absolute or ISOTOPES_HOME-relative. Default: workspace-{id}/. */
   workspace?: string;
   tools?: AgentToolsConfigFile;
   model?: string;
   sandbox?: SandboxConfigFile;
   heartbeat?: HeartbeatConfigFile;
   cron?: { tasks: CronTaskConfigFile[] };
-  /** Default false. */
+  /** Default: false */
   spawnable?: boolean;
-  /** "parent-reuse" (default) | "always-new". */
+  /** Default: "parent-reuse" */
   sessionPolicy?: "always-new" | "parent-reuse";
 }
 
 export interface AgentToolsConfigFile {
-  /** Tool names to explicitly allow (if set, only these are available) */
+  /** If non-empty, only these tools are exposed. */
   allow?: string[];
-  /** Tool names to explicitly deny (takes precedence over allow) */
+  /** Always blocked. Wins over allow. */
   deny?: string[];
 }
 
@@ -98,24 +81,19 @@ export interface SandboxConfigFile {
   docker?: SandboxDockerConfigFile;
 }
 
-// SessionConfig from core/types.ts is used directly — no separate config-file type needed
-// since the config-file shape is identical to the runtime type.
-
-/** Context management configuration (shared across transports) */
 export interface ContextConfigFile {
-  /** Enable channel history buffer (lurking context). Default: true */
+  /** Default: true */
   channelHistory?: boolean;
-  /** Max entries in channel history buffer per channel. Default: 20 */
+  /** Default: 20 */
   channelHistoryLimit?: number;
-  /** Enable message deduplication. Default: true */
+  /** Default: true */
   dedupe?: boolean;
-  /** Enable message debounce (combine rapid messages). Default: false */
+  /** Default: false */
   debounce?: boolean;
-  /** Debounce window in milliseconds. Default: 1500 */
+  /** Default: 1500 */
   debounceWindowMs?: number;
 }
 
-/** Cron job configuration in config file */
 export interface CronJobConfigFile {
   name: string;
   expression: string;
@@ -125,19 +103,12 @@ export interface CronJobConfigFile {
 }
 
 export interface IsotopesConfigFile {
-  /** Default provider for all agents */
   provider?: ProviderConfigFile;
-  /** Default tool policy/guards for all agents */
   tools?: AgentToolsConfigFile;
-  /** Default sandbox config for all agents */
   sandbox?: SandboxConfigFile;
-  /** Agent definitions */
   agents: AgentConfigFile[];
-  /** Channel configurations (Discord accounts, per-guild settings) */
   channels?: ChannelsConfig;
-  /** Channel-level cron job definitions */
   cron?: CronJobConfigFile[];
-  /** Plugin configurations */
   plugins?: Record<string, PluginConfigEntry>;
 }
 
@@ -145,23 +116,16 @@ export function resolveToolSettings(
   agentTools?: AgentToolsConfigFile,
   defaultTools?: AgentToolsConfigFile,
 ): AgentToolSettings {
+  // Agent overrides defaults entirely (not merged) per allow/deny block.
   return {
-    // allow/deny: agent-level overrides defaults entirely (not merged)
     allow: agentTools?.allow ?? defaultTools?.allow,
     deny: agentTools?.deny ?? defaultTools?.deny,
   };
 }
 
-/**
- * Resolve sandbox config from config file types.
- *
- * Layered resolution: top-level `sandbox` provides image / docker /
- * workspaceAccess. Per-agent `sandbox` is a partial override — typically just
- * `{ mode: "off" }` to opt a single agent out. Per-agent `sandbox.docker` is
- * rejected because the runtime maintains a single global ContainerManager.
- *
- * Returns undefined if no sandbox config is provided at any layer.
- */
+// Per-agent sandbox is a partial overlay (e.g. just `enabled: false`); docker
+// settings only come from the top-level config because the runtime maintains a
+// single global ContainerManager.
 export function resolveSandboxConfigFromFile(
   agentId: string,
   agentSandbox?: SandboxConfigFile,
@@ -169,12 +133,8 @@ export function resolveSandboxConfigFromFile(
 ): SandboxConfig | undefined {
   if (!agentSandbox && !defaultSandbox) return undefined;
 
-  const defaults = defaultSandbox
-    ? toSandboxConfig(defaultSandbox)
-    : undefined;
-  const override = agentSandbox
-    ? toSandboxConfig(agentSandbox)
-    : undefined;
+  const defaults = defaultSandbox ? toSandboxConfig(defaultSandbox) : undefined;
+  const override = agentSandbox ? toSandboxConfig(agentSandbox) : undefined;
 
   return resolveSandboxConfig(agentId, defaults, override);
 }
@@ -208,15 +168,6 @@ function toSandboxConfig(file: SandboxConfigFile): SandboxConfig {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Config loader
-// ---------------------------------------------------------------------------
-
-/**
- * Load configuration from a file (YAML or JSON).
- * Supports environment variable substitution in string values.
- * Normalizes the agents union type so downstream always sees agents as an array.
- */
 export async function loadConfig(filePath: string): Promise<IsotopesConfigFile> {
   const content = await fs.readFile(filePath, "utf-8");
   const ext = path.extname(filePath).toLowerCase();
@@ -228,7 +179,6 @@ export async function loadConfig(filePath: string): Promise<IsotopesConfigFile> 
   } else if (ext === ".json") {
     raw = JSON.parse(content) as IsotopesConfigFile;
   } else {
-    // Try YAML first, then JSON
     try {
       raw = YAML.parse(content) as IsotopesConfigFile;
     } catch {
@@ -243,30 +193,17 @@ export async function loadConfig(filePath: string): Promise<IsotopesConfigFile> 
     throw new Error("Config must have at least one agent");
   }
 
-  // Process environment variables
   return processEnvVars(raw);
 }
 
-/**
- * Convert config file agent to AgentConfig.
- * Merge priority: agent > global
- */
 export function toAgentConfig(
   agent: AgentConfigFile,
   globalProvider?: ProviderConfigFile,
   globalTools?: AgentToolsConfigFile,
   globalSandbox?: SandboxConfigFile,
 ): AgentConfig {
-  // 2-tier merge: agent > global (shallow replace per block)
-  const tools = agent.tools ?? globalTools;
-  const resolvedToolSettings = resolveToolSettings(tools);
-  // Sandbox: top-level provides docker / workspaceAccess; per-agent overlays
-  // partial overrides (typically just `enabled: false`). The merge happens
-  // inside resolveSandboxConfigFromFile so per-agent need not repeat docker config.
-
-  // Model: per-agent override > global defaultModel
+  const resolvedToolSettings = resolveToolSettings(agent.tools ?? globalTools);
   const model = agent.model ?? globalProvider?.defaultModel;
-
   const sandbox =
     agent.sandbox || globalSandbox
       ? resolveSandboxConfigFromFile(agent.id, agent.sandbox, globalSandbox)
@@ -284,14 +221,7 @@ export function toAgentConfig(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Environment variable processing
-// ---------------------------------------------------------------------------
-
-/**
- * Recursively process environment variable substitutions.
- * Supports ${VAR} and ${VAR:-default} syntax.
- */
+// Recursively substitute ${VAR} and ${VAR:-default} in string values.
 function processEnvVars<T>(obj: T): T {
   if (typeof obj === "string") {
     return substituteEnvVars(obj) as T;
@@ -309,24 +239,14 @@ function processEnvVars<T>(obj: T): T {
   return obj;
 }
 
-/**
- * Substitute environment variables in a string.
- * ${VAR} — required, throws if not set
- * ${VAR:-default} — optional with default
- */
 function substituteEnvVars(str: string): string {
-  // Match ${VAR} or ${VAR:-default}
   return str.replace(/\$\{([^}]+)\}/g, (match, expr: string) => {
     const [varName, defaultValue] = expr.split(":-");
     const value = process.env[varName.trim()];
 
-    if (value !== undefined) {
-      return value;
-    }
-    if (defaultValue !== undefined) {
-      return defaultValue;
-    }
-    // Don't throw for unset vars without default — might be intentional
+    if (value !== undefined) return value;
+    if (defaultValue !== undefined) return defaultValue;
+    // Unset vars without default — leave the literal `${VAR}` so it's visible.
     return match;
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,8 +103,6 @@ export interface SandboxConfigFile {
 
 /** Context management configuration (shared across transports) */
 export interface ContextConfigFile {
-  /** Max user turns to include in prompt context. Default: 20 */
-  historyTurns?: number;
   /** Enable channel history buffer (lurking context). Default: true */
   channelHistory?: boolean;
   /** Max entries in channel history buffer per channel. Default: 20 */
@@ -115,15 +113,6 @@ export interface ContextConfigFile {
   debounce?: boolean;
   /** Debounce window in milliseconds. Default: 1500 */
   debounceWindowMs?: number;
-  /** Tool result pruning options */
-  pruning?: {
-    /** Number of recent assistant messages to protect from pruning. Default: 3 */
-    protectRecent?: number;
-    /** Head chars for soft trim. Default: 1500 */
-    headChars?: number;
-    /** Tail chars for soft trim. Default: 1500 */
-    tailChars?: number;
-  };
 }
 
 /** Cron job configuration in config file */

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,34 +124,21 @@ export interface CronJobConfigFile {
   enabled?: boolean;
 }
 
-/** Agent defaults — shared configuration inherited by all agents unless overridden */
-export interface AgentDefaultsConfigFile {
-  tools?: AgentToolsConfigFile;
-  sandbox?: SandboxConfigFile;
-}
-
-/** Raw config file structure — agents can be array or object form */
-export interface IsotopesConfigFileRaw {
+export interface IsotopesConfigFile {
   /** Default provider for all agents */
   provider?: ProviderConfigFile;
   /** Default tool policy/guards for all agents */
   tools?: AgentToolsConfigFile;
   /** Default sandbox config for all agents */
   sandbox?: SandboxConfigFile;
-  /** Agent definitions — array form or object with defaults + list */
-  agents: AgentConfigFile[] | { defaults?: AgentDefaultsConfigFile; list: AgentConfigFile[] };
+  /** Agent definitions */
+  agents: AgentConfigFile[];
   /** Channel configurations (Discord accounts, per-guild settings) */
   channels?: ChannelsConfig;
   /** Channel-level cron job definitions */
   cron?: CronJobConfigFile[];
   /** Plugin configurations */
   plugins?: Record<string, PluginConfigEntry>;
-}
-
-/** Normalized config — agents is always an array. */
-export interface IsotopesConfigFile extends Omit<IsotopesConfigFileRaw, "agents"> {
-  agents: AgentConfigFile[];
-  agentDefaults?: AgentDefaultsConfigFile;
 }
 
 export function resolveToolSettings(
@@ -168,8 +155,7 @@ export function resolveToolSettings(
 /**
  * Resolve sandbox config from config file types.
  *
- * Layered resolution: an agents-level config (from
- * `agents.defaults.sandbox` or top-level `sandbox`) provides image / docker /
+ * Layered resolution: top-level `sandbox` provides image / docker /
  * workspaceAccess. Per-agent `sandbox` is a partial override — typically just
  * `{ mode: "off" }` to opt a single agent out. Per-agent `sandbox.docker` is
  * rejected because the runtime maintains a single global ContainerManager.
@@ -235,83 +221,55 @@ export async function loadConfig(filePath: string): Promise<IsotopesConfigFile> 
   const content = await fs.readFile(filePath, "utf-8");
   const ext = path.extname(filePath).toLowerCase();
 
-  let raw: IsotopesConfigFileRaw;
+  let raw: IsotopesConfigFile;
 
   if (ext === ".yaml" || ext === ".yml") {
-    raw = YAML.parse(content) as IsotopesConfigFileRaw;
+    raw = YAML.parse(content) as IsotopesConfigFile;
   } else if (ext === ".json") {
-    raw = JSON.parse(content) as IsotopesConfigFileRaw;
+    raw = JSON.parse(content) as IsotopesConfigFile;
   } else {
     // Try YAML first, then JSON
     try {
-      raw = YAML.parse(content) as IsotopesConfigFileRaw;
+      raw = YAML.parse(content) as IsotopesConfigFile;
     } catch {
-      raw = JSON.parse(content) as IsotopesConfigFileRaw;
+      raw = JSON.parse(content) as IsotopesConfigFile;
     }
   }
 
-  // Normalize agents: support both array form and object form { defaults, list }
-  let agentList: AgentConfigFile[];
-  let agentDefaults: AgentDefaultsConfigFile | undefined;
-
-  if (Array.isArray(raw.agents)) {
-    agentList = raw.agents;
-  } else if (
-    raw.agents &&
-    typeof raw.agents === "object" &&
-    "list" in raw.agents
-  ) {
-    if (!Array.isArray(raw.agents.list)) {
-      throw new Error("Config agents.list must be an array");
-    }
-    agentList = raw.agents.list;
-    agentDefaults = raw.agents.defaults;
-  } else {
-    throw new Error("Config must have an 'agents' array or an 'agents' object with a 'list' field");
+  if (!Array.isArray(raw.agents)) {
+    throw new Error("Config must have an 'agents' array");
   }
-
-  if (agentList.length === 0) {
+  if (raw.agents.length === 0) {
     throw new Error("Config must have at least one agent");
   }
 
-  // Build normalized config — agents is always an array from here on
-  let config: IsotopesConfigFile = {
-    ...raw,
-    agents: agentList,
-    agentDefaults,
-  };
-
   // Process environment variables
-  config = processEnvVars(config);
-
-  return config;
+  return processEnvVars(raw);
 }
 
 /**
  * Convert config file agent to AgentConfig.
- * Merge priority: agent > agentDefaults > global
+ * Merge priority: agent > global
  */
 export function toAgentConfig(
   agent: AgentConfigFile,
-  agentDefaults?: AgentDefaultsConfigFile,
   globalProvider?: ProviderConfigFile,
   globalTools?: AgentToolsConfigFile,
   globalSandbox?: SandboxConfigFile,
 ): AgentConfig {
-  // 3-tier merge: agent > defaults > global (shallow replace per block)
-  const tools = agent.tools ?? agentDefaults?.tools ?? globalTools;
+  // 2-tier merge: agent > global (shallow replace per block)
+  const tools = agent.tools ?? globalTools;
   const resolvedToolSettings = resolveToolSettings(tools);
-  // Sandbox: agents-level (defaults > global) is the base; per-agent overlays
-  // partial overrides (typically just `mode: "off"`). The merge happens inside
-  // resolveSandboxConfigFromFile so per-agent need not repeat docker config.
-  const baseSandbox = agentDefaults?.sandbox ?? globalSandbox;
+  // Sandbox: top-level provides docker / workspaceAccess; per-agent overlays
+  // partial overrides (typically just `enabled: false`). The merge happens
+  // inside resolveSandboxConfigFromFile so per-agent need not repeat docker config.
 
   // Model: per-agent override > global defaultModel
   const model = agent.model ?? globalProvider?.defaultModel;
 
   const sandbox =
-    agent.sandbox || baseSandbox
-      ? resolveSandboxConfigFromFile(agent.id, agent.sandbox, baseSandbox)
+    agent.sandbox || globalSandbox
+      ? resolveSandboxConfigFromFile(agent.id, agent.sandbox, globalSandbox)
       : undefined;
 
   return {

--- a/src/legacy/plugins/discord/discord.test.ts
+++ b/src/legacy/plugins/discord/discord.test.ts
@@ -795,34 +795,6 @@ describe("DiscordTransport", () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
     });
-
-    it("calls preparePromptMessages — agent receives truncated history per historyTurns", async () => {
-
-      // Provide messages that would be affected by limitHistoryTurns
-      sessionStore.getMessages = vi.fn().mockResolvedValue([
-        { role: "user", content: ("old") },
-        { role: "assistant", content: ("old reply") },
-        { role: "user", content: ("recent") },
-        { role: "assistant", content: ("recent reply") },
-        { role: "user", content: ("hello bot") },
-      ]);
-
-      const transportCtx = new DiscordTransport({
-        groupAccess: { policy: "open" },
-        token: "test-token",
-
-        agentRuntime: sharedRuntime,
-        sessionStore,
-        defaultAgentId: "default",
-        context: { historyTurns: 2 },
-      });
-      const spy = spyOnRunAgent(transportCtx);
-
-      const msg = makeMsg({ id: "unique-msg" });
-      await (transportCtx as unknown as { handleMessage: (m: MockIncomingMessage) => Promise<void> }).handleMessage(msg);
-
-      expect(spy).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe("inbound_meta injection", () => {

--- a/src/legacy/plugins/discord/types.ts
+++ b/src/legacy/plugins/discord/types.ts
@@ -29,24 +29,17 @@ export interface ThreadBinding {
 export interface GuildConfig {
   requireMention?: boolean;
   context?: {
-    historyTurns?: number;
     channelHistory?: boolean;
     channelHistoryLimit?: number;
   };
 }
 
 export interface DiscordAccountContextConfig {
-  historyTurns?: number;
   channelHistory?: boolean;
   channelHistoryLimit?: number;
   dedupe?: boolean;
   debounce?: boolean;
   debounceWindowMs?: number;
-  pruning?: {
-    protectRecent?: number;
-    headChars?: number;
-    tailChars?: number;
-  };
 }
 
 export interface DiscordAccountConfig {


### PR DESCRIPTION
## Summary
Comprehensive config schema cleanup. Three independent simplifications, bundled because they all answer the same question: "what does the schema actually need?"

Net diff: **+71 / -277** (≈ -200 LOC).

## 1. Audit + delete dead fields

Bidirectional audit:
- **Forward** (schema → runtime): for each field, grep all consumers. Flag fields with zero readers.
- **Reverse** (runtime → schema): grep all config accesses, cross-check against schema. Flag silent extras.

**Dead fields removed** from \`ContextConfigFile\`:
- \`historyTurns\` — defined, zero readers
- \`pruning\` (entire sub-object: \`protectRecent\`, \`headChars\`, \`tailChars\`) — zero readers

Same fields removed from the parallel \`legacy/plugins/discord/types.ts\` definitions to prevent drift. A discord test asserting dead behavior was deleted.

**Reverse audit clean**: every runtime config access maps to a schema field.

## 2. Drop object-form agents

The schema supported two yaml forms for the \`agents\` field:

\`\`\`yaml
# Array form (used by everyone)
agents:
  - id: main
  - id: helper

# Object form (used by nobody — 0 yaml files in repo)
agents:
  defaults:
    tools: { deny: [shell] }
    sandbox: { enabled: true }
  list:
    - id: main
\`\`\`

The object form's only feature was the \`defaults\` block. But top-level \`tools:\` and \`sandbox:\` already serve as global defaults with the same shape and merge semantics — so \`agents.defaults.tools\` and \`agents.defaults.sandbox\` are pure duplicates.

Maintaining both forms cost ~50 LOC of normalize / union types / passing \`agentDefaults\` through 3 layers (config → runtime → app).

Removed:
- \`AgentDefaultsConfigFile\` interface
- \`IsotopesConfigFileRaw\` (no longer needed — \`IsotopesConfigFile\` is the only shape)
- \`agents\` field union → \`AgentConfigFile[]\`
- \`agentDefaults\` field on \`IsotopesConfigFile\`
- \`loadConfig\` normalize block (~30 lines of if/else parsing)
- \`toAgentConfig\` 3-tier merge → 2-tier (agent > global)
- \`agentDefaults\` parameter on \`AddAgentOptions\` + caller plumbing in runtime/app
- 3 tests asserting object-form behavior

## 3. isotopes.example.yaml — comprehensive rewrite

Previous example had ~10 dead fields that were never in the schema (false advertising):

| Field | Status |
|---|---|
| \`compaction\` (top-level + per-agent) | never in schema |
| \`session\` (top-level) | never in schema |
| \`heartbeatInterval\` / \`heartbeatPrompt\` | replaced by \`heartbeat:\` block long ago |
| \`allowedWorkspaces\` | deleted in #704 (sandbox containment) |
| \`tools.fs.workspaceOnly\` | never in schema |
| \`subagentStreaming\` | never in schema |
| \`context.historyTurns\`, \`context.pruning\` | deleted in this PR |
| Built-in runners block (\`- id: claude\` outside \`agents:\`) | invalid YAML |
| Object form (\`agents.defaults\`) | deleted in this PR |

New example covers every still-supported field:
- **Adds**: \`agents.<id>.\` runner / enabled / spawnable / sessionPolicy
- **Adds**: \`sandbox.docker.\` pidsLimit / noNewPrivileges
- **Adds**: \`sandbox.mounts\` array (was missing entirely)
- **Drops** everything dead listed above
- File header notes "every field in this file is consumed by the runtime; no dead options"

YAML validated: parses cleanly.

## Known limitation (separate concern)
Runtime uses \`as IsotopesConfigFile\` cast — no Zod validation. User typos (e.g. \`histroyTurns: 30\`) silently fail rather than warn. Worth a separate issue.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (750/750 passing)
- [x] YAML parse check on rewritten example

🤖 Generated with [Claude Code](https://claude.com/claude-code)