### PR TITLE
fix(gateway): dedupe in-flight resolveSessionId by sessionKey (#769)

### DIFF
--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -217,7 +217,8 @@ describe("gateway.dispatch (queued)", () => {
     expect(createSpy).toHaveBeenCalledTimes(1);
 
     await gateway.abort(second.sessionId);
-    await first;
+    const firstResult = await first;
+    expect(firstResult.sessionId).toBe(second.sessionId);
   });
 
   it("falls through to a fresh run if the prior run ended between observe and steer", async () => {

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -144,11 +144,9 @@ describe("gateway.dispatch (queued)", () => {
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const first = gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "first" });
-    // Let `first` finish resolveSessionId + set active before second dispatches.
-    // (resolveSessionId is not race-safe across concurrent dispatches with the
-    // same sessionKey — separate concern, not the steer race fixed by handle.ready.)
-    await new Promise((r) => setTimeout(r, 5));
-
+    // Without #769 dedupe, second's resolveSessionId would race with first's
+    // and create a separate session. With dedupe, second sees the in-flight
+    // resolve, awaits the same promise, and ends up steering the same run.
     const second = await gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "second" });
     expect(second.state).toBe("queued");
     expect(second.sessionId).toMatch(/^sess-/);
@@ -179,11 +177,50 @@ describe("gateway.dispatch (queued)", () => {
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const first = gateway.dispatch({ ...baseMsg, sessionKey: "race", content: "a" });
-    await new Promise((r) => setTimeout(r, 5));
     const second = await gateway.dispatch({ ...baseMsg, sessionKey: "race", content: "b" });
 
     expect(second.state).toBe("queued");
     expect(steerCalledBeforeRunReady).toBe(false);
+
+    await gateway.abort(second.sessionId);
+    await first;
+  });
+
+  it("dedupes concurrent resolveSessionId calls for the same sessionKey (#769)", async () => {
+    const longRunner: Runner = {
+      resolveSessionId: (req) => req.sessionId ?? "stub",
+      async *run({ abort }) {
+        yield textDelta("running");
+        await new Promise((r) => abort.addEventListener("abort", r, { once: true }));
+        yield agentEnd();
+      },
+    };
+    const runtime = buildRuntime(longRunner);
+    vi.spyOn(runtime, "steer").mockResolvedValue();
+    const stores = makeStores();
+    const createSpy = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const s = stores as any;
+    const origGetOrCreate = s.getOrCreate.bind(s);
+    s.getOrCreate = async (agentId: string) => {
+      const store = await origGetOrCreate(agentId);
+      const origCreate = store.create.bind(store);
+      store.create = async (aid: string, metadata?: { key?: string }) => {
+        createSpy(aid, metadata?.key);
+        return origCreate(aid, metadata);
+      };
+      return store;
+    };
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: stores });
+
+    // Fire both dispatches synchronously — both call resolveSessionId before
+     // either finishes. Without dedupe, both would call store.create.
+    const first = gateway.dispatch({ ...baseMsg, sessionKey: "dup", content: "a" });
+    const second = await gateway.dispatch({ ...baseMsg, sessionKey: "dup", content: "b" });
+
+    expect(second.sessionId).toBeDefined();
+    // Only one create call — the second dispatch reused the in-flight resolve.
+    expect(createSpy).toHaveBeenCalledTimes(1);
 
     await gateway.abort(second.sessionId);
     await first;
@@ -222,7 +259,6 @@ describe("gateway.dispatch (queued)", () => {
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const first = gateway.dispatch({ ...baseMsg, sessionKey: "fail", content: "first" });
-    await new Promise((r) => setTimeout(r, 5));
     const second = await gateway.dispatch({ ...baseMsg, sessionKey: "fail", content: "second" });
 
     expect(second.state).toBe("queued");

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -144,9 +144,6 @@ describe("gateway.dispatch (queued)", () => {
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const first = gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "first" });
-    // Without #769 dedupe, second's resolveSessionId would race with first's
-    // and create a separate session. With dedupe, second sees the in-flight
-    // resolve, awaits the same promise, and ends up steering the same run.
     const second = await gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "second" });
     expect(second.state).toBe("queued");
     expect(second.sessionId).toMatch(/^sess-/);
@@ -186,7 +183,7 @@ describe("gateway.dispatch (queued)", () => {
     await first;
   });
 
-  it("dedupes concurrent resolveSessionId calls for the same sessionKey (#769)", async () => {
+  it("dedupes concurrent resolveSessionId calls for the same sessionKey", async () => {
     const longRunner: Runner = {
       resolveSessionId: (req) => req.sessionId ?? "stub",
       async *run({ abort }) {
@@ -213,13 +210,10 @@ describe("gateway.dispatch (queued)", () => {
     };
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: stores });
 
-    // Fire both dispatches synchronously — both call resolveSessionId before
-     // either finishes. Without dedupe, both would call store.create.
     const first = gateway.dispatch({ ...baseMsg, sessionKey: "dup", content: "a" });
     const second = await gateway.dispatch({ ...baseMsg, sessionKey: "dup", content: "b" });
 
     expect(second.sessionId).toBeDefined();
-    // Only one create call — the second dispatch reused the in-flight resolve.
     expect(createSpy).toHaveBeenCalledTimes(1);
 
     await gateway.abort(second.sessionId);

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -34,12 +34,8 @@ interface ActiveHandle {
 export function createGateway(deps: GatewayDeps): Gateway {
   // sessionId → handle for the dispatch currently driving that session's run
   const active = new Map<string, ActiveHandle>();
-  // In-flight resolveSessionId calls keyed by `${agentId}::${sessionKey}`.
-  // Concurrent dispatches with the same sessionKey share a single resolve
-  // promise so only one session is created. Without this, two near-simultaneous
-  // dispatches both see findByKey → undefined and each call create, producing
-  // two distinct sessions for what callers intend as one logical session.
-  // (No cache for missing sessionKey — anonymous dispatches always get a fresh session.)
+  // Dedupes concurrent resolveSessionId calls so two dispatches with the same
+  // sessionKey share one create instead of racing into two distinct sessions.
   const resolving = new Map<string, Promise<string>>();
 
   async function doResolveSessionId(msg: Message): Promise<string> {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -34,8 +34,15 @@ interface ActiveHandle {
 export function createGateway(deps: GatewayDeps): Gateway {
   // sessionId → handle for the dispatch currently driving that session's run
   const active = new Map<string, ActiveHandle>();
+  // In-flight resolveSessionId calls keyed by `${agentId}::${sessionKey}`.
+  // Concurrent dispatches with the same sessionKey share a single resolve
+  // promise so only one session is created. Without this, two near-simultaneous
+  // dispatches both see findByKey → undefined and each call create, producing
+  // two distinct sessions for what callers intend as one logical session.
+  // (No cache for missing sessionKey — anonymous dispatches always get a fresh session.)
+  const resolving = new Map<string, Promise<string>>();
 
-  async function resolveSessionId(msg: Message): Promise<string> {
+  async function doResolveSessionId(msg: Message): Promise<string> {
     const store = await deps.sessionStoreManager.getOrCreate(msg.agentId);
     if (msg.sessionKey) {
       const existing = await store.findByKey(msg.sessionKey);
@@ -44,6 +51,16 @@ export function createGateway(deps: GatewayDeps): Gateway {
       return created.id;
     }
     return (await store.create(msg.agentId)).id;
+  }
+
+  function resolveSessionId(msg: Message): Promise<string> {
+    if (!msg.sessionKey) return doResolveSessionId(msg);
+    const cacheKey = `${msg.agentId}::${msg.sessionKey}`;
+    const pending = resolving.get(cacheKey);
+    if (pending) return pending;
+    const promise = doResolveSessionId(msg).finally(() => resolving.delete(cacheKey));
+    resolving.set(cacheKey, promise);
+    return promise;
   }
 
   async function triggerRun(sessionId: string, msg: Message, handle: ActiveHandle): Promise<void> {


### PR DESCRIPTION
Closes #769.

## Problem

`gateway.resolveSessionId` did `findByKey → undefined → create` with no atomic guard. Two concurrent dispatches sharing the same `(agentId, sessionKey)` could both observe \`undefined\` and each call \`create\`, producing two distinct sessionIds for what callers intend as one logical session. After that the gateway's \`active\` map indexed them as unrelated, both went through the \"started\" branch, and two parallel runs would fire — splitting the conversation across two sessions.

This is a real risk for:
- **Discord**: multiple users in the same channel @ the same agent within the same tick
- **HTTP** and any transport without InboundDebouncer-style suppression
- **cron / heartbeat** firing on schedule boundaries

The legacy Discord transport (`src/legacy/discord/discord.ts:680`) has the same race pattern but hasn't been observed because of (a) per-(channel,user) debouncer collapsing same-user bursts, (b) Discord.js single-shard serial event dispatch, (c) microsecond-scale in-memory store ops. The new gateway will fan in more transports — we should fix this before Discord migrates.

## Fix

Gateway-level in-flight resolve dedupe:

```ts
const resolving = new Map<string, Promise<string>>();

function resolveSessionId(msg) {
  if (!msg.sessionKey) return doResolveSessionId(msg);
  const cacheKey = `${msg.agentId}::${msg.sessionKey}`;
  const pending = resolving.get(cacheKey);
  if (pending) return pending;
  const promise = doResolveSessionId(msg).finally(() => resolving.delete(cacheKey));
  resolving.set(cacheKey, promise);
  return promise;
}
```

Concurrent dispatches with the same `(agentId, sessionKey)` share a single resolve promise. \`finally\` clears the entry when resolution completes, so subsequent non-overlapping dispatches resolve fresh (and hit the existing session via \`findByKey\`).

Anonymous dispatches (no \`sessionKey\`) bypass the cache and always create a new session — existing semantics preserved.

## Why not openclaw's per-key lane

openclaw serializes the whole turn in a per-sessionKey lane (`enqueueCommandInLane` keyed on `session:<key>`). That works because openclaw doesn't have steer mode for new turns the same way we do — its lane is single-slot, which would deadlock our steer path.

We need only the resolveSessionId TOCTOU closed; our `active` map + `steer` design already handles the \"second message arrives during a live turn\" case correctly. Adding a lane on top would either duplicate that responsibility or break steer.

Promise dedupe is the minimal local fix.

## Test plan

- [x] Removed `setTimeout(5)` workarounds from \"queued\", \"steer awaits readiness\", and \"steer error\" tests — they were masking this race
- [x] New regression test: fires two synchronous dispatches with same `sessionKey`, asserts `store.create` called exactly once
- [x] `pnpm test src/gateway/gateway.test.ts` — 9 tests pass
- [x] `pnpm typecheck`
- [x] `pnpm lint`