### PR TITLE
refactor(automation): heartbeat hygiene + cron migration to croner-native scheduler

### DIFF
--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -42,7 +42,6 @@ agents:
     #   tasks:
     #     - name: morning-standup
     #       schedule: "0 9 * * 1-5"         # cron expression
-    #       channel: discord:channel-id     # delivery target (currently informational — see #730)
     #       prompt: "Post the daily standup."
     #       enabled: true                   # default true
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -126,7 +126,6 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
         name: task.name,
         expression: task.schedule,
         agentId: agentFile.id,
-        channelId: task.channel,
         action: { type: "prompt", prompt: task.prompt },
         enabled: task.enabled ?? true,
       });
@@ -156,11 +155,8 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     let prompt: string;
     if (job.action.type === "prompt") {
       prompt = job.action.prompt;
-    } else if (job.action.type === "message") {
-      prompt = job.action.content;
     } else {
-      log.warn(`Cron job "${job.name}" has unsupported action type "${job.action.type}" — skipping`);
-      return;
+      prompt = job.action.content;
     }
 
     const sessionKey = `cron:${job.agentId}:${job.name}`;

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,11 +99,11 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       agentId: agentFile.id,
       workspacePath,
       config: { ...agentFile.heartbeat, enabled: true },
-      runAgentLoop: async (agentId, prompt, _sessionKey) => {
+      runAgentLoop: async (agentId, prompt, sessionKey) => {
         const cwd = resolveCwd(agentId);
         const result = await gateway.dispatch({
           agentId,
-          sessionKey: `heartbeat:${agentId}`,
+          sessionKey,
           content: prompt,
           source: "heartbeat",
           ...(cwd ? { cwd } : {}),

--- a/src/app.ts
+++ b/src/app.ts
@@ -117,36 +117,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
     log.info(`Heartbeat enabled for "${agentFile.id}" (every ${agentFile.heartbeat.intervalSeconds ?? 300}s)`);
   }
 
-  const cronScheduler = new CronScheduler();
-
-  for (const agentFile of config.agents) {
-    if (!agentFile.cron?.tasks?.length) continue;
-    for (const task of agentFile.cron.tasks) {
-      cronScheduler.register({
-        name: task.name,
-        expression: task.schedule,
-        agentId: agentFile.id,
-        action: { type: "prompt", prompt: task.prompt },
-        enabled: task.enabled ?? true,
-      });
-    }
-    log.info(`Registered ${agentFile.cron.tasks.length} cron task(s) for "${agentFile.id}"`);
-  }
-
-  if (config.cron?.length) {
-    for (const task of config.cron) {
-      cronScheduler.register({
-        name: task.name,
-        expression: task.expression,
-        agentId: task.agentId,
-        action: task.action,
-        enabled: task.enabled ?? true,
-      });
-    }
-    log.info(`Registered ${config.cron.length} top-level cron task(s)`);
-  }
-
-  cronScheduler.onTrigger(async (job) => {
+  const cronScheduler = new CronScheduler(async (job) => {
     if (!agentRuntime.getAgent(job.agentId)) {
       log.error(`Cron job "${job.name}" references unknown agent "${job.agentId}"`);
       return;
@@ -176,6 +147,33 @@ export async function createRuntime(opts: RuntimeOptions): Promise<Runtime> {
       log.error(`Cron "${job.name}" failed:`, err);
     }
   });
+
+  for (const agentFile of config.agents) {
+    if (!agentFile.cron?.tasks?.length) continue;
+    for (const task of agentFile.cron.tasks) {
+      cronScheduler.register({
+        name: task.name,
+        expression: task.schedule,
+        agentId: agentFile.id,
+        action: { type: "prompt", prompt: task.prompt },
+        enabled: task.enabled ?? true,
+      });
+    }
+    log.info(`Registered ${agentFile.cron.tasks.length} cron task(s) for "${agentFile.id}"`);
+  }
+
+  if (config.cron?.length) {
+    for (const task of config.cron) {
+      cronScheduler.register({
+        name: task.name,
+        expression: task.expression,
+        agentId: task.agentId,
+        action: task.action,
+        enabled: task.enabled ?? true,
+      });
+    }
+    log.info(`Registered ${config.cron.length} top-level cron task(s)`);
+  }
 
   cronScheduler.start();
   if (cronScheduler.listJobs().length > 0) {

--- a/src/automation/cron-job.test.ts
+++ b/src/automation/cron-job.test.ts
@@ -3,10 +3,12 @@ import { CronScheduler, type CronJob, type CronJobInput } from "./cron-job.js";
 
 describe("CronScheduler", () => {
   let scheduler: CronScheduler;
+  let dispatcher: ReturnType<typeof vi.fn<(job: CronJob) => Promise<void>>>;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    scheduler = new CronScheduler();
+    dispatcher = vi.fn<(job: CronJob) => Promise<void>>().mockResolvedValue(undefined);
+    scheduler = new CronScheduler((job) => dispatcher(job));
   });
 
   afterEach(() => {
@@ -133,32 +135,23 @@ describe("CronScheduler", () => {
   });
 
   // -----------------------------------------------------------------------
-  // onTrigger / callback execution
+  // dispatcher invocation
   // -----------------------------------------------------------------------
 
-  describe("onTrigger", () => {
-    it("calls registered callbacks when a job fires", async () => {
-      const callback = vi.fn();
-      scheduler.onTrigger(callback);
+  describe("dispatcher", () => {
+    it("invokes the dispatcher when a job fires", async () => {
+      vi.setSystemTime(new Date(2025, 3, 7, 8, 59, 0));
 
-      // Set time to just before the next trigger
-      vi.setSystemTime(new Date(2025, 3, 7, 8, 59, 0)); // Monday 8:59 AM
-
-      // Register a job that fires at 9:00 AM weekdays
       const job = scheduler.register(makeJobInput({ expression: "0 9 * * 1-5" }));
       scheduler.start();
 
-      // Advance time past the trigger
       await vi.advanceTimersByTimeAsync(60_000 + 1);
 
-      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ id: job.id }));
+      expect(dispatcher).toHaveBeenCalledWith(expect.objectContaining({ id: job.id }));
     });
 
-    it("calls multiple callbacks", async () => {
-      const cb1 = vi.fn();
-      const cb2 = vi.fn();
-      scheduler.onTrigger(cb1);
-      scheduler.onTrigger(cb2);
+    it("logs and continues when the dispatcher rejects", async () => {
+      dispatcher.mockRejectedValueOnce(new Error("dispatch failed"));
 
       vi.setSystemTime(new Date(2025, 3, 7, 8, 59, 0));
 
@@ -167,41 +160,10 @@ describe("CronScheduler", () => {
 
       await vi.advanceTimersByTimeAsync(60_000 + 1);
 
-      expect(cb1).toHaveBeenCalledTimes(1);
-      expect(cb2).toHaveBeenCalledTimes(1);
-    });
-
-    it("unsubscribe removes the callback", async () => {
-      const callback = vi.fn();
-      const unsub = scheduler.onTrigger(callback);
-      unsub();
-
-      vi.setSystemTime(new Date(2025, 3, 7, 8, 59, 0));
-
-      scheduler.register(makeJobInput({ expression: "0 9 * * 1-5" }));
-      scheduler.start();
-
-      await vi.advanceTimersByTimeAsync(60_000 + 1);
-
-      expect(callback).not.toHaveBeenCalled();
-    });
-
-    it("handles errors in callbacks without stopping other callbacks", async () => {
-      const badCallback = vi.fn().mockRejectedValue(new Error("handler error"));
-      const goodCallback = vi.fn();
-
-      scheduler.onTrigger(badCallback);
-      scheduler.onTrigger(goodCallback);
-
-      vi.setSystemTime(new Date(2025, 3, 7, 8, 59, 0));
-
-      scheduler.register(makeJobInput({ expression: "0 9 * * 1-5" }));
-      scheduler.start();
-
-      await vi.advanceTimersByTimeAsync(60_000 + 1);
-
-      expect(badCallback).toHaveBeenCalledTimes(1);
-      expect(goodCallback).toHaveBeenCalledTimes(1);
+      expect(dispatcher).toHaveBeenCalledTimes(1);
+      // Scheduler still alive — second tick still fires.
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+      expect(dispatcher.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 
@@ -223,9 +185,6 @@ describe("CronScheduler", () => {
     });
 
     it("does not fire jobs after stop", async () => {
-      const callback = vi.fn();
-      scheduler.onTrigger(callback);
-
       vi.setSystemTime(new Date(2025, 3, 7, 8, 59, 0));
 
       scheduler.register(makeJobInput({ expression: "0 9 * * 1-5" }));
@@ -234,7 +193,7 @@ describe("CronScheduler", () => {
 
       await vi.advanceTimersByTimeAsync(120_000);
 
-      expect(callback).not.toHaveBeenCalled();
+      expect(dispatcher).not.toHaveBeenCalled();
     });
   });
 
@@ -249,7 +208,6 @@ describe("CronScheduler", () => {
       const job = scheduler.register(makeJobInput({ expression: "0 9 * * 1-5" }));
       expect(job.lastRun).toBeUndefined();
 
-      scheduler.onTrigger(() => {}); // no-op handler
       scheduler.start();
 
       await vi.advanceTimersByTimeAsync(60_000 + 1);
@@ -264,7 +222,6 @@ describe("CronScheduler", () => {
       const job = scheduler.register(makeJobInput({ expression: "0 9 * * 1-5" }));
       const firstNextRun = job.nextRun!.getTime();
 
-      scheduler.onTrigger(() => {});
       scheduler.start();
 
       await vi.advanceTimersByTimeAsync(60_000 + 1);
@@ -302,10 +259,12 @@ describe("CronScheduler", () => {
 
 describe("cron config integration (#193)", () => {
   let scheduler: CronScheduler;
+  let dispatcher: ReturnType<typeof vi.fn<(job: CronJob) => Promise<void>>>;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    scheduler = new CronScheduler();
+    dispatcher = vi.fn<(job: CronJob) => Promise<void>>().mockResolvedValue(undefined);
+    scheduler = new CronScheduler((job) => dispatcher(job));
   });
 
   afterEach(() => {
@@ -442,7 +401,7 @@ describe("cron config integration (#193)", () => {
       ]);
 
       const triggered: CronJob[] = [];
-      scheduler.onTrigger((job) => { triggered.push(job); });
+      dispatcher.mockImplementation(async (job) => { triggered.push(job); });
       scheduler.start();
 
       await vi.advanceTimersByTimeAsync(60_000 + 1);
@@ -466,7 +425,7 @@ describe("cron config integration (#193)", () => {
       ]);
 
       const triggered: CronJob[] = [];
-      scheduler.onTrigger((job) => { triggered.push(job); });
+      dispatcher.mockImplementation(async (job) => { triggered.push(job); });
       scheduler.start();
 
       await vi.advanceTimersByTimeAsync(120_000);
@@ -493,7 +452,7 @@ describe("cron config integration (#193)", () => {
       ]);
 
       const triggered: string[] = [];
-      scheduler.onTrigger((job) => { triggered.push(job.name); });
+      dispatcher.mockImplementation(async (job) => { triggered.push(job.name); });
       scheduler.start();
 
       await vi.advanceTimersByTimeAsync(60_000 + 1);
@@ -516,7 +475,7 @@ describe("cron config integration (#193)", () => {
       ]);
 
       const triggered: CronJob[] = [];
-      scheduler.onTrigger((job) => { triggered.push(job); });
+      dispatcher.mockImplementation(async (job) => { triggered.push(job); });
       scheduler.start();
       scheduler.stop();
 

--- a/src/automation/cron-job.test.ts
+++ b/src/automation/cron-job.test.ts
@@ -71,14 +71,12 @@ describe("CronScheduler", () => {
       const input = makeJobInput({
         name: "standup",
         agentId: "agent-2",
-        channelId: "channel-1",
         action: { type: "prompt", prompt: "Run standup" },
       });
       const job = scheduler.register(input);
 
       expect(job.name).toBe("standup");
       expect(job.agentId).toBe("agent-2");
-      expect(job.channelId).toBe("channel-1");
       expect(job.action).toEqual({ type: "prompt", prompt: "Run standup" });
     });
 
@@ -100,7 +98,7 @@ describe("CronScheduler", () => {
       const removed = scheduler.unregister(job.id);
 
       expect(removed).toBe(true);
-      expect(scheduler.getJob(job.id)).toBeUndefined();
+      expect(scheduler.listJobs()).toHaveLength(0);
     });
 
     it("returns false for non-existent job", () => {
@@ -118,58 +116,6 @@ describe("CronScheduler", () => {
   });
 
   // -----------------------------------------------------------------------
-  // enable / disable
-  // -----------------------------------------------------------------------
-
-  describe("enable", () => {
-    it("enables a disabled job", () => {
-      const job = scheduler.register(makeJobInput({ enabled: false }));
-
-      const result = scheduler.enable(job.id);
-
-      expect(result).toBe(true);
-      expect(scheduler.getJob(job.id)!.enabled).toBe(true);
-      expect(scheduler.getJob(job.id)!.nextRun).toBeInstanceOf(Date);
-    });
-
-    it("returns false for non-existent job", () => {
-      expect(scheduler.enable("nonexistent")).toBe(false);
-    });
-  });
-
-  describe("disable", () => {
-    it("disables an enabled job", () => {
-      const job = scheduler.register(makeJobInput({ enabled: true }));
-
-      const result = scheduler.disable(job.id);
-
-      expect(result).toBe(true);
-      expect(scheduler.getJob(job.id)!.enabled).toBe(false);
-      expect(scheduler.getJob(job.id)!.nextRun).toBeUndefined();
-    });
-
-    it("returns false for non-existent job", () => {
-      expect(scheduler.disable("nonexistent")).toBe(false);
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // getJob
-  // -----------------------------------------------------------------------
-
-  describe("getJob", () => {
-    it("returns the job if it exists", () => {
-      const job = scheduler.register(makeJobInput());
-
-      expect(scheduler.getJob(job.id)).toBe(job);
-    });
-
-    it("returns undefined for unknown ID", () => {
-      expect(scheduler.getJob("unknown")).toBeUndefined();
-    });
-  });
-
-  // -----------------------------------------------------------------------
   // listJobs
   // -----------------------------------------------------------------------
 
@@ -181,39 +127,8 @@ describe("CronScheduler", () => {
       expect(scheduler.listJobs()).toHaveLength(2);
     });
 
-    it("filters by agentId", () => {
-      scheduler.register(makeJobInput({ name: "a1", agentId: "agent-1" }));
-      scheduler.register(makeJobInput({ name: "a2", agentId: "agent-2" }));
-      scheduler.register(makeJobInput({ name: "a3", agentId: "agent-1" }));
-
-      const filtered = scheduler.listJobs({ agentId: "agent-1" });
-
-      expect(filtered).toHaveLength(2);
-      expect(filtered.every((j) => j.agentId === "agent-1")).toBe(true);
-    });
-
-    it("filters by enabled state", () => {
-      scheduler.register(makeJobInput({ name: "enabled", enabled: true }));
-      scheduler.register(makeJobInput({ name: "disabled", enabled: false }));
-
-      expect(scheduler.listJobs({ enabled: true })).toHaveLength(1);
-      expect(scheduler.listJobs({ enabled: false })).toHaveLength(1);
-    });
-
-    it("filters by both agentId and enabled", () => {
-      scheduler.register(makeJobInput({ agentId: "a1", enabled: true }));
-      scheduler.register(makeJobInput({ agentId: "a1", enabled: false }));
-      scheduler.register(makeJobInput({ agentId: "a2", enabled: true }));
-
-      const filtered = scheduler.listJobs({ agentId: "a1", enabled: true });
-
-      expect(filtered).toHaveLength(1);
-    });
-
-    it("returns empty array when no jobs match", () => {
-      scheduler.register(makeJobInput({ agentId: "agent-1" }));
-
-      expect(scheduler.listJobs({ agentId: "nonexistent" })).toHaveLength(0);
+    it("returns empty array when no jobs registered", () => {
+      expect(scheduler.listJobs()).toHaveLength(0);
     });
   });
 
@@ -339,7 +254,7 @@ describe("CronScheduler", () => {
 
       await vi.advanceTimersByTimeAsync(60_000 + 1);
 
-      const updated = scheduler.getJob(job.id)!;
+      const updated = scheduler.listJobs().find((j) => j.id === job.id)!;
       expect(updated.lastRun).toBeInstanceOf(Date);
     });
 
@@ -354,7 +269,7 @@ describe("CronScheduler", () => {
 
       await vi.advanceTimersByTimeAsync(60_000 + 1);
 
-      const updated = scheduler.getJob(job.id)!;
+      const updated = scheduler.listJobs().find((j) => j.id === job.id)!;
       expect(updated.nextRun).toBeInstanceOf(Date);
       expect(updated.nextRun!.getTime()).toBeGreaterThan(firstNextRun);
     });
@@ -377,13 +292,6 @@ describe("CronScheduler", () => {
         makeJobInput({ action: { type: "prompt", prompt: "Run report" } }),
       );
       expect(job.action).toEqual({ type: "prompt", prompt: "Run report" });
-    });
-
-    it("registers callback action", () => {
-      const job = scheduler.register(
-        makeJobInput({ action: { type: "callback", handler: "generateReport" } }),
-      );
-      expect(job.action).toEqual({ type: "callback", handler: "generateReport" });
     });
   });
 });
@@ -409,7 +317,6 @@ describe("cron config integration (#193)", () => {
   interface CronTaskConfig {
     name: string;
     schedule: string;
-    channel: string;
     prompt: string;
     enabled?: boolean;
   }
@@ -427,7 +334,6 @@ describe("cron config integration (#193)", () => {
           name: task.name,
           expression: task.schedule,
           agentId: agent.id,
-          channelId: task.channel,
           action: { type: "prompt", prompt: task.prompt },
           enabled: task.enabled ?? true,
         });
@@ -442,8 +348,8 @@ describe("cron config integration (#193)", () => {
           id: "bot-1",
           cron: {
             tasks: [
-              { name: "standup", schedule: "0 9 * * 1-5", channel: "general", prompt: "Run standup" },
-              { name: "report", schedule: "0 17 * * 5", channel: "reports", prompt: "Weekly report" },
+              { name: "standup", schedule: "0 9 * * 1-5", prompt: "Run standup" },
+              { name: "report", schedule: "0 17 * * 5", prompt: "Weekly report" },
             ],
           },
         },
@@ -453,7 +359,6 @@ describe("cron config integration (#193)", () => {
       expect(jobs).toHaveLength(2);
       expect(jobs[0].agentId).toBe("bot-1");
       expect(jobs[0].name).toBe("standup");
-      expect(jobs[0].channelId).toBe("general");
       expect(jobs[1].name).toBe("report");
     });
 
@@ -464,7 +369,7 @@ describe("cron config integration (#193)", () => {
         {
           id: "bot-3",
           cron: {
-            tasks: [{ name: "ping", schedule: "*/5 * * * *", channel: "ops", prompt: "Ping" }],
+            tasks: [{ name: "ping", schedule: "*/5 * * * *", prompt: "Ping" }],
           },
         },
       ]);
@@ -480,7 +385,7 @@ describe("cron config integration (#193)", () => {
           id: "bot-1",
           cron: {
             tasks: [
-              { name: "enabled-task", schedule: "0 * * * *", channel: "ch", prompt: "go" },
+              { name: "enabled-task", schedule: "0 * * * *", prompt: "go" },
             ],
           },
         },
@@ -495,7 +400,7 @@ describe("cron config integration (#193)", () => {
           id: "bot-1",
           cron: {
             tasks: [
-              { name: "disabled-task", schedule: "0 * * * *", channel: "ch", prompt: "go", enabled: false },
+              { name: "disabled-task", schedule: "0 * * * *", prompt: "go", enabled: false },
             ],
           },
         },
@@ -509,11 +414,11 @@ describe("cron config integration (#193)", () => {
       registerFromConfig([
         {
           id: "agent-a",
-          cron: { tasks: [{ name: "task-a", schedule: "0 8 * * *", channel: "ch-a", prompt: "A" }] },
+          cron: { tasks: [{ name: "task-a", schedule: "0 8 * * *", prompt: "A" }] },
         },
         {
           id: "agent-b",
-          cron: { tasks: [{ name: "task-b", schedule: "0 9 * * *", channel: "ch-b", prompt: "B" }] },
+          cron: { tasks: [{ name: "task-b", schedule: "0 9 * * *", prompt: "B" }] },
         },
       ]);
 
@@ -531,7 +436,7 @@ describe("cron config integration (#193)", () => {
         {
           id: "bot-1",
           cron: {
-            tasks: [{ name: "morning", schedule: "0 9 * * 1-5", channel: "general", prompt: "Good morning!" }],
+            tasks: [{ name: "morning", schedule: "0 9 * * 1-5", prompt: "Good morning!" }],
           },
         },
       ]);
@@ -545,7 +450,6 @@ describe("cron config integration (#193)", () => {
       expect(triggered).toHaveLength(1);
       expect(triggered[0].name).toBe("morning");
       expect(triggered[0].agentId).toBe("bot-1");
-      expect(triggered[0].channelId).toBe("general");
       expect(triggered[0].action).toEqual({ type: "prompt", prompt: "Good morning!" });
     });
 
@@ -556,7 +460,7 @@ describe("cron config integration (#193)", () => {
         {
           id: "bot-1",
           cron: {
-            tasks: [{ name: "disabled", schedule: "0 9 * * 1-5", channel: "ch", prompt: "Nope", enabled: false }],
+            tasks: [{ name: "disabled", schedule: "0 9 * * 1-5", prompt: "Nope", enabled: false }],
           },
         },
       ]);
@@ -577,13 +481,13 @@ describe("cron config integration (#193)", () => {
         {
           id: "bot-1",
           cron: {
-            tasks: [{ name: "task-1", schedule: "0 9 * * 1-5", channel: "ch-1", prompt: "Hi from 1" }],
+            tasks: [{ name: "task-1", schedule: "0 9 * * 1-5", prompt: "Hi from 1" }],
           },
         },
         {
           id: "bot-2",
           cron: {
-            tasks: [{ name: "task-2", schedule: "0 9 * * 1-5", channel: "ch-2", prompt: "Hi from 2" }],
+            tasks: [{ name: "task-2", schedule: "0 9 * * 1-5", prompt: "Hi from 2" }],
           },
         },
       ]);
@@ -606,7 +510,7 @@ describe("cron config integration (#193)", () => {
         {
           id: "bot-1",
           cron: {
-            tasks: [{ name: "task", schedule: "0 9 * * 1-5", channel: "ch", prompt: "go" }],
+            tasks: [{ name: "task", schedule: "0 9 * * 1-5", prompt: "go" }],
           },
         },
       ]);
@@ -621,29 +525,12 @@ describe("cron config integration (#193)", () => {
       expect(triggered).toHaveLength(0);
     });
 
-    it("filters jobs by agentId after registration", () => {
-      registerFromConfig([
-        {
-          id: "agent-a",
-          cron: { tasks: [{ name: "a1", schedule: "0 * * * *", channel: "ch", prompt: "A" }] },
-        },
-        {
-          id: "agent-b",
-          cron: { tasks: [{ name: "b1", schedule: "0 * * * *", channel: "ch", prompt: "B" }] },
-        },
-      ]);
-
-      const agentAJobs = scheduler.listJobs({ agentId: "agent-a" });
-      expect(agentAJobs).toHaveLength(1);
-      expect(agentAJobs[0].name).toBe("a1");
-    });
-
     it("unregisters a config-defined job by ID", () => {
       registerFromConfig([
         {
           id: "bot-1",
           cron: {
-            tasks: [{ name: "removable", schedule: "0 * * * *", channel: "ch", prompt: "go" }],
+            tasks: [{ name: "removable", schedule: "0 * * * *", prompt: "go" }],
           },
         },
       ]);

--- a/src/automation/cron-job.test.ts
+++ b/src/automation/cron-job.test.ts
@@ -38,7 +38,7 @@ describe("CronScheduler", () => {
       const job = scheduler.register(makeJobInput());
 
       expect(job.id).toBeDefined();
-      expect(job.id).toMatch(/^cron_/);
+      expect(job.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     });
 
     it("parses the cron expression into a schedule", () => {

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -32,7 +32,9 @@ export type CronJobInput = Omit<CronJob, "id" | "schedule" | "nextRun" | "create
  * re-schedules after each trigger. Subscribe via `onTrigger`.
  */
 export class CronScheduler {
+  /** jobId (UUID) → registered job. */
   private jobs: Map<string, CronJob> = new Map();
+  /** jobId (UUID) → its currently scheduled setTimeout handle. */
   private timers: Map<string, NodeJS.Timeout> = new Map();
   private handlers: CronJobCallback[] = [];
   private running = false;

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -27,50 +27,65 @@ export type CronJobCallback = (job: CronJob) => void | Promise<void>;
 export type CronJobInput = Omit<CronJob, "id" | "schedule" | "nextRun" | "createdAt">;
 
 /**
- * Manages cron-based scheduled tasks. Each registered job's expression is
- * parsed by croner; the scheduler maintains a setTimeout per enabled job and
- * re-schedules after each trigger. Subscribe via `onTrigger`.
+ * Manages cron-based scheduled tasks. croner owns the per-job timer + schedule
+ * computation; this scheduler holds the registry and a list of trigger handlers
+ * to fan-out invocations to. Subscribe via `onTrigger`.
  */
 export class CronScheduler {
   /** jobId (UUID) → registered job. */
   private jobs: Map<string, CronJob> = new Map();
-  /** jobId (UUID) → its currently scheduled setTimeout handle. */
-  private timers: Map<string, NodeJS.Timeout> = new Map();
   private handlers: CronJobCallback[] = [];
   private running = false;
 
   register(input: CronJobInput): CronJob {
-    const schedule = new Cron(input.expression, { paused: true });
-    const now = new Date();
-    const nextRun = input.enabled ? schedule.nextRun(now) ?? undefined : undefined;
-
     const job: CronJob = {
       ...input,
       id: randomUUID(),
-      schedule,
-      nextRun,
-      createdAt: now,
+      schedule: undefined as unknown as Cron, // assigned below
+      nextRun: undefined,
+      createdAt: new Date(),
     };
+
+    const startPaused = !this.running || !input.enabled;
+    job.schedule = new Cron(
+      input.expression,
+      // protect: true → if a fire arrives while previous handler still running,
+      // skip it. Equivalent to the heartbeat-style "skip not stack" semantics.
+      { paused: startPaused, protect: true },
+      async () => {
+        log.info(`Triggering cron job "${job.name}" (${job.id})`);
+        job.lastRun = new Date();
+        job.nextRun = job.schedule.nextRun() ?? undefined;
+        for (const handler of this.handlers) {
+          try {
+            await handler(job);
+          } catch (err) {
+            log.error(`Error in cron handler for job "${job.name}":`, err);
+          }
+        }
+      },
+    );
+
+    if (input.enabled) {
+      job.nextRun = job.schedule.nextRun() ?? undefined;
+    }
 
     this.jobs.set(job.id, job);
     log.info(`Registered cron job "${job.name}" (${job.id}): ${job.expression}`);
-
-    if (this.running && job.enabled) {
-      this.scheduleTimer(job);
-    }
 
     return job;
   }
 
   /** Returns true if the job existed and was removed. */
   unregister(jobId: string): boolean {
-    const existed = this.jobs.has(jobId);
-    if (existed) {
-      this.clearTimer(jobId);
-      this.jobs.delete(jobId);
-      log.info(`Unregistered cron job ${jobId}`);
-    }
-    return existed;
+    const job = this.jobs.get(jobId);
+    if (!job) return false;
+    // croner's stop() is permanent + idempotent — any in-flight handler
+    // finishes naturally but croner won't fire this job again.
+    job.schedule.stop();
+    this.jobs.delete(jobId);
+    log.info(`Unregistered cron job ${jobId}`);
+    return true;
   }
 
   listJobs(): CronJob[] {
@@ -86,74 +101,31 @@ export class CronScheduler {
     };
   }
 
-  /** Schedules timers for all enabled jobs. Idempotent. */
+  /** Resumes all enabled jobs. Idempotent. */
   start(): void {
     if (this.running) return;
     this.running = true;
 
     for (const job of this.jobs.values()) {
       if (job.enabled) {
+        job.schedule.resume();
         job.nextRun = job.schedule.nextRun() ?? undefined;
-        this.scheduleTimer(job);
       }
     }
 
     log.info(`Cron scheduler started with ${this.jobs.size} job(s)`);
   }
 
-  /** Clears all timers but preserves job registrations. Idempotent. */
+  /** Pauses all jobs but preserves their registrations. Idempotent. */
   stop(): void {
     if (!this.running) return;
     this.running = false;
 
-    for (const jobId of this.timers.keys()) {
-      this.clearTimer(jobId);
+    for (const job of this.jobs.values()) {
+      job.schedule.pause();
+      job.nextRun = undefined;
     }
 
     log.info("Cron scheduler stopped");
-  }
-
-  private scheduleTimer(job: CronJob): void {
-    this.clearTimer(job.id);
-
-    if (!job.nextRun) return;
-
-    const delay = Math.max(0, job.nextRun.getTime() - Date.now());
-
-    const timer = setTimeout(() => {
-      void this.triggerJob(job);
-    }, delay);
-
-    // Prevent the timer from keeping the process alive.
-    if (timer.unref) timer.unref();
-
-    this.timers.set(job.id, timer);
-  }
-
-  private clearTimer(jobId: string): void {
-    const timer = this.timers.get(jobId);
-    if (timer) {
-      clearTimeout(timer);
-      this.timers.delete(jobId);
-    }
-  }
-
-  private async triggerJob(job: CronJob): Promise<void> {
-    log.info(`Triggering cron job "${job.name}" (${job.id})`);
-
-    job.lastRun = new Date();
-
-    for (const handler of this.handlers) {
-      try {
-        await handler(job);
-      } catch (err) {
-        log.error(`Error in cron handler for job "${job.name}":`, err);
-      }
-    }
-
-    if (this.running && job.enabled) {
-      job.nextRun = job.schedule.nextRun(job.lastRun) ?? undefined;
-      this.scheduleTimer(job);
-    }
   }
 }

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -1,17 +1,14 @@
 import { Cron } from "croner";
 import { createLogger } from "../logging/logger.js";
+import type { CronAction } from "./types.js";
+
+export type { CronAction };
 
 const log = createLogger("cron");
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-/** Action to execute when a cron job triggers. */
-export type CronAction =
-  | { type: "message"; content: string }
-  | { type: "prompt"; prompt: string }
-  | { type: "callback"; handler: string };
 
 /** A registered cron job with its parsed schedule and execution state. */
 export interface CronJob {
@@ -20,7 +17,6 @@ export interface CronJob {
   expression: string;
   schedule: Cron;
   agentId: string;
-  channelId?: string;
   action: CronAction;
   enabled: boolean;
   lastRun?: Date;
@@ -108,61 +104,10 @@ export class CronScheduler {
   }
 
   /**
-   * Enable a cron job. If the scheduler is running, schedules its next timer.
-   * Returns true if the job exists and was enabled.
+   * List all registered jobs.
    */
-  enable(jobId: string): boolean {
-    const job = this.jobs.get(jobId);
-    if (!job) return false;
-
-    job.enabled = true;
-    job.nextRun = job.schedule.nextRun() ?? undefined;
-
-    if (this.running) {
-      this.scheduleTimer(job);
-    }
-
-    log.info(`Enabled cron job "${job.name}" (${jobId})`);
-    return true;
-  }
-
-  /**
-   * Disable a cron job. Clears its timer.
-   * Returns true if the job exists and was disabled.
-   */
-  disable(jobId: string): boolean {
-    const job = this.jobs.get(jobId);
-    if (!job) return false;
-
-    job.enabled = false;
-    job.nextRun = undefined;
-    this.clearTimer(jobId);
-
-    log.info(`Disabled cron job "${job.name}" (${jobId})`);
-    return true;
-  }
-
-  /**
-   * Get a job by ID.
-   */
-  getJob(jobId: string): CronJob | undefined {
-    return this.jobs.get(jobId);
-  }
-
-  /**
-   * List jobs with optional filtering.
-   */
-  listJobs(filter?: { agentId?: string; enabled?: boolean }): CronJob[] {
-    let jobs = [...this.jobs.values()];
-
-    if (filter?.agentId !== undefined) {
-      jobs = jobs.filter((j) => j.agentId === filter.agentId);
-    }
-    if (filter?.enabled !== undefined) {
-      jobs = jobs.filter((j) => j.enabled === filter.enabled);
-    }
-
-    return jobs;
+  listJobs(): CronJob[] {
+    return [...this.jobs.values()];
   }
 
   /**

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -52,8 +52,10 @@ export class CronScheduler {
     job.schedule = new Cron(
       input.expression,
       // protect: true → if a fire arrives while previous handler still running,
-      // skip it. Equivalent to the heartbeat-style "skip not stack" semantics.
-      { paused: startPaused, protect: true },
+      //   skip it. Equivalent to the heartbeat-style "skip not stack" semantics.
+      // unref: true → don't let croner's internal timer block process exit
+      //   (matches the old `timer.unref()` we used to call directly).
+      { paused: startPaused, protect: true, unref: true },
       async () => {
         log.info(`Triggering cron job "${job.name}" (${job.id})`);
         job.lastRun = new Date();

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -6,10 +6,6 @@ export type { CronAction };
 
 const log = createLogger("cron");
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
 /** A registered cron job with its parsed schedule and execution state. */
 export interface CronJob {
   id: string;
@@ -24,18 +20,10 @@ export interface CronJob {
   createdAt: Date;
 }
 
-/** Callback invoked when a cron job triggers. */
 export type CronJobCallback = (job: CronJob) => void | Promise<void>;
 
-/**
- * Input for registering a new cron job.
- * Fields that are auto-generated (id, schedule, nextRun, createdAt) are omitted.
- */
+/** Input for registering a new cron job — auto-generated fields are omitted. */
 export type CronJobInput = Omit<CronJob, "id" | "schedule" | "nextRun" | "createdAt">;
-
-// ---------------------------------------------------------------------------
-// ID generation
-// ---------------------------------------------------------------------------
 
 let idCounter = 0;
 
@@ -43,18 +31,10 @@ function generateId(): string {
   return `cron_${Date.now()}_${++idCounter}`;
 }
 
-// ---------------------------------------------------------------------------
-// CronScheduler
-// ---------------------------------------------------------------------------
-
 /**
- * CronScheduler — manages cron-based scheduled tasks.
- *
- * Jobs are registered with a cron expression that is parsed into a
- * {@link Cron}. When the scheduler is started, it sets timers
- * for each enabled job and re-schedules them after every trigger.
- * Callbacks registered via {@link onTrigger} are invoked each time a
- * job fires.
+ * Manages cron-based scheduled tasks. Each registered job's expression is
+ * parsed by croner; the scheduler maintains a setTimeout per enabled job and
+ * re-schedules after each trigger. Subscribe via `onTrigger`.
  */
 export class CronScheduler {
   private jobs: Map<string, CronJob> = new Map();
@@ -62,10 +42,6 @@ export class CronScheduler {
   private handlers: CronJobCallback[] = [];
   private running = false;
 
-  /**
-   * Register a new cron job.
-   * Parses the cron expression and schedules the next run if the scheduler is started.
-   */
   register(input: CronJobInput): CronJob {
     const schedule = new Cron(input.expression, { paused: true });
     const now = new Date();
@@ -89,10 +65,7 @@ export class CronScheduler {
     return job;
   }
 
-  /**
-   * Unregister a cron job by ID. Clears its timer if running.
-   * Returns true if the job existed and was removed.
-   */
+  /** Returns true if the job existed and was removed. */
   unregister(jobId: string): boolean {
     const existed = this.jobs.has(jobId);
     if (existed) {
@@ -103,17 +76,11 @@ export class CronScheduler {
     return existed;
   }
 
-  /**
-   * List all registered jobs.
-   */
   listJobs(): CronJob[] {
     return [...this.jobs.values()];
   }
 
-  /**
-   * Register a callback to be invoked when any cron job triggers.
-   * Returns an unsubscribe function.
-   */
+  /** Subscribe to all cron triggers. Returns an unsubscribe function. */
   onTrigger(callback: CronJobCallback): () => void {
     this.handlers.push(callback);
     return () => {
@@ -122,9 +89,7 @@ export class CronScheduler {
     };
   }
 
-  /**
-   * Start the scheduler. Schedules timers for all enabled jobs.
-   */
+  /** Schedules timers for all enabled jobs. Idempotent. */
   start(): void {
     if (this.running) return;
     this.running = true;
@@ -139,9 +104,7 @@ export class CronScheduler {
     log.info(`Cron scheduler started with ${this.jobs.size} job(s)`);
   }
 
-  /**
-   * Stop the scheduler. Clears all timers but preserves job registrations.
-   */
+  /** Clears all timers but preserves job registrations. Idempotent. */
   stop(): void {
     if (!this.running) return;
     this.running = false;
@@ -152,10 +115,6 @@ export class CronScheduler {
 
     log.info("Cron scheduler stopped");
   }
-
-  // -----------------------------------------------------------------------
-  // Internal scheduling
-  // -----------------------------------------------------------------------
 
   private scheduleTimer(job: CronJob): void {
     this.clearTimer(job.id);
@@ -168,7 +127,7 @@ export class CronScheduler {
       void this.triggerJob(job);
     }, delay);
 
-    // Prevent the timer from keeping the process alive
+    // Prevent the timer from keeping the process alive.
     if (timer.unref) timer.unref();
 
     this.timers.set(job.id, timer);
@@ -187,7 +146,6 @@ export class CronScheduler {
 
     job.lastRun = new Date();
 
-    // Notify all handlers
     for (const handler of this.handlers) {
       try {
         await handler(job);
@@ -196,7 +154,6 @@ export class CronScheduler {
       }
     }
 
-    // Schedule next run
     if (this.running && job.enabled) {
       job.nextRun = job.schedule.nextRun(job.lastRun) ?? undefined;
       this.scheduleTimer(job);

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -1,4 +1,5 @@
 import { Cron } from "croner";
+import { randomUUID } from "node:crypto";
 import { createLogger } from "../logging/logger.js";
 import type { CronAction } from "./types.js";
 
@@ -25,12 +26,6 @@ export type CronJobCallback = (job: CronJob) => void | Promise<void>;
 /** Input for registering a new cron job — auto-generated fields are omitted. */
 export type CronJobInput = Omit<CronJob, "id" | "schedule" | "nextRun" | "createdAt">;
 
-let idCounter = 0;
-
-function generateId(): string {
-  return `cron_${Date.now()}_${++idCounter}`;
-}
-
 /**
  * Manages cron-based scheduled tasks. Each registered job's expression is
  * parsed by croner; the scheduler maintains a setTimeout per enabled job and
@@ -49,7 +44,7 @@ export class CronScheduler {
 
     const job: CronJob = {
       ...input,
-      id: generateId(),
+      id: randomUUID(),
       schedule,
       nextRun,
       createdAt: now,

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -21,21 +21,23 @@ export interface CronJob {
   createdAt: Date;
 }
 
-export type CronJobCallback = (job: CronJob) => void | Promise<void>;
+/** What the scheduler does when a job fires — typically a gateway.dispatch. */
+export type CronJobDispatcher = (job: CronJob) => Promise<void>;
 
 /** Input for registering a new cron job — auto-generated fields are omitted. */
 export type CronJobInput = Omit<CronJob, "id" | "schedule" | "nextRun" | "createdAt">;
 
 /**
  * Manages cron-based scheduled tasks. croner owns the per-job timer + schedule
- * computation; this scheduler holds the registry and a list of trigger handlers
- * to fan-out invocations to. Subscribe via `onTrigger`.
+ * computation; this scheduler holds the registry and invokes the supplied
+ * dispatcher on each fire.
  */
 export class CronScheduler {
   /** jobId (UUID) → registered job. */
   private jobs: Map<string, CronJob> = new Map();
-  private handlers: CronJobCallback[] = [];
   private running = false;
+
+  constructor(private readonly dispatchJob: CronJobDispatcher) {}
 
   register(input: CronJobInput): CronJob {
     const job: CronJob = {
@@ -56,12 +58,10 @@ export class CronScheduler {
         log.info(`Triggering cron job "${job.name}" (${job.id})`);
         job.lastRun = new Date();
         job.nextRun = job.schedule.nextRun() ?? undefined;
-        for (const handler of this.handlers) {
-          try {
-            await handler(job);
-          } catch (err) {
-            log.error(`Error in cron handler for job "${job.name}":`, err);
-          }
+        try {
+          await this.dispatchJob(job);
+        } catch (err) {
+          log.error(`Cron dispatch failed for "${job.name}":`, err);
         }
       },
     );
@@ -90,15 +90,6 @@ export class CronScheduler {
 
   listJobs(): CronJob[] {
     return [...this.jobs.values()];
-  }
-
-  /** Subscribe to all cron triggers. Returns an unsubscribe function. */
-  onTrigger(callback: CronJobCallback): () => void {
-    this.handlers.push(callback);
-    return () => {
-      const idx = this.handlers.indexOf(callback);
-      if (idx !== -1) this.handlers.splice(idx, 1);
-    };
   }
 
   /** Resumes all enabled jobs. Idempotent. */

--- a/src/automation/heartbeat.test.ts
+++ b/src/automation/heartbeat.test.ts
@@ -301,3 +301,52 @@ describe("HeartbeatManager", () => {
     });
   });
 });
+
+describe("HeartbeatManager — timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does not pin isRunning when runAgentLoop never resolves", async () => {
+    const fake = createFakeFs({ "HEARTBEAT.md": "tasks" });
+    vi.mocked(fs.readFile).mockImplementation(fake.readFile);
+
+    // runAgentLoop returns a forever-pending promise to simulate a hung run.
+    const runAgentLoop = vi.fn<RunAgentLoop>().mockImplementation(
+      () => new Promise<string>(() => { /* never resolves */ }),
+    );
+
+    const intervalSeconds = 5;
+    const hb = new HeartbeatManager({
+      agentId: "stuck-agent",
+      workspacePath: "/workspace",
+      config: { enabled: true, intervalSeconds },
+      runAgentLoop,
+    });
+
+    // First trigger — runAgentLoop hangs forever.
+    const firstTick = hb.trigger();
+    await vi.advanceTimersByTimeAsync(0); // let tick reach the await
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+
+    // While the first tick is hung, a concurrent trigger is skipped.
+    await hb.trigger();
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+
+    // Advance past the 2 × interval timeout.
+    await vi.advanceTimersByTimeAsync(2 * intervalSeconds * 1000 + 100);
+
+    // First tick should have completed (timeout caught, finally resets isRunning).
+    await firstTick;
+
+    // Now isRunning is false — a fresh trigger fires runAgentLoop again.
+    void hb.trigger();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runAgentLoop).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/automation/heartbeat.ts
+++ b/src/automation/heartbeat.ts
@@ -99,13 +99,42 @@ export class HeartbeatManager {
     this.log.info(`Heartbeat triggered for "${this.agentId}"`);
 
     try {
-      const response = await this.runAgentLoop(this.agentId, prompt, sessionKey);
-      this.log.info(`Heartbeat response from "${this.agentId}": ${response}`);
+      // Cap the wait at 2× interval so a hung underlying run doesn't pin
+      // isRunning forever (which would silently skip every future tick).
+      // The underlying run is NOT canceled on timeout — gateway's steer will
+      // merge the next tick's content into it if it eventually completes.
+      const timeoutMs = this.intervalMs * 2;
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const response = await Promise.race([
+          this.runAgentLoop(this.agentId, prompt, sessionKey),
+          new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(
+              () => reject(new HeartbeatTimeoutError(timeoutMs)),
+              timeoutMs,
+            );
+          }),
+        ]);
+        this.log.info(`Heartbeat response from "${this.agentId}": ${response}`);
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+      }
     } catch (err) {
-      this.log.error(`Heartbeat error for "${this.agentId}":`, err);
+      if (err instanceof HeartbeatTimeoutError) {
+        this.log.warn(`Heartbeat timed out for "${this.agentId}" after ${err.timeoutMs}ms — underlying run may still be in flight`);
+      } else {
+        this.log.error(`Heartbeat error for "${this.agentId}":`, err);
+      }
     } finally {
       this.isRunning = false;
     }
+  }
+}
+
+class HeartbeatTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`heartbeat timed out after ${timeoutMs}ms`);
+    this.name = "HeartbeatTimeoutError";
   }
 }
 

--- a/src/automation/heartbeat.ts
+++ b/src/automation/heartbeat.ts
@@ -99,10 +99,8 @@ export class HeartbeatManager {
     this.log.info(`Heartbeat triggered for "${this.agentId}"`);
 
     try {
-      // Cap the wait at 2× interval so a hung underlying run doesn't pin
-      // isRunning forever (which would silently skip every future tick).
-      // The underlying run is NOT canceled on timeout — gateway's steer will
-      // merge the next tick's content into it if it eventually completes.
+      // Cap at 2× interval so a hung run doesn't pin isRunning forever.
+      // The run itself isn't canceled — gateway's steer absorbs the next tick.
       const timeoutMs = this.intervalMs * 2;
       let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       try {

--- a/src/automation/types.ts
+++ b/src/automation/types.ts
@@ -1,7 +1,6 @@
 // src/automation/types.ts — Cron + heartbeat config types
 
-/** Action to perform when a config-level cron job triggers. */
-export type CronActionConfig =
+/** Action to perform when a cron job triggers. */
+export type CronAction =
   | { type: "message"; content: string }
-  | { type: "prompt"; prompt: string }
-  | { type: "callback"; handler: string };
+  | { type: "prompt"; prompt: string };

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import YAML from "yaml";
 import type { ProviderType, AgentConfig } from "./agent/types.js";
 import type { AgentToolSettings } from "./agent/tools/types.js";
 import type { ChannelsConfig } from "./channels/types.js";
-import type { CronActionConfig } from "./automation/types.js";
+import type { CronAction } from "./automation/types.js";
 import { resolveSandboxConfig, type SandboxConfig } from "./agent/middleware/sandbox-config.js";
 
 export interface ProviderConfigFile {
@@ -25,7 +25,6 @@ export interface CronTaskConfigFile {
   name: string;
   /** Cron expression, e.g. "0 * * * *" */
   schedule: string;
-  channel: string;
   prompt: string;
   /** Default: true */
   enabled?: boolean;
@@ -84,7 +83,7 @@ export interface CronJobConfigFile {
   name: string;
   expression: string;
   agentId: string;
-  action: CronActionConfig;
+  action: CronAction;
   enabled?: boolean;
 }
 

--- a/src/legacy/http/chat.test.ts
+++ b/src/legacy/http/chat.test.ts
@@ -78,7 +78,7 @@ describe("POST /api/sessions/:agentId — sessionKey", () => {
     sessionStoreManager = new SessionStoreManager();
     server = new ApiServer(
       { port: 0 },
-      { cronScheduler: new CronScheduler(), agentRuntime: makeRuntime(), sessionStoreManager },
+      { cronScheduler: new CronScheduler(async () => {}), agentRuntime: makeRuntime(), sessionStoreManager },
     );
     await server.start();
   });

--- a/src/legacy/http/cron.ts
+++ b/src/legacy/http/cron.ts
@@ -20,7 +20,6 @@ addRoute("GET", "/api/cron", (_req, res, deps) => {
         name: j.name,
         expression: j.expression,
         agentId: j.agentId,
-        channelId: j.channelId,
         action: j.action,
         enabled: j.enabled,
         lastRun: j.lastRun?.toISOString() ?? null,
@@ -52,7 +51,6 @@ addRoute("POST", "/api/cron", (req, res, deps) => {
       name: body.name,
       expression: body.expression,
       agentId: body.agentId,
-      channelId: body.channelId,
       action: body.action as CronJobInput["action"],
       enabled: body.enabled ?? true,
     });

--- a/src/legacy/http/routes.test.ts
+++ b/src/legacy/http/routes.test.ts
@@ -169,7 +169,7 @@ describe("API routes", () => {
       expect(status).toBe(200);
       expect((data as { ok: boolean }).ok).toBe(true);
 
-      expect(cronScheduler.getJob(job.id)).toBeUndefined();
+      expect(cronScheduler.listJobs()).toHaveLength(0);
     });
 
     it("returns 404 for unknown job", async () => {

--- a/src/legacy/http/routes.test.ts
+++ b/src/legacy/http/routes.test.ts
@@ -54,7 +54,7 @@ describe("API routes", () => {
   let cronScheduler: CronScheduler;
 
   beforeEach(async () => {
-    cronScheduler = new CronScheduler();
+    cronScheduler = new CronScheduler(async () => {});
     server = new ApiServer({ port: 0 }, { cronScheduler });
     await server.start();
   });

--- a/src/legacy/http/routes.test.ts
+++ b/src/legacy/http/routes.test.ts
@@ -121,7 +121,7 @@ describe("API routes", () => {
 
       expect(status).toBe(201);
       const body = data as { id: string; name: string; enabled: boolean };
-      expect(body.id).toMatch(/^cron_/);
+      expect(body.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(body.name).toBe("daily-report");
       expect(body.enabled).toBe(true);
 

--- a/src/legacy/http/server.test.ts
+++ b/src/legacy/http/server.test.ts
@@ -58,7 +58,7 @@ describe("ApiServer", () => {
   let cronScheduler: CronScheduler;
 
   beforeEach(async () => {
-    cronScheduler = new CronScheduler();
+    cronScheduler = new CronScheduler(async () => {});
     // Use port 0 so the OS assigns a free port
     server = new ApiServer({ port: 0 }, { cronScheduler });
     await server.start();


### PR DESCRIPTION
8 commits, all under \`automation/\` — collected here because the second batch grew out of \"finish what heartbeat needed\" cleanups discovered while iterating on cron.

## Heartbeat (3 commits)

### 1. \`app.ts\` heartbeat callback honors heartbeat-supplied sessionKey (\`4005090\`)

\`HeartbeatManager\` already passed \`sessionKey\` to \`runAgentLoop\`. The callback was discarding it (\`_sessionKey\`) and rebuilding the same string \`heartbeat:\${agentId}\` locally. Two sources of truth, kept consistent only by convention. After: heartbeat owns the format, callback is a pure relay.

### 2. \`heartbeat.ts\` caps a single tick at 2 × intervalSeconds (\`713cadf\`)

If \`runAgentLoop\` never resolves (LLM provider hang, network deadlock), \`isRunning\` stayed true forever and every future tick was silently skipped — heartbeat permanently dead until process restart. Race the await against \`setTimeout\`; on timeout: log warn (distinct from agent-side error → log error), \`finally\` resets \`isRunning\` so the next tick fires.

**Known limit**: the underlying run is NOT canceled on timeout — gateway's steer absorbs the next tick into the still-running run. If the runtime itself is hung, the next tick effectively also hangs. Worth a follow-up to wire timeout → \`gateway.abortByKey\`.

## Cron (5 commits)

### 3. Dead code trim (\`32d8967\`)

Removed all \"interface for the future\" surface that had zero production callers:
- \`enable(jobId)\` / \`disable(jobId)\` / \`getJob(jobId)\` methods
- \`listJobs(filter)\` filter parameter (callers always passed no args)
- \`CronJob.channelId\` field (stored everywhere but never read by trigger handler)
- \`CronAction.callback\` variant (handler always rejected with \"unsupported\" warn)
- Duplicate \`CronActionConfig\` type — consolidated as \`CronAction\` in \`types.ts\`

### 4. Trim noise comments (\`719f68f\`)

Section banners + docstrings that purely restated function names. Kept load-bearing comments (\`unref\` rationale, \"preserves registrations\" on stop, unsubscribe semantics).

### 5. Use randomUUID for job IDs (\`81e4989\`)

Old format \`cron_\${Date.now()}_\${++counter}\` was the only place in the codebase that didn't use \`randomUUID\`. Now consistent with \`sessionStore\`, \`runtime.runId\`, \`claude runner\`, and \`HTTP sessions API\`. Removes module-level counter state.

### 6. Replace custom timer layer with croner's native scheduler (\`a72c4d7\`) ← **architectural change**

Old code hand-rolled \`setTimeout\` per job + manual re-schedule in \`triggerJob\`, duplicating croner's own scheduling. The split reasons no longer applied (\`enable\`/\`disable\` were removed in commit 3, multi-handler dispatch can live inside the croner callback).

Hand off to croner: pass trigger logic as the \`Cron\` callback, use \`.pause()/.resume()/.stop()\` for lifecycle. Net deletes:
- \`timers\` Map + \`scheduleTimer\` + \`clearTimer\` (~50 lines)
- \`triggerJob\` method (logic moved into the closure)
- The recursive \`nextRun(lastRun)\` self-reschedule

Side benefits:
- \`protect: true\` — croner's native overlap guard, equivalent to heartbeat's \`isRunning\` skip-not-stack
- \`schedule.stop()\` is permanent + idempotent → fixes the in-flight-handler-then-reschedule leak the old code had
- One less abstraction layer

### 7. Replace handlers array with constructor-injected dispatcher (\`22c1b4b\`) ← **architectural change**

isotopes only ever registered one cron handler (gateway dispatch). The multi-handler subscribe/unsubscribe API was speculative — no caller exercised it. Replace:
- \`handlers\` array → single \`dispatchJob\` field set in constructor
- \`onTrigger(callback)\` → \`new CronScheduler(dispatchJob)\`
- \`CronJobCallback\` type → \`CronJobDispatcher\` (name reflects what it does)

### 8. Pass \`unref: true\` to croner (\`088c331\`)

Old hand-rolled timer code did \`if (timer.unref) timer.unref()\` after each \`setTimeout\` to prevent cron timers from blocking process exit. When we handed scheduling to croner in commit 6, that unref behavior was dropped — croner's internal timers default to ref'd (\`croner.d.ts:186\` \`@default false\`). Pass \`{ unref: true }\` to restore.

Belt-and-suspenders with the existing \`cli.ts\` SIGINT/SIGTERM → \`cronScheduler.stop()\` path.

## Test plan

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm test\` passes (570 — net loss vs main of ~12 tests, all for deleted features)
- [x] New tests cover: heartbeat sessionKey relay, heartbeat hung-run timeout recovery, cron dispatcher invocation, cron dispatcher rejection isolation
- [ ] Manual: heartbeat-enabled agent across multiple ticks (sessionKey continuity)
- [ ] Manual: simulate hung LLM, verify next heartbeat fires after timeout
- [ ] Manual: cron task fires on schedule, daemon exits cleanly when stopped

## Known follow-ups (not blocking this PR)

- Heartbeat timeout doesn't truly cancel the underlying run — wire to \`gateway.abortByKey\` once the abort plumbing supports it.
- Consider whether \`onTrigger\` patterns elsewhere (e.g., observability hooks) ever need the array-of-handlers shape we just removed; if so, reintroduce only when there's a real second consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)