### PR TITLE
feat(gateway): typed Gateway abstraction (steer-only) (#763)

### DIFF
--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -80,7 +80,7 @@ const baseMsg: Message = { agentId: "main", content: "hi", source: "tui" };
 describe("gateway.dispatch (started)", () => {
   it("returns started + accumulates responseText", async () => {
     const runtime = buildRuntime(fastRunner(["hel", "lo, ", "world"]));
-    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const result = await gateway.dispatch(baseMsg);
     expect(result.state).toBe("started");
@@ -107,7 +107,7 @@ describe("gateway.dispatch (started)", () => {
       },
     };
     const runtime = buildRuntime(runner);
-    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const onTextDelta = vi.fn();
     const onToolStart = vi.fn();
@@ -122,7 +122,7 @@ describe("gateway.dispatch (started)", () => {
 
   it("captures errorMessage from agent_end", async () => {
     const runtime = buildRuntime(fastRunner(["x"], "error", "boom"));
-    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const result = await gateway.dispatch(baseMsg);
     expect(result.errorMessage).toBe("boom");
@@ -141,7 +141,7 @@ describe("gateway.dispatch (queued)", () => {
     };
     const runtime = buildRuntime(longRunner);
     const steerSpy = vi.spyOn(runtime, "steer").mockResolvedValue();
-    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const first = gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "first" });
     await new Promise((r) => setTimeout(r, 5));
@@ -168,7 +168,7 @@ describe("gateway.abort", () => {
       },
     };
     const runtime = buildRuntime(runner);
-    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     let capturedSid = "";
     const fut = gateway.dispatch(baseMsg, {

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -188,6 +188,25 @@ describe("gateway.dispatch (queued)", () => {
     await gateway.abort(second.sessionId);
     await first;
   });
+
+  it("falls through to a fresh run if the prior run ended between observe and steer", async () => {
+    // First run completes immediately. Second dispatch grabs a stale handle
+    // (active still set from the just-finished run could in theory be observed
+    // before the finally-delete; we simulate by serializing dispatches across
+    // a completed first run). The second dispatch must start a fresh run, not
+    // attempt to steer into the dead one.
+    const runtime = buildRuntime(fastRunner(["one"]));
+    const steerSpy = vi.spyOn(runtime, "steer");
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
+
+    const first = await gateway.dispatch({ ...baseMsg, sessionKey: "ended", content: "first" });
+    expect(first.state).toBe("started");
+
+    const second = await gateway.dispatch({ ...baseMsg, sessionKey: "ended", content: "second" });
+    expect(second.state).toBe("started");
+    expect(second.responseText).toBe("one");
+    expect(steerSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("gateway.abort", () => {

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from "vitest";
+import { createGateway } from "./gateway.js";
+import { AgentRuntime, type Runner } from "../agent/runtime.js";
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import type { Message } from "./types.js";
+
+let nextSessionId = 0;
+
+function makeStores() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const stores = new Map<string, any>();
+  return {
+    async getOrCreate(agentId: string) {
+      let s = stores.get(agentId);
+      if (s) return s;
+      const sessions = new Map();
+      const byKey = new Map<string, string>();
+      s = {
+        async create(aid: string, metadata?: { key?: string }) {
+          const id = `sess-${++nextSessionId}`;
+          const session = { id, agentId: aid, metadata, lastActiveAt: new Date() };
+          sessions.set(id, session);
+          if (metadata?.key) byKey.set(metadata.key, id);
+          return session;
+        },
+        async findByKey(key: string) {
+          const id = byKey.get(key);
+          return id ? sessions.get(id) : undefined;
+        },
+      };
+      stores.set(agentId, s);
+      return s;
+    },
+  } as never;
+}
+
+function textDelta(delta: string): AgentEvent {
+  return {
+    type: "message_update",
+    message: { role: "assistant", content: [{ type: "text", text: delta }] } as never,
+    assistantMessageEvent: {
+      type: "text_delta",
+      contentIndex: 0,
+      delta,
+      partial: { role: "assistant", content: [{ type: "text", text: delta }] } as never,
+    } as never,
+  };
+}
+
+function agentEnd(text = "ok", stopReason: string = "end", errorMessage?: string): AgentEvent {
+  return {
+    type: "agent_end",
+    messages: [{
+      role: "assistant",
+      content: [{ type: "text", text }],
+      stopReason,
+      ...(errorMessage ? { errorMessage } : {}),
+    }] as never,
+  };
+}
+
+function fastRunner(deltas: string[], stopReason: string = "end", errorMessage?: string): Runner {
+  return {
+    resolveSessionId: (req) => req.sessionId ?? "stub",
+    async *run() {
+      for (const d of deltas) yield textDelta(d);
+      yield agentEnd(deltas.join(""), stopReason, errorMessage);
+    },
+  };
+}
+
+function buildRuntime(runner: Runner) {
+  const rt = new AgentRuntime();
+  rt.registerRunner("main", runner);
+  return rt;
+}
+
+const baseMsg: Message = { agentId: "main", content: "hi", source: "tui" };
+
+describe("gateway.dispatch (started)", () => {
+  it("returns started + accumulates responseText", async () => {
+    const runtime = buildRuntime(fastRunner(["hel", "lo, ", "world"]));
+    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+
+    const result = await gateway.dispatch(baseMsg);
+    expect(result.state).toBe("started");
+    expect(result.responseText).toBe("hello, world");
+    expect(result.errorMessage).toBeNull();
+    expect(result.sessionId).toMatch(/^sess-/);
+  });
+
+  it("invokes onTextDelta + onToolStart/End callbacks", async () => {
+    const toolEvent: AgentEvent = {
+      type: "tool_execution_start", toolCallId: "t1", toolName: "echo", args: { x: 1 },
+    };
+    const toolEnd: AgentEvent = {
+      type: "tool_execution_end", toolCallId: "t1", toolName: "echo", result: "done", isError: false,
+    };
+    const runner: Runner = {
+      resolveSessionId: (req) => req.sessionId ?? "stub",
+      async *run() {
+        yield textDelta("a");
+        yield toolEvent;
+        yield toolEnd;
+        yield textDelta("b");
+        yield agentEnd("ab");
+      },
+    };
+    const runtime = buildRuntime(runner);
+    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+
+    const onTextDelta = vi.fn();
+    const onToolStart = vi.fn();
+    const onToolEnd = vi.fn();
+    await gateway.dispatch(baseMsg, { onTextDelta, onToolStart, onToolEnd });
+
+    expect(onTextDelta).toHaveBeenCalledWith("a");
+    expect(onTextDelta).toHaveBeenCalledWith("b");
+    expect(onToolStart).toHaveBeenCalledWith({ id: "t1", name: "echo", args: { x: 1 } });
+    expect(onToolEnd).toHaveBeenCalledWith({ id: "t1", name: "echo", result: "done", isError: false });
+  });
+
+  it("captures errorMessage from agent_end", async () => {
+    const runtime = buildRuntime(fastRunner(["x"], "error", "boom"));
+    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+
+    const result = await gateway.dispatch(baseMsg);
+    expect(result.errorMessage).toBe("boom");
+  });
+});
+
+describe("gateway.dispatch (queued)", () => {
+  it("forwards to runtime.steer when session is busy", async () => {
+    const longRunner: Runner = {
+      resolveSessionId: (req) => req.sessionId ?? "stub",
+      async *run({ abort }) {
+        yield textDelta("running");
+        await new Promise((r) => abort.addEventListener("abort", r, { once: true }));
+        yield agentEnd();
+      },
+    };
+    const runtime = buildRuntime(longRunner);
+    const steerSpy = vi.spyOn(runtime, "steer").mockResolvedValue();
+    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+
+    const first = gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "first" });
+    await new Promise((r) => setTimeout(r, 5));
+
+    const second = await gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "second" });
+    expect(second.state).toBe("queued");
+    expect(second.sessionId).toMatch(/^sess-/);
+    expect(steerSpy).toHaveBeenCalledWith(second.sessionId, "second");
+
+    await gateway.abort(second.sessionId);
+    await first;
+  });
+});
+
+describe("gateway.abort", () => {
+  it("cancels in-flight run", async () => {
+    let aborted = false;
+    const runner: Runner = {
+      resolveSessionId: (req) => req.sessionId ?? "stub",
+      async *run({ abort }) {
+        yield textDelta("x");
+        await new Promise<void>((r) => abort.addEventListener("abort", () => { aborted = true; r(); }, { once: true }));
+        yield agentEnd();
+      },
+    };
+    const runtime = buildRuntime(runner);
+    const gateway = createGateway({ runtime, sessionStoreManager: makeStores() });
+
+    let capturedSid = "";
+    const fut = gateway.dispatch(baseMsg, {
+      onTextDelta: () => {
+        if (!capturedSid) {
+          for (const r of runtime.listRuns()) capturedSid = r.sessionId;
+        }
+      },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(capturedSid).toMatch(/^sess-/);
+    await gateway.abort(capturedSid, "test");
+
+    const result = await fut;
+    expect(result.state).toBe("started");
+    expect(aborted).toBe(true);
+  });
+});

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -207,6 +207,30 @@ describe("gateway.dispatch (queued)", () => {
     expect(second.responseText).toBe("one");
     expect(steerSpy).not.toHaveBeenCalled();
   });
+
+  it("surfaces non-race steer failures via errorMessage (not silent null)", async () => {
+    const longRunner: Runner = {
+      resolveSessionId: (req) => req.sessionId ?? "stub",
+      async *run({ abort }) {
+        yield textDelta("running");
+        await new Promise((r) => abort.addEventListener("abort", r, { once: true }));
+        yield agentEnd();
+      },
+    };
+    const runtime = buildRuntime(longRunner);
+    vi.spyOn(runtime, "steer").mockRejectedValue(new Error("pi rejected"));
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
+
+    const first = gateway.dispatch({ ...baseMsg, sessionKey: "fail", content: "first" });
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await gateway.dispatch({ ...baseMsg, sessionKey: "fail", content: "second" });
+
+    expect(second.state).toBe("queued");
+    expect(second.errorMessage).toBe("pi rejected");
+
+    await gateway.abort(second.sessionId);
+    await first;
+  });
 });
 
 describe("gateway.abort", () => {

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -144,12 +144,46 @@ describe("gateway.dispatch (queued)", () => {
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const first = gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "first" });
+    // Let `first` finish resolveSessionId + set active before second dispatches.
+    // (resolveSessionId is not race-safe across concurrent dispatches with the
+    // same sessionKey — separate concern, not the steer race fixed by handle.ready.)
     await new Promise((r) => setTimeout(r, 5));
 
     const second = await gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "second" });
     expect(second.state).toBe("queued");
     expect(second.sessionId).toMatch(/^sess-/);
     expect(steerSpy).toHaveBeenCalledWith(second.sessionId, "second");
+
+    await gateway.abort(second.sessionId);
+    await first;
+  });
+
+  it("steer awaits run readiness (no race against runner registration)", async () => {
+    let runnerStarted = false;
+    let steerCalledBeforeRunReady = false;
+    const slowStartRunner: Runner = {
+      resolveSessionId: (req) => req.sessionId ?? "stub",
+      async *run({ abort }) {
+        // Simulate runner doing async setup before pi registers the run.
+        await new Promise((r) => setTimeout(r, 20));
+        runnerStarted = true;
+        yield textDelta("ready");
+        await new Promise((r) => abort.addEventListener("abort", r, { once: true }));
+        yield agentEnd();
+      },
+    };
+    const runtime = buildRuntime(slowStartRunner);
+    vi.spyOn(runtime, "steer").mockImplementation(async () => {
+      if (!runnerStarted) steerCalledBeforeRunReady = true;
+    });
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
+
+    const first = gateway.dispatch({ ...baseMsg, sessionKey: "race", content: "a" });
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await gateway.dispatch({ ...baseMsg, sessionKey: "race", content: "b" });
+
+    expect(second.state).toBe("queued");
+    expect(steerCalledBeforeRunReady).toBe(false);
 
     await gateway.abort(second.sessionId);
     await first;

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -1,6 +1,5 @@
 import type { AgentRuntime } from "../agent/runtime.js";
 import type { SessionStoreManager } from "../agent/runners/pi/session-store.js";
-import type { RunRequest } from "../agent/types.js";
 import type {
   DispatchCallbacks,
   DispatchResult,
@@ -42,19 +41,15 @@ export function createGateway(deps: GatewayDeps): Gateway {
     return (await store.create(msg.agentId)).id;
   }
 
-  function buildRequest(msg: Message, sessionId: string): RunRequest {
-    return {
-      to: msg.agentId,
-      sessionId,
-      content: msg.content,
-      ...(msg.cwd ? { cwd: msg.cwd } : {}),
-      ...(msg.extraSystemPrompt ? { extraSystemPrompt: msg.extraSystemPrompt } : {}),
-    };
-  }
-
   async function consume(sessionId: string, msg: Message, handle: ActiveHandle): Promise<void> {
     try {
-      for await (const event of deps.runtime.run(buildRequest(msg, sessionId))) {
+      for await (const event of deps.runtime.run({
+        to: msg.agentId,
+        sessionId,
+        content: msg.content,
+        ...(msg.cwd ? { cwd: msg.cwd } : {}),
+        ...(msg.extraSystemPrompt ? { extraSystemPrompt: msg.extraSystemPrompt } : {}),
+      })) {
         if (event.type === "message_update") {
           const ame = event.assistantMessageEvent;
           if (ame.type === "text_delta") {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -17,11 +17,15 @@ export interface GatewayDeps {
 }
 
 // State for the dispatch driving this session's run.
-// Filled in as runtime events arrive; `done` resolves at agent_end.
+// `ready` resolves once the underlying runner has registered the run
+// (i.e. the first event has arrived) so steer can safely target it.
+// `done` resolves at agent_end.
 interface ActiveHandle {
   callbacks?: DispatchCallbacks;
   responseText: string;
   errorMessage: string | null;
+  ready: Promise<void>;
+  resolveReady: () => void;
   done: Promise<void>;
   resolveDone: () => void;
 }
@@ -42,6 +46,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
   }
 
   async function triggerRun(sessionId: string, msg: Message, handle: ActiveHandle): Promise<void> {
+    let readyResolved = false;
     try {
       for await (const event of deps.agentRuntime.run({
         to: msg.agentId,
@@ -50,6 +55,10 @@ export function createGateway(deps: GatewayDeps): Gateway {
         ...(msg.cwd ? { cwd: msg.cwd } : {}),
         ...(msg.extraSystemPrompt ? { extraSystemPrompt: msg.extraSystemPrompt } : {}),
       })) {
+        if (!readyResolved) {
+          readyResolved = true;
+          handle.resolveReady();
+        }
         if (event.type === "message_update") {
           const ame = event.assistantMessageEvent;
           if (ame.type === "text_delta") {
@@ -70,14 +79,30 @@ export function createGateway(deps: GatewayDeps): Gateway {
       log.error(`triggerRun error for ${sessionId}: ${handle.errorMessage}`);
     } finally {
       active.delete(sessionId);
+      if (!readyResolved) handle.resolveReady();
       handle.resolveDone();
     }
   }
 
+  /**
+   * Dispatch a message to an agent.
+   *
+   * - If the session has no active run, starts one and streams events through
+   *   `callbacks` until agent_end. Returns `state: "started"` with the final
+   *   responseText.
+   * - If the session already has an active run, forwards `msg.content` to the
+   *   runner's native queue via `steer` and returns `state: "queued"` immediately.
+   *   The steered content's output continues streaming through the **original**
+   *   handle's callbacks (the first dispatcher's). The `callbacks` argument
+   *   passed on a queued call is **ignored** — there is one transport sink per
+   *   session, owned by whoever started the run.
+   */
   async function dispatch(msg: Message, callbacks?: DispatchCallbacks): Promise<DispatchResult> {
     const sessionId = await resolveSessionId(msg);
 
-    if (active.has(sessionId)) {
+    const existing = active.get(sessionId);
+    if (existing) {
+      await existing.ready;
       try {
         await deps.agentRuntime.steer(sessionId, msg.content);
       } catch (err) {
@@ -86,12 +111,16 @@ export function createGateway(deps: GatewayDeps): Gateway {
       return { sessionId, state: "queued", responseText: "", errorMessage: null };
     }
 
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((r) => { resolveReady = r; });
     let resolveDone!: () => void;
     const done = new Promise<void>((r) => { resolveDone = r; });
     const handle: ActiveHandle = {
       callbacks,
       responseText: "",
       errorMessage: null,
+      ready,
+      resolveReady,
       done,
       resolveDone,
     };

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -1,0 +1,121 @@
+import type { AgentRuntime } from "../agent/runtime.js";
+import type { SessionStoreManager } from "../agent/runners/pi/session-store.js";
+import type { RunRequest } from "../agent/types.js";
+import type {
+  DispatchCallbacks,
+  DispatchResult,
+  Gateway,
+  Message,
+} from "./types.js";
+import { createLogger } from "../logging/logger.js";
+import { getAgentEndMeta } from "../agent/runners/pi/messages.js";
+
+const log = createLogger("gateway");
+
+export interface GatewayDeps {
+  runtime: AgentRuntime;
+  sessionStoreManager: SessionStoreManager;
+}
+
+// State carried by the dispatch that owns a session's current run.
+// Mutated by `consume` as events arrive; `done` resolves at agent_end.
+interface ActiveHandle {
+  callbacks?: DispatchCallbacks;
+  responseText: string;
+  errorMessage: string | null;
+  done: Promise<void>;
+  resolveDone: () => void;
+}
+
+export function createGateway(deps: GatewayDeps): Gateway {
+  // sessionId → handle for the dispatch currently driving that session's run
+  const active = new Map<string, ActiveHandle>();
+
+  async function resolveSessionId(msg: Message): Promise<string> {
+    const store = await deps.sessionStoreManager.getOrCreate(msg.agentId);
+    if (msg.sessionKey) {
+      const existing = await store.findByKey(msg.sessionKey);
+      if (existing) return existing.id;
+      const created = await store.create(msg.agentId, { key: msg.sessionKey });
+      return created.id;
+    }
+    return (await store.create(msg.agentId)).id;
+  }
+
+  function buildRequest(msg: Message, sessionId: string): RunRequest {
+    return {
+      to: msg.agentId,
+      sessionId,
+      content: msg.content,
+      ...(msg.cwd ? { cwd: msg.cwd } : {}),
+      ...(msg.extraSystemPrompt ? { extraSystemPrompt: msg.extraSystemPrompt } : {}),
+    };
+  }
+
+  async function consume(sessionId: string, msg: Message, handle: ActiveHandle): Promise<void> {
+    try {
+      for await (const event of deps.runtime.run(buildRequest(msg, sessionId))) {
+        handle.callbacks?.onEvent?.(event);
+        if (event.type === "message_update") {
+          const ame = event.assistantMessageEvent;
+          if (ame.type === "text_delta") {
+            handle.responseText += ame.delta;
+            handle.callbacks?.onTextDelta?.(ame.delta);
+          }
+        } else if (event.type === "tool_execution_start") {
+          handle.callbacks?.onToolStart?.({ id: event.toolCallId, name: event.toolName, args: event.args });
+        } else if (event.type === "tool_execution_end") {
+          handle.callbacks?.onToolEnd?.({ id: event.toolCallId, name: event.toolName, result: event.result, isError: event.isError });
+        } else if (event.type === "agent_end") {
+          const meta = getAgentEndMeta(event.messages);
+          if (meta.stopReason === "error") handle.errorMessage = meta.errorMessage ?? "Unknown agent error";
+        }
+      }
+    } catch (err) {
+      handle.errorMessage = err instanceof Error ? err.message : String(err);
+      log.error(`consume error for ${sessionId}: ${handle.errorMessage}`);
+    } finally {
+      active.delete(sessionId);
+      handle.resolveDone();
+    }
+  }
+
+  async function dispatch(msg: Message, callbacks?: DispatchCallbacks): Promise<DispatchResult> {
+    const sessionId = await resolveSessionId(msg);
+
+    if (active.has(sessionId)) {
+      try {
+        await deps.runtime.steer(sessionId, msg.content);
+      } catch (err) {
+        log.warn(`steer failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      return { sessionId, state: "queued", responseText: "", errorMessage: null };
+    }
+
+    let resolveDone!: () => void;
+    const done = new Promise<void>((r) => { resolveDone = r; });
+    const handle: ActiveHandle = {
+      callbacks,
+      responseText: "",
+      errorMessage: null,
+      done,
+      resolveDone,
+    };
+    active.set(sessionId, handle);
+    void consume(sessionId, msg, handle);
+
+    await handle.done;
+    return {
+      sessionId,
+      state: "started",
+      responseText: handle.responseText,
+      errorMessage: handle.errorMessage,
+    };
+  }
+
+  async function abort(sessionId: string, reason?: string): Promise<void> {
+    deps.runtime.cancel(sessionId, reason ? { reason } : undefined);
+  }
+
+  return { dispatch, abort };
+}

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -41,7 +41,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
     return (await store.create(msg.agentId)).id;
   }
 
-  async function consume(sessionId: string, msg: Message, handle: ActiveHandle): Promise<void> {
+  async function triggerRun(sessionId: string, msg: Message, handle: ActiveHandle): Promise<void> {
     try {
       for await (const event of deps.agentRuntime.run({
         to: msg.agentId,
@@ -67,7 +67,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
       }
     } catch (err) {
       handle.errorMessage = err instanceof Error ? err.message : String(err);
-      log.error(`consume error for ${sessionId}: ${handle.errorMessage}`);
+      log.error(`triggerRun error for ${sessionId}: ${handle.errorMessage}`);
     } finally {
       active.delete(sessionId);
       handle.resolveDone();
@@ -96,7 +96,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
       resolveDone,
     };
     active.set(sessionId, handle);
-    void consume(sessionId, msg, handle);
+    void triggerRun(sessionId, msg, handle);
 
     await handle.done;
     return {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -19,7 +19,8 @@ export interface GatewayDeps {
 // State for the dispatch driving this session's run.
 // `ready` resolves once the underlying runner has registered the run
 // (i.e. the first event has arrived) so steer can safely target it.
-// `done` resolves at agent_end.
+// `done` resolves at agent_end; it never rejects — runner errors are
+// captured into `errorMessage` and surfaced via DispatchResult.
 interface ActiveHandle {
   callbacks?: DispatchCallbacks;
   responseText: string;
@@ -100,40 +101,52 @@ export function createGateway(deps: GatewayDeps): Gateway {
   async function dispatch(msg: Message, callbacks?: DispatchCallbacks): Promise<DispatchResult> {
     const sessionId = await resolveSessionId(msg);
 
-    const existing = active.get(sessionId);
-    if (existing) {
-      await existing.ready;
-      try {
-        await deps.agentRuntime.steer(sessionId, msg.content);
-      } catch (err) {
-        log.warn(`steer failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+    // Loop to handle the case where the active run ends between when we
+    // observe it and when we try to steer — fall through to start a fresh run.
+    while (true) {
+      const existing = active.get(sessionId);
+      if (existing) {
+        await existing.ready;
+        // The run may have ended while we awaited ready (finally also resolves
+        // ready). If `active` no longer holds our handle, retry as a fresh run.
+        if (active.get(sessionId) !== existing) continue;
+        try {
+          await deps.agentRuntime.steer(sessionId, msg.content);
+          return { sessionId, state: "queued", responseText: "", errorMessage: null };
+        } catch (err) {
+          // Steer can still race with the run ending between recheck and the
+          // steer call. If the run is gone, retry as fresh; otherwise the
+          // failure is something else — log and return queued with no effect.
+          if (!active.has(sessionId)) continue;
+          log.warn(`steer failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+          return { sessionId, state: "queued", responseText: "", errorMessage: null };
+        }
       }
-      return { sessionId, state: "queued", responseText: "", errorMessage: null };
+
+      let resolveReady!: () => void;
+      const ready = new Promise<void>((r) => { resolveReady = r; });
+      let resolveDone!: () => void;
+      const done = new Promise<void>((r) => { resolveDone = r; });
+      const handle: ActiveHandle = {
+        callbacks,
+        responseText: "",
+        errorMessage: null,
+        ready,
+        resolveReady,
+        done,
+        resolveDone,
+      };
+      active.set(sessionId, handle);
+      void triggerRun(sessionId, msg, handle);
+
+      await handle.done;
+      return {
+        sessionId,
+        state: "started",
+        responseText: handle.responseText,
+        errorMessage: handle.errorMessage,
+      };
     }
-
-    let resolveReady!: () => void;
-    const ready = new Promise<void>((r) => { resolveReady = r; });
-    let resolveDone!: () => void;
-    const done = new Promise<void>((r) => { resolveDone = r; });
-    const handle: ActiveHandle = {
-      callbacks,
-      responseText: "",
-      errorMessage: null,
-      ready,
-      resolveReady,
-      done,
-      resolveDone,
-    };
-    active.set(sessionId, handle);
-    void triggerRun(sessionId, msg, handle);
-
-    await handle.done;
-    return {
-      sessionId,
-      state: "started",
-      responseText: handle.responseText,
-      errorMessage: handle.errorMessage,
-    };
   }
 
   async function abort(sessionId: string, reason?: string): Promise<void> {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -118,8 +118,9 @@ export function createGateway(deps: GatewayDeps): Gateway {
           // steer call. If the run is gone, retry as fresh; otherwise the
           // failure is something else — log and return queued with no effect.
           if (!active.has(sessionId)) continue;
-          log.warn(`steer failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
-          return { sessionId, state: "queued", responseText: "", errorMessage: null };
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          log.warn(`steer failed for ${sessionId}: ${errorMessage}`);
+          return { sessionId, state: "queued", responseText: "", errorMessage };
         }
       }
 

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -17,8 +17,8 @@ export interface GatewayDeps {
   sessionStoreManager: SessionStoreManager;
 }
 
-// State carried by the dispatch that owns a session's current run.
-// Mutated by `consume` as events arrive; `done` resolves at agent_end.
+// State for the dispatch driving this session's run.
+// Filled in as runtime events arrive; `done` resolves at agent_end.
 interface ActiveHandle {
   callbacks?: DispatchCallbacks;
   responseText: string;

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -55,7 +55,6 @@ export function createGateway(deps: GatewayDeps): Gateway {
   async function consume(sessionId: string, msg: Message, handle: ActiveHandle): Promise<void> {
     try {
       for await (const event of deps.runtime.run(buildRequest(msg, sessionId))) {
-        handle.callbacks?.onEvent?.(event);
         if (event.type === "message_update") {
           const ame = event.assistantMessageEvent;
           if (ame.type === "text_delta") {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -12,7 +12,7 @@ import { getAgentEndMeta } from "../agent/runners/pi/messages.js";
 const log = createLogger("gateway");
 
 export interface GatewayDeps {
-  runtime: AgentRuntime;
+  agentRuntime: AgentRuntime;
   sessionStoreManager: SessionStoreManager;
 }
 
@@ -43,7 +43,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
 
   async function consume(sessionId: string, msg: Message, handle: ActiveHandle): Promise<void> {
     try {
-      for await (const event of deps.runtime.run({
+      for await (const event of deps.agentRuntime.run({
         to: msg.agentId,
         sessionId,
         content: msg.content,
@@ -79,7 +79,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
 
     if (active.has(sessionId)) {
       try {
-        await deps.runtime.steer(sessionId, msg.content);
+        await deps.agentRuntime.steer(sessionId, msg.content);
       } catch (err) {
         log.warn(`steer failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -108,7 +108,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
   }
 
   async function abort(sessionId: string, reason?: string): Promise<void> {
-    deps.runtime.cancel(sessionId, reason ? { reason } : undefined);
+    deps.agentRuntime.cancel(sessionId, reason ? { reason } : undefined);
   }
 
   return { dispatch, abort };

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,0 +1,8 @@
+export { createGateway, type GatewayDeps } from "./gateway.js";
+export type {
+  Gateway,
+  Message,
+  MessageSource,
+  DispatchCallbacks,
+  DispatchResult,
+} from "./types.js";

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -1,5 +1,3 @@
-import type { AgentEvent } from "@mariozechner/pi-agent-core";
-
 export type MessageSource = "channel" | "tui" | "ui" | "cron" | "heartbeat" | "spawn";
 
 export interface Message {
@@ -17,7 +15,6 @@ export interface DispatchCallbacks {
   onTextDelta?: (delta: string) => void;
   onToolStart?: (call: { id: string; name: string; args: unknown }) => void;
   onToolEnd?: (result: { id: string; name: string; result: unknown; isError: boolean }) => void;
-  onEvent?: (event: AgentEvent) => void;
 }
 
 export interface DispatchResult {

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -1,0 +1,33 @@
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
+
+export type MessageSource = "channel" | "tui" | "ui" | "cron" | "heartbeat" | "spawn";
+
+export interface Message {
+  agentId: string;
+  sessionKey?: string;
+  content: string;
+  source: MessageSource;
+  sender?: string;
+  timestamp?: number;
+  cwd?: string;
+  extraSystemPrompt?: string;
+}
+
+export interface DispatchCallbacks {
+  onTextDelta?: (delta: string) => void;
+  onToolStart?: (call: { id: string; name: string; args: unknown }) => void;
+  onToolEnd?: (result: { id: string; name: string; result: unknown; isError: boolean }) => void;
+  onEvent?: (event: AgentEvent) => void;
+}
+
+export interface DispatchResult {
+  sessionId: string;
+  state: "started" | "queued";
+  responseText: string;
+  errorMessage: string | null;
+}
+
+export interface Gateway {
+  dispatch(msg: Message, callbacks?: DispatchCallbacks): Promise<DispatchResult>;
+  abort(sessionId: string, reason?: string): Promise<void>;
+}


### PR DESCRIPTION
Closes #763.

## What this adds

A typed `Gateway` abstraction above `AgentRuntime` that all message-producing callers (Discord, TUI, UI, cron, heartbeat, spawn_agent) will eventually share. This PR ships the abstraction + tests; caller migrations follow in subsequent PRs.

## API surface

```ts
interface Gateway {
  dispatch(msg: Message, callbacks?: DispatchCallbacks): Promise<DispatchResult>;
  abort(sessionId: string, reason?: string): Promise<void>;
}
```

- `dispatch` resolves the session, then either **starts** a new run (streams events through `callbacks` until `agent_end`) or **queues** the message via `runtime.steer` if the session already has an active run.
- Queued returns immediately with `state: "queued"` and an empty `responseText`. The steered content's output continues streaming through the **original** dispatcher's callbacks — there is one transport sink per session. The `callbacks` arg on a queued call is ignored (documented on JSDoc).
- `abort` forwards to `runtime.cancel`.

Constructed via `createGateway({ agentRuntime, sessionStoreManager })` (factory + deps pattern).

## Steer-only design

This replaces the closed PR #764 (which had a gateway-level pendingBuffer). After verifying that `pi-agent-core` already exposes a native message queue via `steer`, the gateway no longer maintains its own buffer — it forwards directly to the runtime. One queue, in pi, where it belongs.

## Race fix

An earlier draft had a race where a second dispatch arriving between `active.set(sessionId)` and the underlying runner registering its run would call `steer` against an unknown sessionId. Fixed by giving each `ActiveHandle` a `ready` promise that resolves on the runner's first event; `dispatch` awaits it before steering. Regression test included.

## Out of scope (tracked separately)

- #766 — relocate `SessionStoreManager` out of `agent/runners/pi/`
- #767 — audit the deps/options pattern across the codebase
- #768 — re-evaluate whether the "runner is swappable" abstraction is worth keeping (gateway currently imports `getAgentEndMeta` from the pi runner directly)

## Test plan

- [x] `pnpm test src/gateway/gateway.test.ts` — 6 tests covering started/queued/abort/callbacks/error/race
- [x] `pnpm typecheck`
- [x] `pnpm lint`