### PR TITLE
fix(tui): default agent to "main" (#731 follow-up)

### DIFF
--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -121,15 +121,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         return;
       }
 
-      let resolvedAgentId = requestedAgent;
-      if (!resolvedAgentId) {
-        const sessions = await api.fetchSessions();
-        resolvedAgentId = sessions[0]?.agentId;
-        if (!resolvedAgentId) {
-          setError("No agents available");
-          return;
-        }
-      }
+      const resolvedAgentId = requestedAgent ?? "main";
 
       if (options.session) {
         sessionKeyRef.current = options.session;


### PR DESCRIPTION
Was falling back to `sessions[0]?.agentId` (first agent that happened to have a session) — order-dependent and failed when no sessions existed. Now resolves to `main`. If `main` isn't configured, daemon errors surface via `setError`.

Regression test for the `/api/usage` Promise.allSettled bug deferred — that block is going to be torn apart when `/sessions` page lands; testing the transient shape isn't worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)