### PR TITLE
feat(tui): in-app /sessions page replaces CLI sessions + --session flag (#749)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ isotopes reload [agentId]          Reload workspace (hot-reload)
 isotopes tui [--agent id]
                                    Interactive TUI chat with an agent
 
-isotopes sessions list             List all sessions
-isotopes sessions show <id>        Show session details
-isotopes sessions delete <id>      Delete a session
-isotopes sessions reset <id>       Reset session history
-
 isotopes cron list                 List scheduled jobs
 isotopes cron add <spec> <task>    Add a cron job
 isotopes cron remove <id>          Remove a cron job
@@ -70,7 +65,7 @@ Options:
   -v, --version    Show version
   -c, --config     Path to config file
   --agent          Agent ID for tui command
-  --json           Output as JSON (sessions, cron commands)
+  --json           Output as JSON (cron commands)
   --lines          Number of log lines (default: 50)
   --level          Filter logs by level (debug/info/warn/error)
   -f, --follow     Follow log output

--- a/src/legacy/cli.ts
+++ b/src/legacy/cli.ts
@@ -140,7 +140,6 @@ const { values, positionals } = parseArgs({
     level: { type: "string" },
     follow: { type: "boolean", short: "f" },
     force: { type: "boolean" },
-    session: { type: "string" },
   },
   allowPositionals: true,
 });
@@ -156,13 +155,7 @@ Usage:
   isotopes                           Run in foreground (default)
   isotopes init [--force]            Write a default ~/.isotopes/isotopes.yaml
 
-  isotopes tui [--agent id] [--session key]
-                                     Interactive TUI chat with an agent
-
-  isotopes sessions list             List all sessions
-  isotopes sessions show <id>        Show session details
-  isotopes sessions delete <id>      Delete a session
-  isotopes sessions reset <id>       Reset session history
+  isotopes tui [--agent id]          Interactive TUI chat with an agent
 
   isotopes cron list                 List scheduled jobs
   isotopes cron add <spec> <task>    Add a cron job
@@ -184,7 +177,7 @@ Options:
   -v, --version    Show version
   -c, --config     Path to config file
   --agent          Agent ID for tui command
-  --json           Output as JSON (sessions, cron commands)
+  --json           Output as JSON (cron commands)
   --lines          Number of log lines (default: 50)
   --level          Filter logs by level (debug/info/warn/error)
   -f, --follow     Follow log output
