### PR TITLE
refactor(gateway): simplify agentExists, remove separator comment

### DIFF
--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -140,8 +140,6 @@ export function createGateway(deps: GatewayDeps): Gateway {
     };
   }
 
-  // --- public API ---
-
   async function dispatch(msg: Message): Promise<DispatchResult> {
     const sessionId = await resolveSessionId(msg);
 
@@ -220,7 +218,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
   }
 
   function agentExists(agentId: string): boolean {
-    return deps.agentRuntime.getAgent(agentId)?.config !== undefined;
+    return deps.agentRuntime.getAgent(agentId) !== undefined;
   }
 
   async function listSessions(): Promise<Session[]> {


### PR DESCRIPTION
## Summary
- Simplify `agentExists`: `getAgent(id)?.config !== undefined` → `getAgent(id) !== undefined`
- Remove `// --- public API ---` separator comment

## Test plan
- [x] `pnpm test` — 40 files, 518 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)