### PR TITLE
fix(discord): rename ready listener to clientReady

### DIFF
--- a/src/legacy/plugins/discord/discord.test.ts
+++ b/src/legacy/plugins/discord/discord.test.ts
@@ -122,7 +122,7 @@ describe("DiscordTransport", () => {
       const { Client } = await import("discord.js");
       const mockClient = (Client as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
 
-      expect(mockClient.on).toHaveBeenCalledWith("ready", expect.any(Function));
+      expect(mockClient.on).toHaveBeenCalledWith("clientReady", expect.any(Function));
       expect(mockClient.on).toHaveBeenCalledWith("messageCreate", expect.any(Function));
     });
   });

--- a/src/legacy/plugins/discord/discord.ts
+++ b/src/legacy/plugins/discord/discord.ts
@@ -235,7 +235,7 @@ export class DiscordTransport implements Transport {
   }
 
   async start(): Promise<void> {
-    this.client.on("ready", () => {
+    this.client.on("clientReady", () => {
       log.info(`Logged in as ${this.client.user?.tag}`);
       this.ready = true;
     });


### PR DESCRIPTION
## Summary
- discord.js v14 deprecated the `ready` event in favor of `clientReady` (to disambiguate from the gateway READY event); it will be removed in v15.
- Update the listener in `src/legacy/plugins/discord/discord.ts` and the corresponding test.

## Test plan
- [x] `npx vitest run src/legacy/plugins/discord/discord.test.ts` passes
- [ ] No deprecation warning at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)