### PR TITLE
fix(discord): stop typing indicator after steered dispatch

### DIFF
--- a/src/channels/discord/inbound.test.ts
+++ b/src/channels/discord/inbound.test.ts
@@ -218,15 +218,19 @@ describe("handleInbound", () => {
     expect(settled).toBe(true);
   });
 
-  it("does not await subscriber.done when dispatch returns steered", async () => {
+  it("awaits subscriber.done even when dispatch returns steered", async () => {
     gateway.dispatch.mockResolvedValueOnce({ sessionId: "s", state: "steered" });
     let resolveDone!: () => void;
     const done = new Promise<void>((r) => { resolveDone = r; });
     buildSubscriber = vi.fn().mockReturnValue({ onEvent: vi.fn(), done });
     const msg = fakeMsg({ mentionedIds: [BOT_ID], content: `<@${BOT_ID}> hi` });
-    // Should resolve without resolveDone() being called.
-    await handleInbound(msg, route(msg), { gateway }, ctx());
-    resolveDone(); // cleanup
+    let resolved = false;
+    const p = handleInbound(msg, route(msg), { gateway }, ctx()).then(() => { resolved = true; });
+    await vi.waitFor(() => expect(gateway.dispatch).toHaveBeenCalled());
+    expect(resolved).toBe(false);
+    resolveDone();
+    await p;
+    expect(resolved).toBe(true);
   });
 });
 

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -191,10 +191,7 @@ export async function handleInbound(
   }
 
   try {
-    const result = await deps.gateway.dispatch(message);
-    if (result.state === "steered") {
-      return;
-    }
+    await deps.gateway.dispatch(message);
     await subscriber.done;
   } finally {
     unsubscribe();


### PR DESCRIPTION
## Summary
- When a message was steered into an already-running session, `handleInbound` returned early without awaiting `subscriber.done`, so `stopTyping()` was never called — Discord kept showing "is typing..." indefinitely.
- Removed the early-return for steered dispatches so `subscriber.done` is always awaited, ensuring `stopTyping()` fires when the run ends.

## Test plan
- [x] Updated existing test to verify steered dispatches now await `subscriber.done`
- [x] All 76 discord channel tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)