### PR TITLE
docs: remove stale src/extensions/channels/README.md

### DIFF
--- a/src/extensions/channels/README.md
+++ b/src/extensions/channels/README.md
@@ -1,5 +1,0 @@
-# channels/
-
-Reserved slot for future channel adapter discovery (Discord, Feishu, etc.).
-
-Mirrors the user-side path `~/.isotopes/extensions/channels/`. Empty until a channel adapter actually needs runtime discovery — current channels are hard-wired in `app.ts` and `legacy/discord/`.


### PR DESCRIPTION
## Summary
- README was outdated: claimed the dir was empty and pointed to the removed \`legacy/discord/\` path, while \`loader.ts\` already lives here and discovers built-in channel adapters.

## Test plan
- [x] No code references the file (grep clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)