@@ -259,84 +252,6 @@ async function handleServiceCommand(): Promise<void> {
 // ---------------------------------------------------------------------------
 // Sessions command
 // ---------------------------------------------------------------------------
-
-type SessionInfo = { id: string; agentId: string; messageCount?: number; createdAt?: string };
-
-function printSessionFields(s: SessionInfo, indent: string): void {
-  console.log(`${indent}Agent: ${s.agentId}`);
-  console.log(`${indent}Messages: ${s.messageCount ?? "?"}`);
-  console.log(`${indent}Created: ${s.createdAt ?? "?"}`);
-}
-
-async function handleSessionsCommand(): Promise<void> {
-  const subCmd = positionals[0];
-  const sessionId = positionals[1];
-
-  await withDaemonErrors(async () => {
-    switch (subCmd) {
-      case "list":
-      case undefined: {
-        const sessions = await apiCall<SessionInfo[]>("GET", "/api/sessions");
-        printJsonOr(sessions, () => {
-          if (sessions.length === 0) {
-            console.log("No active sessions");
-            return;
-          }
-          console.log(`Sessions (${sessions.length}):\n`);
-          for (const s of sessions) {
-            console.log(`  ${s.id}`);
-            printSessionFields(s, "    ");
-            console.log();
-          }
-        });
-        break;
-      }
-      case "show": {
-        const id = requireArg(sessionId, "isotopes sessions show <id>");
-        try {
-          const session = await apiCall<SessionInfo>("GET", `/api/sessions/${id}`);
-          printJsonOr(session, () => {
-            console.log(`Session: ${session.id}`);
-            printSessionFields(session, "  ");
-          });
-        } catch (err) {
-          if (err instanceof ApiError && err.status === 404) {
-            console.error(`Session not found: ${id}`);
-            process.exit(1);
-          }
-          throw err;
-        }
-        break;
-      }
-      case "delete": {
-        const id = requireArg(sessionId, "isotopes sessions delete <id>");
-        await apiAction({
-          method: "DELETE",
-          path: `/api/sessions/${id}`,
-          notFoundLabel: "Session",
-          notFoundId: id,
-          success: `Session deleted: ${id}`,
-        });
-        break;
-      }
-      case "reset": {
-        const id = requireArg(sessionId, "isotopes sessions reset <id>");
-        await apiAction({
-          method: "POST",
-          path: `/api/sessions/${id}/reset`,
-          notFoundLabel: "Session",
-          notFoundId: id,
-          success: `Session reset: ${id}`,
-        });
-        break;
-      }
-      default:
-        console.error(`Unknown sessions subcommand: ${subCmd}`);
-        console.error("Usage: isotopes sessions [list|show|delete|reset] [id]");
-        process.exit(1);
-    }
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Cron command
@@ -579,13 +494,9 @@ async function run(): Promise<void> {
 
     case "tui": {
       const { launchTui } = await import("./tui/index.js");
-      await launchTui({ agent: values.agent, session: values.session });
+      await launchTui({ agent: values.agent });
       break;
     }
-
-    case "sessions":
-      await handleSessionsCommand();
-      break;
 
     case "cron":
       await handleCronCommand();

--- a/src/legacy/tui/App.tsx
+++ b/src/legacy/tui/App.tsx
@@ -13,7 +13,9 @@ function modeFor(sessionKey: string): "owned" | "attach" {
 }
 
 export function App({ options }: Props) {
+  const launchAgentId = options.agent ?? "main";
   const [screen, setScreen] = useState<Screen>("chat");
+  const [agentId, setAgentId] = useState<string>(launchAgentId);
   const [sessionKey, setSessionKey] = useState<string>("tui");
 
   if (screen === "status") {
@@ -23,10 +25,12 @@ export function App({ options }: Props) {
   if (screen === "sessions") {
     return (
       <SessionsScreen
+        currentAgentId={agentId}
         currentSessionKey={sessionKey}
         onSwitchScreen={setScreen}
-        onSelect={(key) => {
-          setSessionKey(key);
+        onSelect={(nextAgentId, nextKey) => {
+          setAgentId(nextAgentId);
+          setSessionKey(nextKey);
           setScreen("chat");
         }}
       />
@@ -35,8 +39,8 @@ export function App({ options }: Props) {
 
   return (
     <ChatScreen
-      key={sessionKey}
-      options={options}
+      key={`${agentId}:${sessionKey}`}
+      agentId={agentId}
       sessionKey={sessionKey}
       mode={modeFor(sessionKey)}
       onSwitchScreen={setScreen}

--- a/src/legacy/tui/App.tsx
+++ b/src/legacy/tui/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { ChatScreen } from "./ChatScreen.js";
 import { StatusScreen } from "./StatusScreen.js";
+import { SessionsScreen } from "./SessionsScreen.js";
 import type { Screen, TuiOptions } from "./types.js";
 
 interface Props {
@@ -9,10 +10,30 @@ interface Props {
 
 export function App({ options }: Props) {
   const [screen, setScreen] = useState<Screen>("chat");
+  const [attachKey, setAttachKey] = useState<string | undefined>(undefined);
 
   if (screen === "status") {
     return <StatusScreen onSwitchScreen={setScreen} />;
   }
 
-  return <ChatScreen options={options} onSwitchScreen={setScreen} />;
+  if (screen === "sessions") {
+    return (
+      <SessionsScreen
+        onSwitchScreen={setScreen}
+        onSelect={(key) => {
+          setAttachKey(key);
+          setScreen("chat");
+        }}
+      />
+    );
+  }
+
+  return (
+    <ChatScreen
+      key={attachKey ?? "owned"}
+      options={options}
+      attachKey={attachKey}
+      onSwitchScreen={setScreen}
+    />
+  );
 }

--- a/src/legacy/tui/App.tsx
+++ b/src/legacy/tui/App.tsx
@@ -8,9 +8,13 @@ interface Props {
   options: TuiOptions;
 }
 
+function modeFor(sessionKey: string): "owned" | "attach" {
+  return sessionKey === "tui" || sessionKey.startsWith("tui:") ? "owned" : "attach";
+}
+
 export function App({ options }: Props) {
   const [screen, setScreen] = useState<Screen>("chat");
-  const [attachKey, setAttachKey] = useState<string | undefined>(undefined);
+  const [sessionKey, setSessionKey] = useState<string>("tui");
 
   if (screen === "status") {
     return <StatusScreen onSwitchScreen={setScreen} />;
@@ -19,9 +23,10 @@ export function App({ options }: Props) {
   if (screen === "sessions") {
     return (
       <SessionsScreen
+        currentSessionKey={sessionKey}
         onSwitchScreen={setScreen}
         onSelect={(key) => {
-          setAttachKey(key);
+          setSessionKey(key);
           setScreen("chat");
         }}
       />
@@ -30,9 +35,10 @@ export function App({ options }: Props) {
 
   return (
     <ChatScreen
-      key={attachKey ?? "owned"}
+      key={sessionKey}
       options={options}
-      attachKey={attachKey}
+      sessionKey={sessionKey}
+      mode={modeFor(sessionKey)}
       onSwitchScreen={setScreen}
     />
   );

--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -94,10 +94,12 @@ export function historyToChatMessages(items: Array<{ role: string; type?: string
 
 interface Props {
   options: TuiOptions;
+  /** When set, attach to this session as observer (no local echo). When undefined, own a `tui` session for the agent. */
+  attachKey?: string;
   onSwitchScreen: (screen: Screen) => void;
 }
 
-export function ChatScreen({ options, onSwitchScreen }: Props) {
+export function ChatScreen({ options, attachKey, onSwitchScreen }: Props) {
   const { exit } = useApp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
@@ -107,8 +109,10 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
   const [error, setError] = useState<string | null>(null);
   const sessionKeyRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const attachAbortRef = useRef<AbortController | null>(null);
   const pendingSteerRef = useRef<ChatMessage[]>([]);
   const settledRef = useRef<ChatMessage[]>([]);
+  const isAttached = attachKey !== undefined;
 
   const initAgent = useCallback(async (requestedAgent?: string) => {
     setAgentReady(false);
@@ -121,6 +125,31 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
       }
 
       const resolvedAgentId = requestedAgent ?? "main";
+
+      if (attachKey) {
+        sessionKeyRef.current = attachKey;
+        setAgentId(resolvedAgentId);
+        const { items: history } = await api.getHistory(resolvedAgentId, attachKey);
+        setMessages(historyToChatMessages(history));
+        const attachAbort = new AbortController();
+        attachAbortRef.current = attachAbort;
+        void (async () => {
+          try {
+            await api.attachStream(resolvedAgentId, attachKey, (m) => {
+              const converted = historyToChatMessages([m.message as { role: string; content: unknown; toolCallId?: string }]);
+              if (converted.length > 0) {
+                setMessages((prev) => [...prev, ...converted]);
+              }
+            }, attachAbort.signal);
+          } catch (err) {
+            if (!attachAbort.signal.aborted) {
+              setError(`Attach failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+          }
+        })();
+        setAgentReady(true);
+        return;
+      }
 
       const session = await api.createSession(resolvedAgentId, "tui");
       sessionKeyRef.current = session.key;
@@ -148,11 +177,32 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     void initAgent(options.agent);
     return () => {
       abortRef.current?.abort();
+      attachAbortRef.current?.abort();
     };
   }, []);
 
   const sendMessage = async (text: string) => {
     if (!sessionKeyRef.current || isStreaming) return;
+
+    // Attach mode: attachStream is the single source of truth for UI updates.
+    // Skip local user echo and inline streaming preview.
+    if (isAttached) {
+      setIsStreaming(true);
+      const abort = new AbortController();
+      abortRef.current = abort;
+      try {
+        await api.sendMessage(agentId, sessionKeyRef.current, text, () => {}, abort.signal);
+      } catch (err) {
+        if (!abort.signal.aborted) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setMessages((prev) => [...prev, { role: "system", content: `Error: ${msg}`, timestamp: new Date() }]);
+        }
+      } finally {
+        abortRef.current = null;
+        setIsStreaming(false);
+      }
+      return;
+    }
 
     const userMsg: ChatMessage = { role: "user", content: text, timestamp: new Date() };
     setMessages((prev) => [...prev, userMsg]);
@@ -246,6 +296,10 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     if (slash) {
       const handled = dispatch(slash.command, slash.args, {
         onNewChat: () => {
+          if (isAttached) {
+            setMessages((prev) => [...prev, { role: "system", content: "/new is disabled while attached to another session. Use /sessions to switch.", timestamp: new Date() }]);
+            return;
+          }
           setMessages([]);
           settledRef.current = [];
           setIsStreaming(true);
@@ -266,6 +320,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         },
         onExit: () => exit(),
         onShowStatus: () => onSwitchScreen("status"),
+        onShowSessions: () => onSwitchScreen("sessions"),
         onHelp: () => setMessages((prev) => [...prev, { role: "system", content: HELP_TEXT, timestamp: new Date() }]),
       });
       if (!handled) {
@@ -370,6 +425,7 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
         <Text bold>isotopes</Text>
         <Text> — agent: </Text>
         <Text color="cyan">{agentId || "loading..."}</Text>
+        {isAttached && <Text color="magenta"> [attached: {attachKey}]</Text>}
         {isStreaming && <Text color="yellow"> (streaming...)</Text>}
       </Box>
 

--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Box, Text, Static, useInput, useApp } from "ink";
 import { randomUUID } from "node:crypto";
 import { parseSlashCommand, dispatch, HELP_TEXT } from "./commands.js";
-import type { ChatMessage, ContentBlock, TuiOptions, Screen, SSEEvent } from "./types.js";
+import type { ChatMessage, ContentBlock, Screen, SSEEvent } from "./types.js";
 import * as api from "./api.js";
 
 const MAX_VISIBLE_MESSAGES = 50;
@@ -93,19 +93,19 @@ export function historyToChatMessages(items: Array<{ role: string; type?: string
 }
 
 interface Props {
-  options: TuiOptions;
+  agentId: string;
   sessionKey: string;
   mode: "owned" | "attach";
   onSwitchScreen: (screen: Screen) => void;
 }
 
-export function ChatScreen({ options, sessionKey, mode, onSwitchScreen }: Props) {
+export function ChatScreen({ agentId: propAgentId, sessionKey, mode, onSwitchScreen }: Props) {
   const { exit } = useApp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
   const [agentReady, setAgentReady] = useState(false);
-  const [agentId, setAgentId] = useState(options.agent ?? "");
+  const [agentId, setAgentId] = useState(propAgentId);
   const [error, setError] = useState<string | null>(null);
   const sessionKeyRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -114,7 +114,7 @@ export function ChatScreen({ options, sessionKey, mode, onSwitchScreen }: Props)
   const settledRef = useRef<ChatMessage[]>([]);
   const isAttached = mode === "attach";
 
-  const initAgent = useCallback(async (requestedAgent?: string) => {
+  const initAgent = useCallback(async () => {
     setAgentReady(false);
     setError(null);
     try {
@@ -124,18 +124,15 @@ export function ChatScreen({ options, sessionKey, mode, onSwitchScreen }: Props)
         return;
       }
 
-      const resolvedAgentId = requestedAgent ?? "main";
-
       if (mode === "attach") {
         sessionKeyRef.current = sessionKey;
-        setAgentId(resolvedAgentId);
-        const { items: history } = await api.getHistory(resolvedAgentId, sessionKey);
+        const { items: history } = await api.getHistory(propAgentId, sessionKey);
         setMessages(historyToChatMessages(history));
         const attachAbort = new AbortController();
         attachAbortRef.current = attachAbort;
         void (async () => {
           try {
-            await api.attachStream(resolvedAgentId, sessionKey, (m) => {
+            await api.attachStream(propAgentId, sessionKey, (m) => {
               const converted = historyToChatMessages([m.message as { role: string; content: unknown; toolCallId?: string }]);
               if (converted.length > 0) {
                 setMessages((prev) => [...prev, ...converted]);
@@ -151,7 +148,7 @@ export function ChatScreen({ options, sessionKey, mode, onSwitchScreen }: Props)
         return;
       }
 
-      const session = await api.createSession(resolvedAgentId, sessionKey);
+      const session = await api.createSession(propAgentId, sessionKey);
       sessionKeyRef.current = session.key;
       setAgentId(session.agentId);
 
@@ -174,7 +171,7 @@ export function ChatScreen({ options, sessionKey, mode, onSwitchScreen }: Props)
   }, []);
 
   useEffect(() => {
-    void initAgent(options.agent);
+    void initAgent();
     return () => {
       abortRef.current?.abort();
       attachAbortRef.current?.abort();

--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -94,12 +94,12 @@ export function historyToChatMessages(items: Array<{ role: string; type?: string
 
 interface Props {
   options: TuiOptions;
-  /** When set, attach to this session as observer (no local echo). When undefined, own a `tui` session for the agent. */
-  attachKey?: string;
+  sessionKey: string;
+  mode: "owned" | "attach";
   onSwitchScreen: (screen: Screen) => void;
 }
 
-export function ChatScreen({ options, attachKey, onSwitchScreen }: Props) {
+export function ChatScreen({ options, sessionKey, mode, onSwitchScreen }: Props) {
   const { exit } = useApp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
@@ -112,7 +112,7 @@ export function ChatScreen({ options, attachKey, onSwitchScreen }: Props) {
   const attachAbortRef = useRef<AbortController | null>(null);
   const pendingSteerRef = useRef<ChatMessage[]>([]);
   const settledRef = useRef<ChatMessage[]>([]);
-  const isAttached = attachKey !== undefined;
+  const isAttached = mode === "attach";
 
   const initAgent = useCallback(async (requestedAgent?: string) => {
     setAgentReady(false);
@@ -126,16 +126,16 @@ export function ChatScreen({ options, attachKey, onSwitchScreen }: Props) {
 
       const resolvedAgentId = requestedAgent ?? "main";
 
-      if (attachKey) {
-        sessionKeyRef.current = attachKey;
+      if (mode === "attach") {
+        sessionKeyRef.current = sessionKey;
         setAgentId(resolvedAgentId);
-        const { items: history } = await api.getHistory(resolvedAgentId, attachKey);
+        const { items: history } = await api.getHistory(resolvedAgentId, sessionKey);
         setMessages(historyToChatMessages(history));
         const attachAbort = new AbortController();
         attachAbortRef.current = attachAbort;
         void (async () => {
           try {
-            await api.attachStream(resolvedAgentId, attachKey, (m) => {
+            await api.attachStream(resolvedAgentId, sessionKey, (m) => {
               const converted = historyToChatMessages([m.message as { role: string; content: unknown; toolCallId?: string }]);
               if (converted.length > 0) {
                 setMessages((prev) => [...prev, ...converted]);
@@ -151,7 +151,7 @@ export function ChatScreen({ options, attachKey, onSwitchScreen }: Props) {
         return;
       }
 
-      const session = await api.createSession(resolvedAgentId, "tui");
+      const session = await api.createSession(resolvedAgentId, sessionKey);
       sessionKeyRef.current = session.key;
       setAgentId(session.agentId);
 
@@ -184,8 +184,6 @@ export function ChatScreen({ options, attachKey, onSwitchScreen }: Props) {
   const sendMessage = async (text: string) => {
     if (!sessionKeyRef.current || isStreaming) return;
 
-    // Attach mode: attachStream is the single source of truth for UI updates.
-    // Skip local user echo and inline streaming preview.
     if (isAttached) {
       setIsStreaming(true);
       const abort = new AbortController();
@@ -308,7 +306,7 @@ export function ChatScreen({ options, attachKey, onSwitchScreen }: Props) {
               if (sessionKeyRef.current) {
                 await api.deleteSession(agentId, sessionKeyRef.current).catch(() => {});
               }
-              const session = await api.createSession(agentId, "tui");
+              const session = await api.createSession(agentId, sessionKey);
               sessionKeyRef.current = session.key;
               setMessages([{ role: "system", content: "New conversation started.", timestamp: new Date() }]);
             } catch (err) {
@@ -425,7 +423,7 @@ export function ChatScreen({ options, attachKey, onSwitchScreen }: Props) {
         <Text bold>isotopes</Text>
         <Text> — agent: </Text>
         <Text color="cyan">{agentId || "loading..."}</Text>
-        {isAttached && <Text color="magenta"> [attached: {attachKey}]</Text>}
+        {isAttached && <Text color="magenta"> [attached: {sessionKey}]</Text>}
         {isStreaming && <Text color="yellow"> (streaming...)</Text>}
       </Box>
 

--- a/src/legacy/tui/ChatScreen.tsx
+++ b/src/legacy/tui/ChatScreen.tsx
@@ -107,7 +107,6 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
   const [error, setError] = useState<string | null>(null);
   const sessionKeyRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const attachAbortRef = useRef<AbortController | null>(null);
   const pendingSteerRef = useRef<ChatMessage[]>([]);
   const settledRef = useRef<ChatMessage[]>([]);
 
@@ -122,32 +121,6 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
       }
 
       const resolvedAgentId = requestedAgent ?? "main";
-
-      if (options.session) {
-        sessionKeyRef.current = options.session;
-        setAgentId(resolvedAgentId);
-        const { items: history } = await api.getHistory(resolvedAgentId, options.session);
-        const chatMessages = historyToChatMessages(history);
-        setMessages(chatMessages);
-        const attachAbort = new AbortController();
-        attachAbortRef.current = attachAbort;
-        void (async () => {
-          try {
-            await api.attachStream(resolvedAgentId, options.session!, (m) => {
-              const converted = historyToChatMessages([m.message as { role: string; content: unknown; toolCallId?: string }]);
-              if (converted.length > 0) {
-                setMessages((prev) => [...prev, ...converted]);
-              }
-            }, attachAbort.signal);
-          } catch (err) {
-            if (!attachAbort.signal.aborted) {
-              setError(`Attach failed: ${err instanceof Error ? err.message : String(err)}`);
-            }
-          }
-        })();
-        setAgentReady(true);
-        return;
-      }
 
       const session = await api.createSession(resolvedAgentId, "tui");
       sessionKeyRef.current = session.key;
@@ -169,39 +142,17 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
-  }, [options.session]);
+  }, []);
 
   useEffect(() => {
     void initAgent(options.agent);
     return () => {
       abortRef.current?.abort();
-      attachAbortRef.current?.abort();
     };
   }, []);
 
   const sendMessage = async (text: string) => {
     if (!sessionKeyRef.current || isStreaming) return;
-
-    // Attach mode: attachStream is the single source of truth for UI updates.
-    // Skip local user echo and inline streaming preview — the persisted
-    // user message + assistant response will arrive via the bus.
-    if (options.session) {
-      setIsStreaming(true);
-      const abort = new AbortController();
-      abortRef.current = abort;
-      try {
-        await api.sendMessage(agentId, sessionKeyRef.current, text, () => {}, abort.signal);
-      } catch (err) {
-        if (!abort.signal.aborted) {
-          const msg = err instanceof Error ? err.message : String(err);
-          setMessages((prev) => [...prev, { role: "system", content: `Error: ${msg}`, timestamp: new Date() }]);
-        }
-      } finally {
-        abortRef.current = null;
-        setIsStreaming(false);
-      }
-      return;
-    }
 
     const userMsg: ChatMessage = { role: "user", content: text, timestamp: new Date() };
     setMessages((prev) => [...prev, userMsg]);
@@ -295,10 +246,6 @@ export function ChatScreen({ options, onSwitchScreen }: Props) {
     if (slash) {
       const handled = dispatch(slash.command, slash.args, {
         onNewChat: () => {
-          if (options.session) {
-            setMessages((prev) => [...prev, { role: "system", content: "/new is disabled in --session attach mode (would delete the attached session). Exit and relaunch without --session.", timestamp: new Date() }]);
-            return;
-          }
           setMessages([]);
           settledRef.current = [];
           setIsStreaming(true);

--- a/src/legacy/tui/SessionsScreen.tsx
+++ b/src/legacy/tui/SessionsScreen.tsx
@@ -15,18 +15,24 @@ export function SessionsScreen({ onSwitchScreen, onSelect }: Props) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    void (async () => {
+    let cancelled = false;
+    const refresh = async () => {
       const isUp = await isDaemonRunning();
+      if (cancelled) return;
       setRunning(isUp);
       if (!isUp) return;
       try {
         const list = await fetchSessions();
+        if (cancelled) return;
         setSessions(list);
-        setCursor(0);
+        setCursor((c) => (list.length === 0 ? 0 : Math.min(c, list.length - 1)));
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err));
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
       }
-    })();
+    };
+    void refresh();
+    const timer = setInterval(() => void refresh(), 5000);
+    return () => { cancelled = true; clearInterval(timer); };
   }, []);
 
   useInput((_ch, key) => {

--- a/src/legacy/tui/SessionsScreen.tsx
+++ b/src/legacy/tui/SessionsScreen.tsx
@@ -4,11 +4,12 @@ import { fetchSessions, isDaemonRunning } from "./api.js";
 import type { Screen, SessionSummary } from "./types.js";
 
 interface Props {
+  currentSessionKey: string;
   onSwitchScreen: (screen: Screen) => void;
   onSelect: (sessionKey: string) => void;
 }
 
-export function SessionsScreen({ onSwitchScreen, onSelect }: Props) {
+export function SessionsScreen({ currentSessionKey, onSwitchScreen, onSelect }: Props) {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [running, setRunning] = useState<boolean | null>(null);
   const [cursor, setCursor] = useState(0);
@@ -24,8 +25,9 @@ export function SessionsScreen({ onSwitchScreen, onSelect }: Props) {
       try {
         const list = await fetchSessions();
         if (cancelled) return;
-        setSessions(list);
-        setCursor((c) => (list.length === 0 ? 0 : Math.min(c, list.length - 1)));
+        const sorted = [...list].sort((a, b) => (b.lastActivityAt ?? "").localeCompare(a.lastActivityAt ?? ""));
+        setSessions(sorted);
+        setCursor((c) => (sorted.length === 0 ? 0 : Math.min(c, sorted.length - 1)));
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));
       }
@@ -46,7 +48,12 @@ export function SessionsScreen({ onSwitchScreen, onSelect }: Props) {
     } else if (key.downArrow) {
       setCursor((c) => (c + 1) % sessions.length);
     } else if (key.return) {
-      onSelect(sessions[cursor].key);
+      const chosen = sessions[cursor].key;
+      if (chosen === currentSessionKey) {
+        onSwitchScreen("chat");
+      } else {
+        onSelect(chosen);
+      }
     }
   });
 
@@ -70,19 +77,21 @@ export function SessionsScreen({ onSwitchScreen, onSelect }: Props) {
         )}
         {sessions.map((s, i) => {
           const selected = i === cursor;
+          const isCurrent = s.key === currentSessionKey;
           const time = s.lastActivityAt ? new Date(s.lastActivityAt).toLocaleTimeString() : "";
           return (
             <Text key={s.key}>
               <Text color={selected ? "cyan" : undefined}>{selected ? "▸ " : "  "}</Text>
               <Text color={selected ? "cyan" : undefined} bold={selected}>{s.agentId}</Text>
               <Text color="gray"> {s.key} {time}</Text>
+              {isCurrent && <Text color="green"> (current)</Text>}
             </Text>
           );
         })}
       </Box>
 
       <Box borderStyle="single" paddingX={1} marginTop={1}>
-        <Text dimColor>↑↓ navigate  enter attach  esc back</Text>
+        <Text dimColor>↑↓ navigate  enter switch  esc back</Text>
       </Box>
     </Box>
   );

--- a/src/legacy/tui/SessionsScreen.tsx
+++ b/src/legacy/tui/SessionsScreen.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { fetchSessions, isDaemonRunning } from "./api.js";
+import type { Screen, SessionSummary } from "./types.js";
+
+interface Props {
+  onSwitchScreen: (screen: Screen) => void;
+  onSelect: (sessionKey: string) => void;
+}
+
+export function SessionsScreen({ onSwitchScreen, onSelect }: Props) {
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [running, setRunning] = useState<boolean | null>(null);
+  const [cursor, setCursor] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      const isUp = await isDaemonRunning();
+      setRunning(isUp);
+      if (!isUp) return;
+      try {
+        const list = await fetchSessions();
+        setSessions(list);
+        setCursor(0);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+  }, []);
+
+  useInput((_ch, key) => {
+    if (key.escape) {
+      onSwitchScreen("chat");
+      return;
+    }
+    if (sessions.length === 0) return;
+    if (key.upArrow) {
+      setCursor((c) => (c - 1 + sessions.length) % sessions.length);
+    } else if (key.downArrow) {
+      setCursor((c) => (c + 1) % sessions.length);
+    } else if (key.return) {
+      onSelect(sessions[cursor].key);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Box borderStyle="single" paddingX={1}>
+        <Text bold>isotopes — sessions</Text>
+      </Box>
+
+      <Box flexDirection="column" paddingX={1} marginTop={1}>
+        {running === null && <Text color="gray">Loading…</Text>}
+        {running === false && (
+          <>
+            <Text bold color="red">Daemon not running</Text>
+            <Text color="gray">Start with: isotopes start</Text>
+          </>
+        )}
+        {error && <Text color="red">{error}</Text>}
+        {running && !error && sessions.length === 0 && (
+          <Text color="gray">No active sessions</Text>
+        )}
+        {sessions.map((s, i) => {
+          const selected = i === cursor;
+          const time = s.lastActivityAt ? new Date(s.lastActivityAt).toLocaleTimeString() : "";
+          return (
+            <Text key={s.key}>
+              <Text color={selected ? "cyan" : undefined}>{selected ? "▸ " : "  "}</Text>
+              <Text color={selected ? "cyan" : undefined} bold={selected}>{s.agentId}</Text>
+              <Text color="gray"> {s.key} {time}</Text>
+            </Text>
+          );
+        })}
+      </Box>
+
+      <Box borderStyle="single" paddingX={1} marginTop={1}>
+        <Text dimColor>↑↓ navigate  enter attach  esc back</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/legacy/tui/SessionsScreen.tsx
+++ b/src/legacy/tui/SessionsScreen.tsx
@@ -4,12 +4,13 @@ import { fetchSessions, isDaemonRunning } from "./api.js";
 import type { Screen, SessionSummary } from "./types.js";
 
 interface Props {
+  currentAgentId: string;
   currentSessionKey: string;
   onSwitchScreen: (screen: Screen) => void;
-  onSelect: (sessionKey: string) => void;
+  onSelect: (agentId: string, sessionKey: string) => void;
 }
 
-export function SessionsScreen({ currentSessionKey, onSwitchScreen, onSelect }: Props) {
+export function SessionsScreen({ currentAgentId, currentSessionKey, onSwitchScreen, onSelect }: Props) {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [running, setRunning] = useState<boolean | null>(null);
   const [cursor, setCursor] = useState(0);
@@ -48,11 +49,11 @@ export function SessionsScreen({ currentSessionKey, onSwitchScreen, onSelect }: 
     } else if (key.downArrow) {
       setCursor((c) => (c + 1) % sessions.length);
     } else if (key.return) {
-      const chosen = sessions[cursor].key;
-      if (chosen === currentSessionKey) {
+      const chosen = sessions[cursor];
+      if (chosen.agentId === currentAgentId && chosen.key === currentSessionKey) {
         onSwitchScreen("chat");
       } else {
-        onSelect(chosen);
+        onSelect(chosen.agentId, chosen.key);
       }
     }
   });
@@ -77,7 +78,7 @@ export function SessionsScreen({ currentSessionKey, onSwitchScreen, onSelect }: 
         )}
         {sessions.map((s, i) => {
           const selected = i === cursor;
-          const isCurrent = s.key === currentSessionKey;
+          const isCurrent = s.agentId === currentAgentId && s.key === currentSessionKey;
           const time = s.lastActivityAt ? new Date(s.lastActivityAt).toLocaleTimeString() : "";
           return (
             <Text key={s.key}>

--- a/src/legacy/tui/StatusScreen.tsx
+++ b/src/legacy/tui/StatusScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
-import { fetchStatus, fetchSessions, isDaemonRunning } from "./api.js";
-import type { DaemonStatus, SessionSummary, Screen } from "./types.js";
+import { fetchStatus, isDaemonRunning } from "./api.js";
+import type { DaemonStatus, Screen } from "./types.js";
 
 interface Props {
   onSwitchScreen: (screen: Screen) => void;
@@ -21,7 +21,6 @@ function formatUptime(seconds: number): string {
 
 export function StatusScreen({ onSwitchScreen }: Props) {
   const [status, setStatus] = useState<DaemonStatus | null>(null);
-  const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [running, setRunning] = useState<boolean | null>(null);
   const [lastRefresh, setLastRefresh] = useState<Date>(new Date());
 
@@ -29,9 +28,11 @@ export function StatusScreen({ onSwitchScreen }: Props) {
     const isUp = await isDaemonRunning();
     setRunning(isUp);
     if (isUp) {
-      const [s, sess] = await Promise.allSettled([fetchStatus(), fetchSessions()]);
-      if (s.status === "fulfilled") setStatus(s.value);
-      if (sess.status === "fulfilled") setSessions(sess.value);
+      try {
+        setStatus(await fetchStatus());
+      } catch {
+        // keep prior status
+      }
     }
     setLastRefresh(new Date());
   };
@@ -89,18 +90,6 @@ export function StatusScreen({ onSwitchScreen }: Props) {
             <Text>  Cron:    <Text color="cyan">{status.cronJobs} job(s)</Text></Text>
           </Box>
         )}
-
-        <Box flexDirection="column">
-          <Text bold underline>Sessions ({sessions.length})</Text>
-          {sessions.length === 0 && <Text color="gray">  No active sessions</Text>}
-          {sessions.slice(0, 20).map((s) => (
-            <Text key={s.key}>
-              {"  "}<Text color="cyan">{s.agentId}</Text>
-              <Text color="gray"> {s.key} {s.lastActivityAt ? new Date(s.lastActivityAt).toLocaleTimeString() : ""}</Text>
-            </Text>
-          ))}
-          {sessions.length > 20 && <Text color="gray">  ... and {sessions.length - 20} more</Text>}
-        </Box>
       </Box>
 
       <Box borderStyle="single" paddingX={1}>

--- a/src/legacy/tui/commands.test.ts
+++ b/src/legacy/tui/commands.test.ts
@@ -37,6 +37,7 @@ describe("dispatch", () => {
     onNewChat: () => calls.push("new"),
     onExit: () => calls.push("exit"),
     onShowStatus: () => calls.push("status"),
+    onShowSessions: () => calls.push("sessions"),
     onHelp: () => calls.push("help"),
   };
 
@@ -45,6 +46,11 @@ describe("dispatch", () => {
   it("dispatches /new", () => {
     expect(dispatch("new", "", callbacks)).toBe(true);
     expect(calls).toEqual(["new"]);
+  });
+
+  it("dispatches /sessions", () => {
+    expect(dispatch("sessions", "", callbacks)).toBe(true);
+    expect(calls).toEqual(["sessions"]);
   });
 
   it("dispatches /exit and aliases", () => {

--- a/src/legacy/tui/commands.ts
+++ b/src/legacy/tui/commands.ts
@@ -20,6 +20,7 @@ export interface CommandCallbacks {
   onNewChat: () => void;
   onExit: () => void;
   onShowStatus: () => void;
+  onShowSessions: () => void;
   onHelp: () => void;
 }
 
@@ -40,6 +41,9 @@ export function dispatch(
     case "status":
       callbacks.onShowStatus();
       return true;
+    case "sessions":
+      callbacks.onShowSessions();
+      return true;
     case "help":
       callbacks.onHelp();
       return true;
@@ -50,6 +54,7 @@ export function dispatch(
 
 export const HELP_TEXT = [
   "/new          — Start a new conversation",
+  "/sessions     — Browse and attach to any session",
   "/status       — Show daemon status",
   "/help         — Show this help",
   "/exit /quit /q — Quit the TUI",

--- a/src/legacy/tui/index.tsx
+++ b/src/legacy/tui/index.tsx
@@ -3,15 +3,8 @@ import { render } from "ink";
 import { App } from "./App.js";
 import type { TuiOptions } from "./types.js";
 
-export async function launchTui(values: {
-  agent?: string;
-  session?: string;
-}): Promise<void> {
-  const options: TuiOptions = {
-    agent: values.agent,
-    session: values.session,
-  };
-
+export async function launchTui(values: { agent?: string }): Promise<void> {
+  const options: TuiOptions = { agent: values.agent };
   const { waitUntilExit } = render(<App options={options} />);
   await waitUntilExit();
 }

--- a/src/legacy/tui/types.ts
+++ b/src/legacy/tui/types.ts
@@ -40,6 +40,4 @@ export type Screen = "chat" | "status";
 
 export interface TuiOptions {
   agent?: string;
-  /** Attach to an existing session by key instead of creating the default `tui` session. */
-  session?: string;
 }

--- a/src/legacy/tui/types.ts
+++ b/src/legacy/tui/types.ts
@@ -36,7 +36,7 @@ export type SSEEvent =
   | { type: "turn_end" }
   | { type: "error"; message: string };
 
-export type Screen = "chat" | "status";
+export type Screen = "chat" | "status" | "sessions";
 
 export interface TuiOptions {
   agent?: string;


### PR DESCRIPTION
Closes #749. Drops user-facing CLI session management, replaces with an interactive in-TUI picker. Unified mode design (after review feedback): no separate "attach" mental state to escape from.

## Design

App tracks one piece of state: \`currentSessionKey\`. The mode is **derived from the key**:
- \`tui\` or \`tui:*\` → **owned** mode (createSession, local echo, streamed response)
- everything else (\`discord:*\`, \`peer:*\`, …) → **attach** mode (observer, no local echo, attachStream)

Selecting any session in \`/sessions\` just changes \`currentSessionKey\`. ChatScreen remounts via React \`key\` prop = clean state reset. To leave attach mode, pick the \`tui\` row — it's marked \`(current)\` and Enter on it just closes the picker.

## What changed (4 commits)

1. **Remove CLI** — \`isotopes sessions list/show/delete/reset\` + \`isotopes tui --session\` deleted (-156 LOC)
2. **Add /sessions page** — SessionsScreen, ↑↓/Enter/Esc, App tracks attachKey
3. **Polish** — 5s polling, cursor clamp, \`lastActivityAt desc\` sort
4. **Unify modes** — replace attachKey with currentSessionKey + derived mode (review feedback: no one-way attach trap, no self-attach paradox)

## Behavior

- Launch → owned mode for \`tui\` session
- \`/sessions\` → list (sorted by activity, current marked \`(current)\` in green)
- Pick discord session → ChatScreen remounts in attach mode, header shows \`[attached: discord:...]\`
- Pick own \`tui\` row → returns to chat (no-op)
- Live-mirror Discord conversations from terminal works as before
- \`/new\` only allowed in owned mode

## Tests
- \`commands.test.ts\` covers new \`/sessions\` dispatch
- SessionsScreen rendering not unit-tested (no ink-testing-library; matches StatusScreen/App pattern). Manually verified by author.

## Breaking
- \`isotopes sessions ...\` subcommand and \`isotopes tui --session\` flag both removed; no compat shim
- Old \`tui:main\` keyed sessions (from #744 vintage) still accessible via \`/sessions\` if they exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)