### PR TITLE
feat(config): validate agent IDs at config load time

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -370,6 +370,19 @@ agents:
       await expect(loadConfig(configPath)).rejects.toThrow();
     });
 
+    it("rejects agent ids with invalid characters", async () => {
+      const configPath = path.join(tempDir, "isotopes.yaml");
+      await fs.writeFile(configPath, "agents:\n  - id: Agent:Dev\n");
+      await expect(loadConfig(configPath)).rejects.toThrow(/Invalid agent id/);
+    });
+
+    it("accepts valid agent ids", async () => {
+      const configPath = path.join(tempDir, "isotopes.yaml");
+      await fs.writeFile(configPath, "agents:\n  - id: code-reviewer_v2\n");
+      const config = await loadConfig(configPath);
+      expect(config.agents[0].id).toBe("code-reviewer_v2");
+    });
+
     it("loads file with unknown extension by trying YAML first", async () => {
       const configPath = path.join(tempDir, "config.toml");
       await fs.writeFile(

--- a/src/config.ts
+++ b/src/config.ts
@@ -177,6 +177,15 @@ export async function loadConfig(filePath: string): Promise<IsotopesConfigFile> 
     throw new Error("Config must have at least one agent");
   }
 
+  const agentIdPattern = /^[a-z0-9_-]+$/;
+  for (const agent of raw.agents) {
+    if (!agentIdPattern.test(agent.id)) {
+      throw new Error(
+        `Invalid agent id "${agent.id}": must match [a-z0-9_-]+`,
+      );
+    }
+  }
+
   return processEnvVars(raw);
 }
 


### PR DESCRIPTION
## Summary
- Add agent ID validation in `loadConfig()`: must match `[a-z0-9_-]+`
- Invalid IDs throw at startup with a clear error message
- Prepares for removing `normalizeAgentId` in #829

## Test plan
- [x] `pnpm test` — 40 files, 518 tests pass (2 new tests added)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)