### PR TITLE
refactor(tui): owned mode requires exact "tui" key (#754)

### DIFF
--- a/src/legacy/tui/App.tsx
+++ b/src/legacy/tui/App.tsx
@@ -8,10 +8,6 @@ interface Props {
   options: TuiOptions;
 }
 
-function modeFor(sessionKey: string): "owned" | "attach" {
-  return sessionKey === "tui" || sessionKey.startsWith("tui:") ? "owned" : "attach";
-}
-
 export function App({ options }: Props) {
   const launchAgentId = options.agent ?? "main";
   const [screen, setScreen] = useState<Screen>("chat");
@@ -42,7 +38,7 @@ export function App({ options }: Props) {
       key={`${agentId}:${sessionKey}`}
       agentId={agentId}
       sessionKey={sessionKey}
-      mode={modeFor(sessionKey)}
+      mode={sessionKey === "tui" ? "owned" : "attach"}
       onSwitchScreen={setScreen}
     />
   );


### PR DESCRIPTION
Drop `startsWith("tui:")` from modeFor. Only exact `"tui"` is owned mode now.

The prefix match was speculative future-proofing with no callers — the only owned-mode key in use is just `"tui"`. Removing it eliminates a future foot-gun (any transport using a `tui:` key would be silently classified as owned).

Inlined the now-1-line ternary at the use site.

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)