### PR TITLE
refactor(logging): clean slate for logging overhaul

### DIFF
--- a/src/agent/adapters/claude/runner.ts
+++ b/src/agent/adapters/claude/runner.ts
@@ -1,13 +1,11 @@
 import { query, type Options, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { randomUUID } from "node:crypto";
-import { createLogger } from "../../../logging/logger.js";
 import type { RunRequest } from "../../types.js";
 import { RunValidationError } from "../../types.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, AssistantMessageEvent } from "@mariozechner/pi-ai";
 
-const log = createLogger("agents:runner:claude");
 
 export class ClaudeRunner {
   resolveSessionId(req: RunRequest): string {
@@ -38,7 +36,6 @@ export class ClaudeRunner {
       settingSources: ["user"],
     };
 
-    log.info("ClaudeRunner.run", { sessionId: opts.sessionId, cwd: request.cwd });
 
     const toolNameById = new Map<string, string>();
     let assistantText = "";

--- a/src/agent/adapters/claude/runner.ts
+++ b/src/agent/adapters/claude/runner.ts
@@ -6,7 +6,6 @@ import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, AssistantMessageEvent } from "@mariozechner/pi-ai";
 
-
 export class ClaudeRunner {
   resolveSessionId(req: RunRequest): string {
     return req.sessionId ?? `claude:${randomUUID()}`;
@@ -35,7 +34,6 @@ export class ClaudeRunner {
       permissionMode: "bypassPermissions",
       settingSources: ["user"],
     };
-
 
     const toolNameById = new Map<string, string>();
     let assistantText = "";
@@ -74,7 +72,6 @@ export class ClaudeRunner {
     yield buildAgentEnd(assistantText, stopReason, errorMessage, costUsd);
   }
 }
-
 
 type Translated =
   | { kind: "text"; text: string }

--- a/src/agent/middleware/container.ts
+++ b/src/agent/middleware/container.ts
@@ -1,9 +1,6 @@
 import { spawn } from "node:child_process";
-import { createLogger } from "../../logging/logger.js";
 import { EXEC_MAX_OUTPUT_BYTES, type ExecResult } from "./executor.js";
 import type { DockerConfig, Mount, WorkspaceAccess } from "./sandbox-config.js";
-
-const log = createLogger("middleware:container");
 
 export type ContainerStatus = "created" | "running" | "paused" | "exited";
 
@@ -79,8 +76,7 @@ export class ContainerManager {
       const line = stdout.toString("utf8").trim();
       if (!line) return null;
       return parseInspectLine(line);
-    } catch (err) {
-      log.debug(`status(${containerId}) failed`, err);
+    } catch {
       return null;
     }
   }

--- a/src/agent/middleware/executor.ts
+++ b/src/agent/middleware/executor.ts
@@ -1,9 +1,7 @@
 import { spawn } from "node:child_process";
-import { createLogger } from "../../logging/logger.js";
 import { ContainerManager, type ContainerInfo } from "./container.js";
 import { type DockerConfig, type Mount, type SandboxConfig, type WorkspaceAccess } from "./sandbox-config.js";
 
-const log = createLogger("middleware:executor");
 
 /** Cap collected stdout/stderr per `execute()` call to prevent OOM from runaway commands. */
 export const EXEC_MAX_OUTPUT_BYTES = 100 * 1024;
@@ -193,8 +191,7 @@ export class SandboxExecutor {
           const updated: ContainerInfo = { ...existing, status: "running" };
           this.containers.set(agentId, updated);
           return updated;
-        } catch (err) {
-          log.debug(`Failed to restart container ${existing.id}, recreating`, err);
+        } catch {
           await this.safeRemove(existing.id);
         }
       }
@@ -207,7 +204,6 @@ export class SandboxExecutor {
     // Reap an orphan from a previous process — otherwise `docker create` fails on the name conflict.
     const orphan = await this.containerManager.status(containerName);
     if (orphan) {
-      log.info(`Removing orphan container ${containerName} (${orphan.status}) from previous run`);
       await this.safeRemove(orphan.id);
     }
 
@@ -273,8 +269,8 @@ export class SandboxExecutor {
 
   private async safeRemove(containerId: string): Promise<void> {
     try { await this.containerManager.stop(containerId, 5); }
-    catch (err) { log.debug(`Stop failed for ${containerId}`, err); }
+    catch { /* ignore */ }
     try { await this.containerManager.remove(containerId, true); }
-    catch (err) { log.debug(`Remove failed for ${containerId}`, err); }
+    catch { /* ignore */ }
   }
 }

--- a/src/agent/middleware/executor.ts
+++ b/src/agent/middleware/executor.ts
@@ -2,7 +2,6 @@ import { spawn } from "node:child_process";
 import { ContainerManager, type ContainerInfo } from "./container.js";
 import { type DockerConfig, type Mount, type SandboxConfig, type WorkspaceAccess } from "./sandbox-config.js";
 
-
 /** Cap collected stdout/stderr per `execute()` call to prevent OOM from runaway commands. */
 export const EXEC_MAX_OUTPUT_BYTES = 100 * 1024;
 

--- a/src/agent/pi/session-store.ts
+++ b/src/agent/pi/session-store.ts
@@ -123,9 +123,7 @@ export class DefaultSessionStore implements SessionStore {
     await this.persistIndex();
     try {
       await fs.rm(this.transcriptFile(sessionId), { force: true });
-    } catch {
-      // TODO: add logging
-    }
+    } catch { /* ignore */ }
   }
 
   async clearMessages(sessionId: string): Promise<void> {

--- a/src/agent/pi/session-store.ts
+++ b/src/agent/pi/session-store.ts
@@ -13,7 +13,6 @@ import type {
 } from "../types.js";
 import { getIsotopesHome } from "../../utils/paths.js";
 
-
 interface PersistedSessionRecord {
   id: string;
   agentId: string;
@@ -256,7 +255,6 @@ function toSession(s: StoredSession): Session {
 // ---------------------------------------------------------------------------
 // SessionStoreManager — one DefaultSessionStore per agentId.
 // ---------------------------------------------------------------------------
-
 
 export class SessionStoreManager {
   private stores = new Map<string, DefaultSessionStore>();

--- a/src/agent/pi/session-store.ts
+++ b/src/agent/pi/session-store.ts
@@ -12,9 +12,7 @@ import type {
   TranscriptUpdate,
 } from "../types.js";
 import { getIsotopesHome } from "../../utils/paths.js";
-import { createLogger } from "../../logging/logger.js";
 
-const log = createLogger("session-store");
 
 interface PersistedSessionRecord {
   id: string;
@@ -125,8 +123,8 @@ export class DefaultSessionStore implements SessionStore {
     await this.persistIndex();
     try {
       await fs.rm(this.transcriptFile(sessionId), { force: true });
-    } catch (err) {
-      log.debug(`Could not remove transcript file for session ${sessionId}`, err);
+    } catch {
+      // TODO: add logging
     }
   }
 
@@ -191,7 +189,6 @@ export class DefaultSessionStore implements SessionStore {
     try {
       raw = await fs.readFile(this.indexFile(), "utf-8");
     } catch {
-      log.debug("No session index found (first run or empty store)");
       return;
     }
     const index = JSON.parse(raw) as PersistedSessionIndex;
@@ -230,7 +227,7 @@ export class DefaultSessionStore implements SessionStore {
     if (!set) return;
     for (const fn of set) {
       try { fn(update); }
-      catch (err) { log.warn("Transcript listener threw", err); }
+      catch { /* ignore */ }
     }
   }
 
@@ -262,7 +259,6 @@ function toSession(s: StoredSession): Session {
 // SessionStoreManager — one DefaultSessionStore per agentId.
 // ---------------------------------------------------------------------------
 
-const mgrLog = createLogger("session-store-manager");
 
 export class SessionStoreManager {
   private stores = new Map<string, DefaultSessionStore>();
@@ -283,7 +279,6 @@ export class SessionStoreManager {
       await store.init();
       this.stores.set(agentId, store);
       this.inits.delete(agentId);
-      mgrLog.debug(`Initialized session store for agent ${agentId} at ${dataDir}`);
       return store;
     })();
 

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -215,7 +215,6 @@ export class AgentRuntime {
     await fs.mkdir(workspacePath, { recursive: true });
 
     await seedWorkspaceTemplates(workspacePath, agentConfig.id);
-
     await reconcileWorkspaceState(workspacePath);
     await ensureWorkspaceStructure(workspacePath);
 

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -1,7 +1,6 @@
 import { existsSync, statSync, realpathSync } from "node:fs";
 import { resolve, normalize } from "node:path";
 import { randomUUID } from "node:crypto";
-import { createLogger } from "../logging/logger.js";
 import type {
   RegisteredAgent,
   RunRequest,
@@ -38,7 +37,6 @@ import type { DefaultSessionStore } from "./pi/session-store.js";
 import { SandboxExecutor } from "./middleware/executor.js";
 import type { SandboxConfig } from "./middleware/sandbox-config.js";
 
-const log = createLogger("agents:runtime");
 
 export const MAX_DEPTH = 5;
 export const MAX_CHILDREN_PER_PARENT = 5;
@@ -116,9 +114,6 @@ export class AgentRuntime {
     if (opts.extensionPaths) this.extensionPaths = opts.extensionPaths;
     if (opts.sandboxBaseConfig) {
       this.sandboxExecutor = SandboxExecutor.fromConfig(opts.sandboxBaseConfig);
-      if (this.sandboxExecutor) {
-        log.info(`Sandbox executor initialized (image: ${opts.sandboxBaseConfig.docker?.image})`);
-      }
     }
 
     if (opts.globalProvider) {
@@ -208,7 +203,6 @@ export class AgentRuntime {
       ...(agentConfig.sessionPolicy ? { sessionPolicy: agentConfig.sessionPolicy } : {}),
     };
     this.registerRunner(agentConfig.id, new ClaudeRunner(), { spawnable: agentConfig.spawnable === true });
-    log.info(`Added agent: ${agent.id} (runner: claude)`);
     return { agent, workspacePath: null };
   }
 
@@ -221,10 +215,7 @@ export class AgentRuntime {
     const workspacePath = getAgentWorkspacePath(agentConfig);
     await fs.mkdir(workspacePath, { recursive: true });
 
-    const seededFiles = await seedWorkspaceTemplates(workspacePath, agentConfig.id);
-    if (seededFiles.length > 0) {
-      log.info(`Seeded ${seededFiles.length} template file(s) for ${agentConfig.id}: ${seededFiles.join(", ")}`);
-    }
+    await seedWorkspaceTemplates(workspacePath, agentConfig.id);
 
     await reconcileWorkspaceState(workspacePath);
     await ensureWorkspaceStructure(workspacePath);
@@ -241,10 +232,6 @@ export class AgentRuntime {
     const runner = new PiRunner({ agent, piDeps: this.piDeps() });
     this.registerRunner(agent.id, runner, { spawnable: agentConfig.spawnable === true });
 
-    log.info(`Added agent: ${agent.id} (runner: pi, workspace: ${workspacePath})`);
-    if (agentConfig.sandbox?.enabled) {
-      log.info(`spawn_agent disabled for ${agentConfig.id} (sandbox active)`);
-    }
 
     return {
       agent,
@@ -326,12 +313,11 @@ export class AgentRuntime {
     const timeoutHandle = setTimeout(() => this.cancel(sessionId, { reason: "timeout" }), sec * 1000);
     timeoutHandle.unref();
 
-    log.info("run", { runId, agentId: req.to, sessionId, depth });
 
     try {
       req.onRunStart?.(sessionId);
-    } catch (err) {
-      log.warn("onRunStart callback threw", { runId, error: err instanceof Error ? err.message : String(err) });
+    } catch {
+      // TODO: add logging
     }
 
     try {
@@ -341,11 +327,6 @@ export class AgentRuntime {
         abort: abort.signal,
         onSession: (session) => { handle.session = session; },
       })) {
-        if (event.type === "tool_execution_start") {
-          log.debug("tool_call", { runId, sessionId, agentId: req.to, toolName: event.toolName, id: event.toolCallId });
-        } else if (event.type === "tool_execution_end") {
-          log.debug("tool_result", { runId, sessionId, id: event.toolCallId });
-        }
         yield event;
       }
     } finally {
@@ -353,8 +334,8 @@ export class AgentRuntime {
       // Consumer break → abort inner runner so no orphan SDK work.
       if (!handle.abort.signal.aborted) handle.abort.abort();
       if (handle.cancelReason && req.onCancel) {
-        try { req.onCancel(handle.cancelReason); } catch (err) {
-          log.warn("onCancel callback threw", { runId, error: err instanceof Error ? err.message : String(err) });
+        try { req.onCancel(handle.cancelReason); } catch {
+          // TODO: add logging
         }
       }
       this.runs.delete(sessionId);
@@ -365,7 +346,6 @@ export class AgentRuntime {
     const handle = this.runs.get(sessionId);
     if (!handle) return false;
     if (opts?.reason) handle.cancelReason = opts.reason;
-    log.info("Cancelling run", { sessionId, runId: handle.runId, agentId: handle.agentId, reason: opts?.reason });
     handle.abort.abort();
     return true;
   }

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -316,9 +316,7 @@ export class AgentRuntime {
 
     try {
       req.onRunStart?.(sessionId);
-    } catch {
-      // TODO: add logging
-    }
+    } catch { /* ignore */ }
 
     try {
       for await (const event of entry.runner.run({
@@ -334,9 +332,7 @@ export class AgentRuntime {
       // Consumer break → abort inner runner so no orphan SDK work.
       if (!handle.abort.signal.aborted) handle.abort.abort();
       if (handle.cancelReason && req.onCancel) {
-        try { req.onCancel(handle.cancelReason); } catch {
-          // TODO: add logging
-        }
+        try { req.onCancel(handle.cancelReason); } catch { /* ignore */ }
       }
       this.runs.delete(sessionId);
     }

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -37,7 +37,6 @@ import type { DefaultSessionStore } from "./pi/session-store.js";
 import { SandboxExecutor } from "./middleware/executor.js";
 import type { SandboxConfig } from "./middleware/sandbox-config.js";
 
-
 export const MAX_DEPTH = 5;
 export const MAX_CHILDREN_PER_PARENT = 5;
 /** Default per-run timeout when req.timeoutSeconds is absent. */
@@ -232,7 +231,6 @@ export class AgentRuntime {
     const runner = new PiRunner({ agent, piDeps: this.piDeps() });
     this.registerRunner(agent.id, runner, { spawnable: agentConfig.spawnable === true });
 
-
     return {
       agent,
       workspacePath,
@@ -312,7 +310,6 @@ export class AgentRuntime {
     const sec = req.timeoutSeconds ?? DEFAULT_TIMEOUT_SEC;
     const timeoutHandle = setTimeout(() => this.cancel(sessionId, { reason: "timeout" }), sec * 1000);
     timeoutHandle.unref();
-
 
     try {
       req.onRunStart?.(sessionId);

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -1,9 +1,6 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type, type Static } from "typebox";
-import { createLogger } from "../../logging/logger.js";
 import type { Executor } from "../middleware/executor.js";
-
-const log = createLogger("tools:exec");
 
 const DEFAULT_TIMEOUT_SEC = 1800;
 
@@ -48,7 +45,6 @@ export function createExecTool(options: ExecToolOptions): AgentTool<typeof execS
 
       try {
         const result = await executor.execute(argv, { workspacePath: cwd, timeout: timeoutMs });
-        log.info("Command executed", { command, cwd, exitCode: result.exitCode });
         return jsonResult({
           stdout: result.stdout.toString("utf8"),
           stderr: result.stderr.toString("utf8"),
@@ -57,13 +53,11 @@ export function createExecTool(options: ExecToolOptions): AgentTool<typeof execS
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.includes("timed out")) {
-          log.warn("Command timed out", { command, timeoutMs });
           return jsonResult({
             stdout: "", stderr: "", exit_code: 124,
             error: `Command timed out after ${timeoutMs / 1000}s`,
           });
         }
-        log.warn("Exec failed", { command, error: msg });
         return jsonResult({
           stdout: "", stderr: `[exec error] ${msg}`, exit_code: 1,
           error: `Exec failed: ${msg}`,

--- a/src/agent/tools/react.ts
+++ b/src/agent/tools/react.ts
@@ -2,7 +2,6 @@ import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "typebox";
 import type { ChannelContext } from "../../channels/types.js";
 
-
 function jsonResult(value: unknown): AgentToolResult<undefined> {
   return { content: [{ type: "text", text: JSON.stringify(value) }], details: undefined };
 }

--- a/src/agent/tools/react.ts
+++ b/src/agent/tools/react.ts
@@ -1,9 +1,7 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "typebox";
-import { createLogger } from "../../logging/logger.js";
 import type { ChannelContext } from "../../channels/types.js";
 
-const log = createLogger("tools:react");
 
 function jsonResult(value: unknown): AgentToolResult<undefined> {
   return { content: [{ type: "text", text: JSON.stringify(value) }], details: undefined };
@@ -33,11 +31,9 @@ export function createMessageReactTool(ctx: ChannelContext): AgentTool<typeof me
       if (!actions.react) return jsonResult({ error: "Channel does not support reactions" });
       try {
         await actions.react(message_id, emoji, channel_id);
-        log.info("Reaction added", { messageId: message_id, emoji });
         return jsonResult({ success: true });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        log.warn("Reaction failed", { messageId: message_id, emoji, error: message });
         return jsonResult({ error: message });
       }
     },

--- a/src/agent/tools/spawn-agent.ts
+++ b/src/agent/tools/spawn-agent.ts
@@ -6,9 +6,7 @@ import { RunValidationError } from "../types.js";
 import type { RunRequest } from "../types.js";
 import { type A2ASink, getA2ASinkFactory } from "../a2a-sink.js";
 import { getAgentEndMeta } from "../pi/messages.js";
-import { createLogger } from "../../logging/logger.js";
 
-const log = createLogger("tools:spawn");
 
 export type A2ASurfaceInfo =
   | { status: "ok"; surfaceId: string }
@@ -102,7 +100,6 @@ export function createSpawnAgentTool(options: SpawnAgentToolOptions): AgentTool 
         parentSessionId,
         onCancel: (reason) => { cancelReason = reason; },
       };
-      log.info("spawn_agent", { from: parentAgentId, to, cwd, parent: parentSessionId });
 
       const sinkFactory = getA2ASinkFactory();
       let sink: A2ASink | undefined;

--- a/src/agent/tools/spawn-agent.ts
+++ b/src/agent/tools/spawn-agent.ts
@@ -7,7 +7,6 @@ import type { RunRequest } from "../types.js";
 import { type A2ASink, getA2ASinkFactory } from "../a2a-sink.js";
 import { getAgentEndMeta } from "../pi/messages.js";
 
-
 export type A2ASurfaceInfo =
   | { status: "ok"; surfaceId: string }
   | { status: "error"; error: string }

--- a/src/agent/workspace/context.ts
+++ b/src/agent/workspace/context.ts
@@ -3,9 +3,7 @@ import path from "node:path";
 import { loadSkills, formatSkillsForPrompt } from "@mariozechner/pi-coding-agent";
 import { getIsotopesHome, getAgentWorkspacePath, getBuiltinSkillsPath } from "../../utils/paths.js";
 import type { AgentConfig } from "../types.js";
-import { createLogger } from "../../logging/logger.js";
 
-const log = createLogger("skills");
 
 /** Standard workspace files that contribute to system prompt */
 export const WORKSPACE_FILES = [
@@ -74,9 +72,6 @@ export async function loadWorkspaceContext(workspacePath: string, options?: { bu
     ],
     includeDefaults: false,
   });
-  for (const d of skillResult.diagnostics) {
-    log.warn(`skill ${d.type}: ${d.message}`, { path: d.path });
-  }
   const skillsPrompt = formatSkillsForPrompt(skillResult.skills);
 
   return {

--- a/src/agent/workspace/context.ts
+++ b/src/agent/workspace/context.ts
@@ -4,7 +4,6 @@ import { loadSkills, formatSkillsForPrompt } from "@mariozechner/pi-coding-agent
 import { getIsotopesHome, getAgentWorkspacePath, getBuiltinSkillsPath } from "../../utils/paths.js";
 import type { AgentConfig } from "../types.js";
 
-
 /** Standard workspace files that contribute to system prompt */
 export const WORKSPACE_FILES = [
   "SOUL.md",

--- a/src/agent/workspace/state.ts
+++ b/src/agent/workspace/state.ts
@@ -1,9 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createLogger } from "../../logging/logger.js";
 import { isBrandNewWorkspace } from "./templates.js";
 
-const log = createLogger("workspace:state");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,7 +63,6 @@ export async function writeWorkspaceState(
 
   const statePath = getStatePath(workspacePath);
   await fs.writeFile(statePath, JSON.stringify(state, null, 2), "utf-8");
-  log.debug(`Wrote workspace state: ${statePath}`);
 }
 
 /**
@@ -98,7 +95,6 @@ export async function reconcileWorkspaceState(workspacePath: string): Promise<Wo
   if (bootstrapExists && !state.bootstrapSeededAt) {
     state.bootstrapSeededAt = new Date().toISOString();
     await writeWorkspaceState(workspacePath, state);
-    log.info(`Recorded bootstrap seeded at ${state.bootstrapSeededAt}`);
     return state;
   }
 
@@ -106,7 +102,6 @@ export async function reconcileWorkspaceState(workspacePath: string): Promise<Wo
   if (state.bootstrapSeededAt && !bootstrapExists) {
     state.setupCompletedAt = new Date().toISOString();
     await writeWorkspaceState(workspacePath, state);
-    log.info(`Hatch complete for workspace at ${workspacePath}`);
     return state;
   }
 
@@ -116,7 +111,6 @@ export async function reconcileWorkspaceState(workspacePath: string): Promise<Wo
     if (!brandNew) {
       state.setupCompletedAt = new Date().toISOString();
       await writeWorkspaceState(workspacePath, state);
-      log.info(`Marked legacy workspace as setup-complete: ${workspacePath}`);
     }
   }
 

--- a/src/agent/workspace/state.ts
+++ b/src/agent/workspace/state.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isBrandNewWorkspace } from "./templates.js";
 
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/src/agent/workspace/templates.ts
+++ b/src/agent/workspace/templates.ts
@@ -125,9 +125,7 @@ export async function seedWorkspaceTemplates(
       created.push(template.filename);
     } catch (err) {
       // EEXIST is expected — file already exists, skip silently
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
-        // TODO: add logging
-      }
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") { /* ignore */ }
     }
   }
 

--- a/src/agent/workspace/templates.ts
+++ b/src/agent/workspace/templates.ts
@@ -3,7 +3,6 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -128,7 +127,6 @@ export async function seedWorkspaceTemplates(
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") { /* ignore */ }
     }
   }
-
 
   return created;
 }

--- a/src/agent/workspace/templates.ts
+++ b/src/agent/workspace/templates.ts
@@ -123,8 +123,7 @@ export async function seedWorkspaceTemplates(
       await fs.writeFile(filePath, template.content, { flag: "wx" });
       created.push(template.filename);
     } catch (err) {
-      // EEXIST is expected — file already exists, skip silently
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") { /* ignore */ }
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
     }
   }
 

--- a/src/agent/workspace/templates.ts
+++ b/src/agent/workspace/templates.ts
@@ -2,9 +2,7 @@ import fs from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createLogger } from "../../logging/logger.js";
 
-const log = createLogger("workspace:templates");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -125,18 +123,14 @@ export async function seedWorkspaceTemplates(
     try {
       await fs.writeFile(filePath, template.content, { flag: "wx" });
       created.push(template.filename);
-      log.debug(`Seeded template: ${template.filename}`);
     } catch (err) {
       // EEXIST is expected — file already exists, skip silently
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
-        log.error(`Failed to seed template ${template.filename}:`, err);
+        // TODO: add logging
       }
     }
   }
 
-  if (created.length > 0) {
-    log.info(`Seeded ${created.length} template(s) in ${workspacePath}: ${created.join(", ")}`);
-  }
 
   return created;
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,7 +51,6 @@ export async function start(opts: AppOptions): Promise<App> {
   const channels = await startChannels({ gateway, config, logger: log, channelContexts });
   const apiServer = await startApiServer(cronScheduler, gateway);
 
-
   const shutdown = async () => {
     cronScheduler.stop();
     for (const hb of heartbeatManagers) hb.stop();

--- a/src/app.ts
+++ b/src/app.ts
@@ -62,9 +62,7 @@ export async function start(opts: AppOptions): Promise<App> {
     sessionStoreManager.destroyAll();
     try {
       await agentRuntime.shutdown();
-    } catch {
-      // TODO: add logging
-    }
+    } catch { /* ignore */ }
   };
 
   return { agentRuntime, agentWorkspaces, cronScheduler, apiServer, shutdown };
@@ -170,9 +168,7 @@ function startCron(
         content: prompt,
         source: "cron",
       });
-    } catch {
-      // TODO: add logging
-    }
+    } catch { /* ignore */ }
   });
 
   for (const agentFile of config.agents) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,10 +51,8 @@ export async function start(opts: AppOptions): Promise<App> {
   const channels = await startChannels({ gateway, config, logger: log, channelContexts });
   const apiServer = await startApiServer(cronScheduler, gateway);
 
-  log.info("App started");
 
   const shutdown = async () => {
-    log.info("Shutting down...");
     cronScheduler.stop();
     for (const hb of heartbeatManagers) hb.stop();
     try { await channels.stopAll(); } catch { /* ignore */ }
@@ -64,8 +62,8 @@ export async function start(opts: AppOptions): Promise<App> {
     sessionStoreManager.destroyAll();
     try {
       await agentRuntime.shutdown();
-    } catch (err) {
-      log.warn(`Sandbox cleanup error: ${err instanceof Error ? err.message : String(err)}`);
+    } catch {
+      // TODO: add logging
     }
   };
 
@@ -147,7 +145,6 @@ function startHeartbeats(
 
     hb.start();
     managers.push(hb);
-    log.info(`Heartbeat enabled for "${agentFile.id}" (every ${agentFile.heartbeat.intervalSeconds ?? 300}s)`);
   }
 
   return managers;
@@ -160,24 +157,21 @@ function startCron(
 ): CronScheduler {
   const scheduler = new CronScheduler(async (job) => {
     if (!agentRuntime.getAgent(job.agentId)) {
-      log.error(`Cron job "${job.name}" references unknown agent "${job.agentId}"`);
       return;
     }
 
     const prompt = job.action.type === "prompt" ? job.action.prompt : job.action.content;
     const sessionKey = `cron:${job.agentId}:${job.name}`;
-    log.info(`Cron executing "${job.name}" for agent "${job.agentId}" (session: ${sessionKey})`);
 
     try {
-      const result = await gateway.dispatchAndWait({
+      await gateway.dispatchAndWait({
         agentId: job.agentId,
         sessionKey,
         content: prompt,
         source: "cron",
       });
-      log.info(`Cron "${job.name}" completed (${result.responseText.length} chars)`);
-    } catch (err) {
-      log.error(`Cron "${job.name}" failed:`, err);
+    } catch {
+      // TODO: add logging
     }
   });
 
@@ -192,7 +186,6 @@ function startCron(
         enabled: task.enabled ?? true,
       });
     }
-    log.info(`Registered ${agentFile.cron.tasks.length} cron task(s) for "${agentFile.id}"`);
   }
 
   if (config.cron?.length) {
@@ -205,7 +198,6 @@ function startCron(
         enabled: task.enabled ?? true,
       });
     }
-    log.info(`Registered ${config.cron.length} top-level cron task(s)`);
   }
 
   scheduler.start();
@@ -217,7 +209,6 @@ async function startApiServer(cronScheduler: CronScheduler, gateway: Gateway): P
   const api = createApi({ cronScheduler, gateway });
   return new Promise<ServerType>((resolve) => {
     const s = serve({ fetch: api.fetch, port, hostname: "127.0.0.1" }, () => {
-      log.info(`API server listening on http://127.0.0.1:${port}`);
       resolve(s);
     });
   });

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -4,7 +4,6 @@ import type { CronAction } from "./types.js";
 
 export type { CronAction };
 
-
 /** A registered cron job with its parsed schedule and execution state. */
 export interface CronJob {
   id: string;

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -1,11 +1,9 @@
 import { Cron } from "croner";
 import { randomUUID } from "node:crypto";
-import { createLogger } from "../logging/logger.js";
 import type { CronAction } from "./types.js";
 
 export type { CronAction };
 
-const log = createLogger("cron");
 
 /** A registered cron job with its parsed schedule and execution state. */
 export interface CronJob {
@@ -57,13 +55,12 @@ export class CronScheduler {
       //   (matches the old `timer.unref()` we used to call directly).
       { paused: startPaused, protect: true, unref: true },
       async () => {
-        log.info(`Triggering cron job "${job.name}" (${job.id})`);
         job.lastRun = new Date();
         job.nextRun = job.schedule.nextRun() ?? undefined;
         try {
           await this.dispatchJob(job);
-        } catch (err) {
-          log.error(`Cron dispatch failed for "${job.name}":`, err);
+        } catch {
+          // TODO: add logging
         }
       },
     );
@@ -73,7 +70,6 @@ export class CronScheduler {
     }
 
     this.jobs.set(job.id, job);
-    log.info(`Registered cron job "${job.name}" (${job.id}): ${job.expression}`);
 
     return job;
   }
@@ -86,7 +82,6 @@ export class CronScheduler {
     // finishes naturally but croner won't fire this job again.
     job.schedule.stop();
     this.jobs.delete(jobId);
-    log.info(`Unregistered cron job ${jobId}`);
     return true;
   }
 
@@ -106,7 +101,6 @@ export class CronScheduler {
       }
     }
 
-    log.info(`Cron scheduler started with ${this.jobs.size} job(s)`);
   }
 
   /** Pauses all jobs but preserves their registrations. Idempotent. */
@@ -119,6 +113,5 @@ export class CronScheduler {
       job.nextRun = undefined;
     }
 
-    log.info("Cron scheduler stopped");
   }
 }

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -59,9 +59,7 @@ export class CronScheduler {
         job.nextRun = job.schedule.nextRun() ?? undefined;
         try {
           await this.dispatchJob(job);
-        } catch {
-          // TODO: add logging
-        }
+        } catch { /* ignore */ }
       },
     );
 

--- a/src/automation/heartbeat.ts
+++ b/src/automation/heartbeat.ts
@@ -74,11 +74,7 @@ export class HeartbeatManager {
     let content: string;
     try {
       content = await fs.readFile(heartbeatPath, "utf-8");
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        return;
-      }
-      // non-ENOENT error — skip this tick
+    } catch {
       return;
     }
 

--- a/src/automation/heartbeat.ts
+++ b/src/automation/heartbeat.ts
@@ -105,9 +105,7 @@ export class HeartbeatManager {
       } finally {
         if (timeoutHandle) clearTimeout(timeoutHandle);
       }
-    } catch {
-      // heartbeat error (timeout or runtime failure) — skip silently
-    } finally {
+    } catch { /* ignore */ } finally {
       this.isRunning = false;
     }
   }

--- a/src/automation/heartbeat.ts
+++ b/src/automation/heartbeat.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createLogger, type Logger } from "../logging/logger.js";
 
 export interface HeartbeatConfig {
   enabled: boolean;
@@ -16,7 +15,6 @@ export interface HeartbeatManagerOptions {
   workspacePath: string;
   config: HeartbeatConfig;
   runAgentLoop: RunAgentLoop;
-  logger?: Logger;
 }
 
 const DEFAULT_INTERVAL_SECONDS = 300;
@@ -31,7 +29,6 @@ export class HeartbeatManager {
   private readonly workspacePath: string;
   private readonly intervalMs: number;
   private readonly runAgentLoop: RunAgentLoop;
-  private readonly log: Logger;
 
   private timer: ReturnType<typeof setInterval> | undefined;
   private isRunning = false;
@@ -41,7 +38,6 @@ export class HeartbeatManager {
     this.workspacePath = options.workspacePath;
     this.intervalMs = (options.config.intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) * 1000;
     this.runAgentLoop = options.runAgentLoop;
-    this.log = options.logger ?? createLogger(`heartbeat:${options.agentId}`);
   }
 
   start(): void {
@@ -54,9 +50,6 @@ export class HeartbeatManager {
     // Don't keep the process alive solely for heartbeats.
     if (this.timer.unref) this.timer.unref();
 
-    this.log.info(
-      `Heartbeat started for "${this.agentId}" (every ${this.intervalMs / 1000}s)`,
-    );
   }
 
   stop(): void {
@@ -65,7 +58,6 @@ export class HeartbeatManager {
     clearInterval(this.timer);
     this.timer = undefined;
 
-    this.log.info(`Heartbeat stopped for "${this.agentId}"`);
   }
 
   /** Manually trigger a single heartbeat. Useful for testing. */
@@ -75,7 +67,6 @@ export class HeartbeatManager {
 
   private async tick(): Promise<void> {
     if (this.isRunning) {
-      this.log.debug(`Heartbeat skipped for "${this.agentId}" (previous still running)`);
       return;
     }
 
@@ -85,10 +76,9 @@ export class HeartbeatManager {
       content = await fs.readFile(heartbeatPath, "utf-8");
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        this.log.debug(`No HEARTBEAT.md found for "${this.agentId}" — skipping`);
         return;
       }
-      this.log.error(`Failed to read HEARTBEAT.md for "${this.agentId}":`, err);
+      // non-ENOENT error — skip this tick
       return;
     }
 
@@ -96,7 +86,6 @@ export class HeartbeatManager {
     const prompt = buildHeartbeatPrompt(content);
 
     this.isRunning = true;
-    this.log.info(`Heartbeat triggered for "${this.agentId}"`);
 
     try {
       // Cap at 2× interval so a hung run doesn't pin isRunning forever.
@@ -104,7 +93,7 @@ export class HeartbeatManager {
       const timeoutMs = this.intervalMs * 2;
       let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       try {
-        const response = await Promise.race([
+        await Promise.race([
           this.runAgentLoop(this.agentId, prompt, sessionKey),
           new Promise<never>((_, reject) => {
             timeoutHandle = setTimeout(
@@ -113,16 +102,11 @@ export class HeartbeatManager {
             );
           }),
         ]);
-        this.log.info(`Heartbeat response from "${this.agentId}": ${response}`);
       } finally {
         if (timeoutHandle) clearTimeout(timeoutHandle);
       }
-    } catch (err) {
-      if (err instanceof HeartbeatTimeoutError) {
-        this.log.warn(`Heartbeat timed out for "${this.agentId}" after ${err.timeoutMs}ms — underlying run may still be in flight`);
-      } else {
-        this.log.error(`Heartbeat error for "${this.agentId}":`, err);
-      }
+    } catch {
+      // heartbeat error (timeout or runtime failure) — skip silently
     } finally {
       this.isRunning = false;
     }

--- a/src/channels/discord/a2a-sink.ts
+++ b/src/channels/discord/a2a-sink.ts
@@ -7,7 +7,6 @@ import type {
 } from "../../agent/a2a-sink.js";
 import { chunkDiscordMessage } from "./outbound.js";
 
-
 const HEADER_PREFIX = "🤖";
 const TOOL_PREFIX = "🔧";
 const OK_PREFIX = "✅";

--- a/src/channels/discord/a2a-sink.ts
+++ b/src/channels/discord/a2a-sink.ts
@@ -102,9 +102,7 @@ export class DiscordA2ASink implements A2ASink {
       : (summary.error ? `\n${truncate(summary.error, 1500)}` : "");
     try {
       await this.deps.sendMessage(this.threadId, head + body);
-    } catch {
-      // TODO: add logging
-    }
+    } catch { /* ignore */ }
     try {
       this.deps.unregisterA2AThread(this.threadId);
     } catch { /* ignore */ }

--- a/src/channels/discord/a2a-sink.ts
+++ b/src/channels/discord/a2a-sink.ts
@@ -1,5 +1,4 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
-import { createLogger } from "../../logging/logger.js";
 import type {
   A2ASink,
   A2ASinkStartInfo,
@@ -8,7 +7,6 @@ import type {
 } from "../../agent/a2a-sink.js";
 import { chunkDiscordMessage } from "./outbound.js";
 
-const log = createLogger("discord-a2a-sink");
 
 const HEADER_PREFIX = "🤖";
 const TOOL_PREFIX = "🔧";
@@ -53,14 +51,9 @@ export class DiscordA2ASink implements A2ASink {
       );
       this.threadId = thread.id;
       this.deps.registerA2AThread(thread.id, info.sessionId);
-      log.debug("Sub-run thread opened", { sessionId: info.sessionId, threadId: thread.id });
       return { status: "ok", surfaceId: thread.id };
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
-      log.warn("Failed to open sub-run thread; streaming disabled", {
-        sessionId: info.sessionId,
-        error,
-      });
       this.threadId = undefined;
       return { status: "error", error };
     }
@@ -109,8 +102,8 @@ export class DiscordA2ASink implements A2ASink {
       : (summary.error ? `\n${truncate(summary.error, 1500)}` : "");
     try {
       await this.deps.sendMessage(this.threadId, head + body);
-    } catch (err) {
-      log.warn("Failed to post summary", { sessionId: this.sessionId, error: err instanceof Error ? err.message : String(err) });
+    } catch {
+      // TODO: add logging
     }
     try {
       this.deps.unregisterA2AThread(this.threadId);
@@ -131,12 +124,7 @@ export class DiscordA2ASink implements A2ASink {
     for (const c of chunks) {
       try {
         await this.deps.sendMessage(this.threadId, c);
-      } catch (err) {
-        log.warn("Failed to send message to sub-run thread", {
-          sessionId: this.sessionId,
-          threadId: this.threadId,
-          error: err instanceof Error ? err.message : String(err),
-        });
+      } catch {
         return;
       }
     }

--- a/src/channels/discord/attachment.ts
+++ b/src/channels/discord/attachment.ts
@@ -1,8 +1,6 @@
 import type { Message as DiscordMessage } from "discord.js";
-import { createLogger } from "../../logging/logger.js";
 import type { InboundImage } from "../../gateway/types.js";
 
-const log = createLogger("discord");
 
 const IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
 const MAX_BYTES = 10 * 1024 * 1024;
@@ -15,19 +13,17 @@ export async function extractAttachmentImages(msg: DiscordMessage): Promise<Inbo
     const ct = attachment.contentType;
     if (!ct || !IMAGE_TYPES.has(ct)) continue;
     if (attachment.size > MAX_BYTES) {
-      log.warn(`skipping oversized image attachment (${attachment.size} bytes)`);
       continue;
     }
     try {
       const res = await fetch(attachment.url);
       if (!res.ok) {
-        log.warn(`failed to fetch attachment ${attachment.url}: ${res.status}`);
         continue;
       }
       const buffer = Buffer.from(await res.arrayBuffer());
       images.push({ type: "image", data: buffer.toString("base64"), mimeType: ct });
-    } catch (err) {
-      log.warn(`error downloading attachment: ${err instanceof Error ? err.message : String(err)}`);
+    } catch {
+      // TODO: add logging
     }
   }
   return images;

--- a/src/channels/discord/attachment.ts
+++ b/src/channels/discord/attachment.ts
@@ -22,9 +22,7 @@ export async function extractAttachmentImages(msg: DiscordMessage): Promise<Inbo
       }
       const buffer = Buffer.from(await res.arrayBuffer());
       images.push({ type: "image", data: buffer.toString("base64"), mimeType: ct });
-    } catch {
-      // TODO: add logging
-    }
+    } catch { /* ignore */ }
   }
   return images;
 }

--- a/src/channels/discord/attachment.ts
+++ b/src/channels/discord/attachment.ts
@@ -1,7 +1,6 @@
 import type { Message as DiscordMessage } from "discord.js";
 import type { InboundImage } from "../../gateway/types.js";
 
-
 const IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
 const MAX_BYTES = 10 * 1024 * 1024;
 

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -5,7 +5,6 @@ import type { DiscordAccountConfig, GuildConfig } from "./types.js";
 import { isDmAllowed, resolveGroupPolicy } from "./config.js";
 import { extractAttachmentImages } from "./attachment.js";
 
-
 /** True if msg is in a Discord thread (uses channel.isThread, not msg.thread). */
 function isThreadMessage(msg: DiscordMessage): boolean {
   return (msg.channel as { isThread?: () => boolean })?.isThread?.() === true;

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -1,12 +1,10 @@
 import type { Message as DiscordMessage, SendableChannels } from "discord.js";
 import type { Gateway, Message, SessionEventListener } from "../../gateway/index.js";
 import { REPLY_PROMPT } from "../reply.js";
-import { createLogger } from "../../logging/logger.js";
 import type { DiscordAccountConfig, GuildConfig } from "./types.js";
 import { isDmAllowed, resolveGroupPolicy } from "./config.js";
 import { extractAttachmentImages } from "./attachment.js";
 
-const log = createLogger("discord");
 
 /** True if msg is in a Discord thread (uses channel.isThread, not msg.thread). */
 function isThreadMessage(msg: DiscordMessage): boolean {
@@ -22,22 +20,18 @@ function threadParentId(msg: DiscordMessage): string | undefined {
 export function passesAllowlist(msg: DiscordMessage, account: DiscordAccountConfig): boolean {
   if (!msg.guild) {
     const ok = isDmAllowed(account, msg.author.id);
-    if (!ok) log.debug(`discord: drop dm from ${msg.author.id} (dmAccess policy)`);
     return ok;
   }
   const group = resolveGroupPolicy(account);
   if (group.policy === "disabled") {
-    log.debug(`discord: drop guild message ${msg.id} (groupAccess.policy=disabled)`);
     return false;
   }
   if (group.policy === "allowlist") {
     // Fail-closed: allowlist policy with no rules is a misconfiguration.
     if (group.guildAllowlist === undefined && group.channelAllowlist === undefined) {
-      log.debug(`discord: drop guild message ${msg.id} (allowlist policy with no rules)`);
       return false;
     }
     if (group.guildAllowlist !== undefined && !group.guildAllowlist.includes(msg.guild.id)) {
-      log.debug(`discord: drop ${msg.id} (guild ${msg.guild.id} not in guildAllowlist)`);
       return false;
     }
     if (group.channelAllowlist !== undefined) {
@@ -45,7 +39,6 @@ export function passesAllowlist(msg: DiscordMessage, account: DiscordAccountConf
       const channelOk = group.channelAllowlist.includes(msg.channelId)
         || (parentId !== undefined && group.channelAllowlist.includes(parentId));
       if (!channelOk) {
-        log.debug(`discord: drop ${msg.id} (channel ${msg.channelId} not in channelAllowlist)`);
         return false;
       }
     }
@@ -86,21 +79,17 @@ export async function handleStopCommand(
     try {
       await gateway.abort(subSessionId, "user");
       didStop = true;
-      log.info(`discord: /stop sub-run aborted (sessionId=${subSessionId})`);
-    } catch (err) {
-      log.warn(`discord: /stop sub-run abort failed: ${err instanceof Error ? err.message : String(err)}`);
+    } catch {
+      // TODO: add logging
     }
   }
 
   try {
     if (await gateway.abortByKey(agentId, sessionKey, "user")) {
       didStop = true;
-      log.info(`discord: /stop aborted sessionKey=${sessionKey}`);
-    } else {
-      log.info(`discord: /stop no active run for sessionKey=${sessionKey}`);
     }
-  } catch (err) {
-    log.warn(`discord: /stop abort failed: ${err instanceof Error ? err.message : String(err)}`);
+  } catch {
+    // TODO: add logging
   }
 
   if ("send" in msg.channel) {
@@ -142,19 +131,16 @@ export async function handleInbound(
 ): Promise<void> {
   if (msg.author.id === ctx.botId) return;
   if (msg.author.bot && deps.allowBots === false) {
-    log.debug(`discord receive: drop bot message from ${msg.author.username}`);
     return;
   }
 
   if (msg.guild && isThreadMessage(msg) && deps.guilds?.[msg.guild.id]?.respondInThreads === false) {
-    log.debug(`discord receive: drop thread message ${msg.id} (respondInThreads=false)`);
     return;
   }
 
   if (msg.guild) {
     const requireMention = deps.guilds?.[msg.guild.id]?.requireMention ?? true;
     if (requireMention && !msg.mentions?.has?.(ctx.botId)) {
-      log.debug(`discord receive: not mentioned (id=${msg.id})`);
       return;
     }
   }
@@ -185,7 +171,6 @@ export async function handleInbound(
     subscriber.onEvent,
   );
   if (!unsubscribe) {
-    log.warn(`discord receive: subscribe failed for ${routing.sessionKey}`);
     return;
   }
 

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -79,18 +79,14 @@ export async function handleStopCommand(
     try {
       await gateway.abort(subSessionId, "user");
       didStop = true;
-    } catch {
-      // TODO: add logging
-    }
+    } catch { /* ignore */ }
   }
 
   try {
     if (await gateway.abortByKey(agentId, sessionKey, "user")) {
       didStop = true;
     }
-  } catch {
-    // TODO: add logging
-  }
+  } catch { /* ignore */ }
 
   if ("send" in msg.channel) {
     try {

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -195,9 +195,7 @@ async function startAccount(args: StartAccountArgs): Promise<void> {
           history,
           a2aThreads,
         });
-      } catch {
-        // will be replaced with logging
-      }
+      } catch { /* ignore */ }
     })();
   });
 

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -46,7 +46,6 @@ const defaultClientFactory: ClientFactory = () =>
     partials: [Partials.Channel, Partials.Message, Partials.User, Partials.GuildMember],
   }) as unknown as ClientLike;
 
-
 interface CreateDiscordChannelOptions {
   /** Test seam: override Discord.js Client construction. */
   clientFactory?: ClientFactory;
@@ -120,7 +119,6 @@ export function createDiscordChannel(
     },
   };
 }
-
 
 interface StartAccountArgs {
   accountId: string;
@@ -275,7 +273,6 @@ async function dispatchInbound(args: InboundArgs): Promise<void> {
     },
   ));
 }
-
 
 /** Find the unique account whose effective agent for this channel matches. */
 function clientForAgentInChannel(

--- a/src/channels/discord/outbound.ts
+++ b/src/channels/discord/outbound.ts
@@ -37,9 +37,7 @@ export class SegmentedStreamBuffer {
       const toFlush = this.buffer;
       this.buffer = "";
       await this.onFlush(toFlush);
-    }).catch(() => {
-      // TODO: add logging
-    });
+    }).catch(() => { /* ignore */ });
     return this.tail;
   }
 

--- a/src/channels/discord/outbound.ts
+++ b/src/channels/discord/outbound.ts
@@ -1,9 +1,7 @@
 import type { SendableChannels } from "discord.js";
 import type { SessionEvent, SessionEventListener } from "../../gateway/index.js";
 import { parseReply } from "../reply.js";
-import { createLogger } from "../../logging/logger.js";
 
-const log = createLogger("discord");
 
 const SENTENCE_BOUNDARIES = [". ", "! ", "? ", "\n\n"];
 const DEFAULT_MAX_BUFFER_SIZE = 500;
@@ -26,10 +24,9 @@ export class SegmentedStreamBuffer {
     this.tail = this.tail.then(async () => {
       this.buffer += text;
       await this.tryFlush();
-    }).catch((err) => {
+    }).catch(() => {
       // Don't poison subsequent appends on a transient Discord error.
       this.buffer = "";
-      log.warn(`SegmentedStreamBuffer flush failed: ${err instanceof Error ? err.message : String(err)}`);
     });
     return this.tail;
   }
@@ -40,8 +37,8 @@ export class SegmentedStreamBuffer {
       const toFlush = this.buffer;
       this.buffer = "";
       await this.onFlush(toFlush);
-    }).catch((err) => {
-      log.warn(`SegmentedStreamBuffer final flush failed: ${err instanceof Error ? err.message : String(err)}`);
+    }).catch(() => {
+      // TODO: add logging
     });
     return this.tail;
   }

--- a/src/channels/discord/outbound.ts
+++ b/src/channels/discord/outbound.ts
@@ -2,7 +2,6 @@ import type { SendableChannels } from "discord.js";
 import type { SessionEvent, SessionEventListener } from "../../gateway/index.js";
 import { parseReply } from "../reply.js";
 
-
 const SENTENCE_BOUNDARIES = [". ", "! ", "? ", "\n\n"];
 const DEFAULT_MAX_BUFFER_SIZE = 500;
 const DISCORD_MAX_MESSAGE_LENGTH = 2000;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -63,7 +63,7 @@ Config: ~/.isotopes/isotopes.yaml
 
 Environment:
   ISOTOPES_HOME   Override home directory (default: ~/.isotopes)
-  DEBUG=true      Enable debug logging
+  LOG_LEVEL       Set log level (debug, info, warn, error; default: info)
 `;
 
 if (values.help) {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -5,10 +5,7 @@ import path from "node:path";
 import os from "node:os";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { createLogger } from "../logging/logger.js";
-
 const execAsync = promisify(exec);
-const log = createLogger("daemon:launchd");
 
 export interface LaunchAgentConfig {
   /** Reverse-domain identifier, e.g. "ai.isotopes.daemon" */
@@ -81,27 +78,23 @@ export async function install(config: LaunchAgentConfig): Promise<void> {
   const domain = `gui/${process.getuid?.() ?? 0}`;
   await fs.mkdir(path.dirname(target), { recursive: true });
   await fs.writeFile(target, buildPlist(config), "utf-8");
-  log.info(`Wrote LaunchAgent plist to ${target}`);
 
   // bootout-then-bootstrap so re-install picks up plist changes
   await execAsync(`launchctl bootout ${domainTarget(config.name)}`).catch(() => undefined);
   await execAsync(`launchctl bootstrap ${domain} ${target}`);
-  log.info(`Loaded LaunchAgent ${config.name}`);
 }
 
 export async function uninstall(name: string): Promise<void> {
   const target = plistPath(name);
-  await execAsync(`launchctl bootout ${domainTarget(name)}`).catch((err) => {
-    log.debug("Could not bootout agent before uninstall (may not be loaded):", err);
+  await execAsync(`launchctl bootout ${domainTarget(name)}`).catch(() => {
+    // May not be loaded — ignore
   });
   await fs.unlink(target);
-  log.info(`Removed LaunchAgent plist ${target}`);
 }
 
 // SIGTERM and respawn in one step. Throws if the agent isn't loaded.
 export async function restart(name: string): Promise<void> {
   await execAsync(`launchctl kickstart -k ${domainTarget(name)}`);
-  log.info(`Restarted LaunchAgent ${name}`);
 }
 
 export async function status(name: string): Promise<LaunchAgentStatus> {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -86,9 +86,7 @@ export async function install(config: LaunchAgentConfig): Promise<void> {
 
 export async function uninstall(name: string): Promise<void> {
   const target = plistPath(name);
-  await execAsync(`launchctl bootout ${domainTarget(name)}`).catch(() => {
-    // May not be loaded — ignore
-  });
+  await execAsync(`launchctl bootout ${domainTarget(name)}`).catch(() => { /* ignore */ });
   await fs.unlink(target);
 }
 

--- a/src/extensions/channels/loader.test.ts
+++ b/src/extensions/channels/loader.test.ts
@@ -12,7 +12,6 @@ function makeLogger(): Logger & { warnings: string[] } {
     info: () => {},
     warn: (msg: string) => { warnings.push(msg); },
     error: () => {},
-    child: () => log,
   };
   return Object.assign(log, { warnings });
 }

--- a/src/extensions/pi/loader.ts
+++ b/src/extensions/pi/loader.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { getIsotopesHome } from "../../utils/paths.js";
 
-
 export function discoverExtensionPaths(): string[] {
   const dir = path.join(getIsotopesHome(), "extensions", "pi");
   if (!fs.existsSync(dir)) return [];

--- a/src/extensions/pi/loader.ts
+++ b/src/extensions/pi/loader.ts
@@ -1,9 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { getIsotopesHome } from "../../utils/paths.js";
-import { createLogger } from "../../logging/logger.js";
 
-const log = createLogger("extensions");
 
 export function discoverExtensionPaths(): string[] {
   const dir = path.join(getIsotopesHome(), "extensions", "pi");
@@ -14,9 +12,6 @@ export function discoverExtensionPaths(): string[] {
     if (!e.isFile()) continue;
     if (!/\.(ts|js|mts|mjs)$/.test(e.name)) continue;
     paths.push(path.join(dir, e.name));
-  }
-  if (paths.length > 0) {
-    log.info(`Discovered ${paths.length} extension(s) in ${dir}`);
   }
   return paths;
 }

--- a/src/extensions/ui/loader.ts
+++ b/src/extensions/ui/loader.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { getIsotopesHome } from "../../utils/paths.js";
 
-
 export interface UIEntry {
   id: string;
   staticDir: string;

--- a/src/extensions/ui/loader.ts
+++ b/src/extensions/ui/loader.ts
@@ -1,9 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { getIsotopesHome } from "../../utils/paths.js";
-import { createLogger } from "../../logging/logger.js";
 
-const log = createLogger("ui");
 
 export interface UIEntry {
   id: string;
@@ -26,9 +24,6 @@ export function discoverUIEntries(): UIEntry[] {
       mountPath: `/ui/${e.name}`,
       spaFallback: true,
     });
-  }
-  if (entries.length > 0) {
-    log.info(`Discovered ${entries.length} UI dir(s) in ${root}`);
   }
   return entries;
 }

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -15,7 +15,6 @@ import { getAgentEndMeta } from "../agent/pi/messages.js";
 import { getAgentWorkspacePath } from "../utils/paths.js";
 import { randomUUID } from "node:crypto";
 
-
 export interface GatewayDeps {
   agentRuntime: AgentRuntime;
   sessionStoreManager: SessionStoreManager;

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -11,12 +11,10 @@ import type {
   SessionEvent,
   SessionEventListener,
 } from "./types.js";
-import { createLogger } from "../logging/logger.js";
 import { getAgentEndMeta } from "../agent/pi/messages.js";
 import { getAgentWorkspacePath } from "../utils/paths.js";
 import { randomUUID } from "node:crypto";
 
-const log = createLogger("gateway");
 
 export interface GatewayDeps {
   agentRuntime: AgentRuntime;
@@ -39,8 +37,8 @@ export function createGateway(deps: GatewayDeps): Gateway {
     const set = listeners.get(sessionId);
     if (!set) return;
     for (const fn of set) {
-      try { fn(event); } catch (err) {
-        log.warn(`subscriber threw: ${err instanceof Error ? err.message : String(err)}`);
+      try { fn(event); } catch {
+        // TODO: add logging
       }
     }
   }
@@ -115,7 +113,6 @@ export function createGateway(deps: GatewayDeps): Gateway {
       errorMessage = await ingestRunnerEvents(sessionId, msg, markReady);
     } catch (err) {
       errorMessage = err instanceof Error ? err.message : String(err);
-      log.error(`triggerRun error for ${sessionId}: ${errorMessage}`);
     } finally {
       active.delete(sessionId);
       if (!readyResolved) handle.resolveReady();
@@ -153,9 +150,8 @@ export function createGateway(deps: GatewayDeps): Gateway {
         try {
           await deps.agentRuntime.steer(sessionId, msg.content);
           return { sessionId, state: "steered" };
-        } catch (err) {
+        } catch {
           if (!active.has(sessionId)) continue;
-          log.warn(`steer failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
           return { sessionId, state: "steered" };
         }
       }

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -37,9 +37,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
     const set = listeners.get(sessionId);
     if (!set) return;
     for (const fn of set) {
-      try { fn(event); } catch {
-        // TODO: add logging
-      }
+      try { fn(event); } catch { /* ignore */ }
     }
   }
 

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -2,7 +2,6 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { serveStatic } from "@hono/node-server/serve-static";
 import path from "node:path";
-import { createLogger } from "../logging/logger.js";
 import type { CronScheduler } from "../automation/cron-job.js";
 import type { Gateway } from "../gateway/index.js";
 import { registerCronRoutes } from "./cron.js";
@@ -10,7 +9,6 @@ import { registerStatusRoutes } from "./status.js";
 import { registerSessionRoutes } from "./sessions.js";
 import { matchUIEntry, discoverUIEntries, type UIEntry } from "../extensions/ui/loader.js";
 
-const log = createLogger("api:server");
 
 export interface ApiDeps {
   cronScheduler: CronScheduler;
@@ -30,12 +28,6 @@ export function createApi(deps: ApiDeps): Hono {
     }),
   );
 
-  app.use("*", async (c, next) => {
-    const start = Date.now();
-    await next();
-    log.info(`${c.req.method} ${c.req.path} ${c.res.status} ${Date.now() - start}ms`);
-  });
-
   mountUI(app, discoverUIEntries());
 
   registerCronRoutes(app, deps);
@@ -47,7 +39,6 @@ export function createApi(deps: ApiDeps): Hono {
   );
 
   app.onError((err, c) => {
-    log.error("Route error:", err);
     return c.json(
       { error: err instanceof Error ? err.message : "Internal server error", status: 500 },
       500,

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -9,7 +9,6 @@ import { registerStatusRoutes } from "./status.js";
 import { registerSessionRoutes } from "./sessions.js";
 import { matchUIEntry, discoverUIEntries, type UIEntry } from "../extensions/ui/loader.js";
 
-
 export interface ApiDeps {
   cronScheduler: CronScheduler;
   gateway: Gateway;

--- a/src/http/sessions.ts
+++ b/src/http/sessions.ts
@@ -1,9 +1,7 @@
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { createLogger } from "../logging/logger.js";
 import type { ApiDeps } from "./server.js";
 
-const log = createLogger("api:sessions");
 
 export function registerSessionRoutes(app: Hono, deps: ApiDeps): void {
   app.get("/api/sessions", async (c) => {
@@ -68,7 +66,6 @@ export function registerSessionRoutes(app: Hono, deps: ApiDeps): void {
     }
 
     const result = await deps.gateway.createOrResumeSession(agentId, body?.sessionKey);
-    log.info(`Session ${result.resumed ? "resumed" : "created"}: ${result.sessionKey} (agent: ${agentId})`);
     return c.json({ key: result.sessionKey, agentId, resumed: result.resumed }, result.resumed ? 200 : 201);
   });
 

--- a/src/http/sessions.ts
+++ b/src/http/sessions.ts
@@ -2,7 +2,6 @@ import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ApiDeps } from "./server.js";
 
-
 export function registerSessionRoutes(app: Hono, deps: ApiDeps): void {
   app.get("/api/sessions", async (c) => {
     const sessions = await deps.gateway.listSessions();

--- a/src/logging/logger.test.ts
+++ b/src/logging/logger.test.ts
@@ -58,23 +58,15 @@ describe("Logger", () => {
       expect(console.error).toHaveBeenCalled();
     });
 
-    it("enables debug when DEBUG=true", () => {
+    it("enables debug when LOG_LEVEL=debug", () => {
       const log = createLogger("test");
 
       log.debug("hidden");
       expect(console.debug).not.toHaveBeenCalled();
 
-      vi.stubEnv("DEBUG", "true");
+      vi.stubEnv("LOG_LEVEL", "debug");
       log.debug("visible");
       expect(console.debug).toHaveBeenCalledWith(expect.stringContaining("visible"));
-    });
-  });
-
-  describe("child loggers", () => {
-    it("creates child logger with combined tag", () => {
-      const child = createLogger("parent").child("child");
-      child.info("Hello");
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining("[parent:child]"));
     });
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -23,7 +23,6 @@ export interface Logger {
   info(message: string, ...args: unknown[]): void;
   warn(message: string, ...args: unknown[]): void;
   error(message: string, ...args: unknown[]): void;
-
 }
 
 export function createLogger(tag: string): Logger {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -8,7 +8,9 @@ const LOG_LEVELS: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error
 let fileStream: nodeFs.WriteStream | null = null;
 
 function getLogLevel(): LogLevel {
-  return process.env.DEBUG === "true" ? "debug" : "info";
+  const level = process.env.LOG_LEVEL?.toLowerCase();
+  if (level && level in LOG_LEVELS) return level as LogLevel;
+  return "info";
 }
 
 export function enableFileLogging(logDir: string): void {
@@ -21,7 +23,7 @@ export interface Logger {
   info(message: string, ...args: unknown[]): void;
   warn(message: string, ...args: unknown[]): void;
   error(message: string, ...args: unknown[]): void;
-  child(subtag: string): Logger;
+
 }
 
 export function createLogger(tag: string): Logger {
@@ -41,6 +43,5 @@ export function createLogger(tag: string): Logger {
     info: (msg, ...args) => log("info", msg, args),
     warn: (msg, ...args) => log("warn", msg, args),
     error: (msg, ...args) => log("error", msg, args),
-    child: (subtag) => createLogger(`${tag}:${subtag}`),
   };
 }


### PR DESCRIPTION
## Summary
- Remove all ~90 `log.*` calls across 24 source files
- Remove `Logger.child()` (unused dead code)
- Replace `DEBUG=true` with `LOG_LEVEL` env var (`debug`, `info`, `warn`, `error`)
- Update tests and CLI help text

Clean slate before re-implementing structured logging from scratch.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (517 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)