### PR TITLE
fix(init): switch skip-provider template to minimax-cn

### DIFF
--- a/src/init/render.ts
+++ b/src/init/render.ts
@@ -6,9 +6,9 @@ const HEADER = `# ~/.isotopes/isotopes.yaml
 `;
 
 const PROVIDER_SKIP = `# provider:
-#   type: github-copilot
-#   defaultModel: claude-opus-4.7
-#   apiKey: \${GITHUB_TOKEN}
+#   type: minimax-cn          # or "minimax" for the international endpoint
+#   defaultModel: MiniMax-M2.7
+#   apiKey: \${MINIMAX_API_KEY}
 `;
 
 function renderProvider(answers: InitAnswers): string {


### PR DESCRIPTION
## Summary
- The skip-provider template pointed at \`github-copilot\` but omitted \`baseUrl\` — that provider needs one (the wizard's active path requires it), so uncommenting the template would fail to start.
- Switch to \`minimax-cn\` (with a hint for \`minimax\`): pi-ai ships the baseUrl built-in, so the 3-line template is actually runnable as-is.

## Test plan
- [x] \`npx vitest run src/init/render.test.ts\` — 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)