### PR TITLE
refactor: unify channels and apiServer to class-based start/stop

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,7 @@ export async function start(opts: AppOptions): Promise<App> {
     log.info("Shutting down");
     cronScheduler.stop();
     for (const hb of heartbeatManagers) hb.stop();
-    try { await channelManager.stop(); } catch { /* ignore */ }
+    await channelManager.stop();
     await apiServer.stop();
     sessionStoreManager.stop();
     try {

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,18 +4,16 @@ import {
   type IsotopesConfigFile,
 } from "./config.js";
 import { SessionStoreManager } from "./agent/pi/session-store.js";
-import { getApiPort } from "./utils/api-client.js";
 import { createLogger } from "./logging/logger.js";
 import { LazyChannelContext } from "./channels/types.js";
 import { getIsotopesHome, getLogsPath } from "./utils/paths.js";
 
-import { serve, type ServerType } from "@hono/node-server";
-import { createApi } from "./http/server.js";
 import { CronScheduler } from "./automation/cron-job.js";
 import { HeartbeatManager } from "./automation/heartbeat.js";
 import { AgentRuntime } from "./agent/runtime.js";
 import { discoverExtensionPaths } from "./extensions/pi/loader.js";
-import { startChannels } from "./extensions/channels/loader.js";
+import { ChannelManager } from "./extensions/channels/loader.js";
+import { ApiServer } from "./http/api-server.js";
 import { createGateway, type Gateway } from "./gateway/index.js";
 
 const log = createLogger("app");
@@ -28,7 +26,7 @@ export interface App {
   agentRuntime: AgentRuntime;
   agentWorkspaces: Map<string, string>;
   cronScheduler: CronScheduler;
-  apiServer: ServerType;
+  apiServer: ApiServer;
   stop: () => Promise<void>;
 }
 
@@ -48,17 +46,17 @@ export async function start(opts: AppOptions): Promise<App> {
   const gateway = createGateway({ agentRuntime, sessionStoreManager });
   const heartbeatManagers = startHeartbeats(config, agentWorkspaces, gateway);
   const cronScheduler = startCron(config, agentRuntime, gateway);
-  const channels = await startChannels({ gateway, config, channelContexts });
-  const apiServer = await startApiServer(cronScheduler, gateway);
+  const channelManager = new ChannelManager(config);
+  await channelManager.start({ gateway, channelContexts });
+  const apiServer = new ApiServer({ cronScheduler, gateway });
+  await apiServer.start();
 
   const stop = async () => {
     log.info("Shutting down");
     cronScheduler.stop();
     for (const hb of heartbeatManagers) hb.stop();
-    try { await channels.stop(); } catch { /* ignore */ }
-    await new Promise<void>((resolve, reject) => {
-      apiServer.close((err) => (err ? reject(err) : resolve()));
-    });
+    try { await channelManager.stop(); } catch { /* ignore */ }
+    await apiServer.stop();
     sessionStoreManager.stop();
     try {
       await agentRuntime.stop();
@@ -202,15 +200,4 @@ function startCron(
   scheduler.start();
   log.info("Cron scheduler started", { jobs: scheduler.listJobs().length });
   return scheduler;
-}
-
-async function startApiServer(cronScheduler: CronScheduler, gateway: Gateway): Promise<ServerType> {
-  const port = getApiPort();
-  const api = createApi({ cronScheduler, gateway });
-  return new Promise<ServerType>((resolve) => {
-    const s = serve({ fetch: api.fetch, port, hostname: "127.0.0.1" }, () => {
-      log.info("API server listening", { url: `http://127.0.0.1:${port}` });
-      resolve(s);
-    });
-  });
 }

--- a/src/extensions/channels/loader.test.ts
+++ b/src/extensions/channels/loader.test.ts
@@ -1,12 +1,11 @@
-// src/extensions/channels/loader.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Gateway } from "../../gateway/index.js";
 import type { Channel } from "../../channels/types.js";
-import { startChannels } from "./loader.js";
+import { ChannelManager } from "./loader.js";
 
 const fakeGateway = {} as Gateway;
 
-describe("startChannels", () => {
+describe("ChannelManager", () => {
   beforeEach(() => {
     vi.resetModules();
   });
@@ -16,19 +15,15 @@ describe("startChannels", () => {
   });
 
   it("loads no adapters when channels.discord config is absent", async () => {
-    const result = await startChannels({
-      gateway: fakeGateway,
-      config: {},
-    });
-    await expect(result.stop()).resolves.toBeUndefined();
+    const manager = new ChannelManager({});
+    await manager.start({ gateway: fakeGateway });
+    await expect(manager.stop()).resolves.toBeUndefined();
   });
 
   it("loads the discord adapter when channels.discord is configured (no-accounts no-op)", async () => {
-    const result = await startChannels({
-      gateway: fakeGateway,
-      config: { channels: { discord: { token: "x" } } },
-    });
-    await expect(result.stop()).resolves.toBeUndefined();
+    const manager = new ChannelManager({ channels: { discord: { token: "x" } } });
+    await manager.start({ gateway: fakeGateway });
+    await expect(manager.stop()).resolves.toBeUndefined();
   });
 
   it("starts the discord adapter when the import succeeds", async () => {
@@ -39,19 +34,17 @@ describe("startChannels", () => {
 
     vi.doMock("../../channels/discord/index.js", () => ({ createDiscordChannel }));
 
-    const { startChannels: load } = await import("./loader.js");
+    const { ChannelManager: CM } = await import("./loader.js");
 
     const discordCfg = { token: "abc" };
-    const result = await load({
-      gateway: fakeGateway,
-      config: { channels: { discord: discordCfg } },
-    });
+    const manager = new CM({ channels: { discord: discordCfg } });
+    await manager.start({ gateway: fakeGateway });
 
     expect(createDiscordChannel).toHaveBeenCalledWith(discordCfg);
     expect(start).toHaveBeenCalledTimes(1);
     expect(start.mock.calls[0]![0]).toMatchObject({ gateway: fakeGateway });
 
-    await result.stop();
+    await manager.stop();
     expect(stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/extensions/channels/loader.ts
+++ b/src/extensions/channels/loader.ts
@@ -1,8 +1,12 @@
 import type { Channel, ChannelDeps } from "../../channels/types.js";
 import { createDiscordChannel } from "../../channels/discord/index.js";
+import { createLogger } from "../../logging/logger.js";
+
+const log = createLogger("channel-manager");
 
 export class ChannelManager {
   private channels: Channel[] = [];
+  private running = false;
   private readonly config: { channels?: Record<string, unknown> };
 
   constructor(config: { channels?: Record<string, unknown> }) {
@@ -10,14 +14,26 @@ export class ChannelManager {
   }
 
   async start(deps: ChannelDeps): Promise<void> {
+    if (this.running) return;
+
     if (this.config.channels?.discord) {
       this.channels.push(createDiscordChannel(this.config.channels.discord));
     }
 
     await Promise.all(this.channels.map((c) => c.start(deps)));
+    this.running = true;
   }
 
   async stop(): Promise<void> {
-    await Promise.all(this.channels.map((c) => c.stop()));
+    if (!this.running) return;
+
+    await Promise.allSettled(this.channels.map(async (c) => {
+      try {
+        await c.stop();
+      } catch (err) {
+        log.warn("Channel stop failed", { error: err });
+      }
+    }));
+    this.running = false;
   }
 }

--- a/src/extensions/channels/loader.ts
+++ b/src/extensions/channels/loader.ts
@@ -27,7 +27,7 @@ export class ChannelManager {
   async stop(): Promise<void> {
     if (!this.running) return;
 
-    await Promise.allSettled(this.channels.map(async (c) => {
+    await Promise.all(this.channels.map(async (c) => {
       try {
         await c.stop();
       } catch (err) {

--- a/src/extensions/channels/loader.ts
+++ b/src/extensions/channels/loader.ts
@@ -1,26 +1,23 @@
 import type { Channel, ChannelDeps } from "../../channels/types.js";
 import { createDiscordChannel } from "../../channels/discord/index.js";
 
-export interface StartChannelsResult {
-  stop(): Promise<void>;
-}
+export class ChannelManager {
+  private channels: Channel[] = [];
+  private readonly config: { channels?: Record<string, unknown> };
 
-export interface StartChannelsDeps extends ChannelDeps {
-  config: { channels?: Record<string, unknown> };
-}
-
-export async function startChannels(deps: StartChannelsDeps): Promise<StartChannelsResult> {
-  const channels: Channel[] = [];
-
-  if (deps.config.channels?.discord) {
-    channels.push(createDiscordChannel(deps.config.channels.discord));
+  constructor(config: { channels?: Record<string, unknown> }) {
+    this.config = config;
   }
 
-  await Promise.all(channels.map((c) => c.start(deps)));
+  async start(deps: ChannelDeps): Promise<void> {
+    if (this.config.channels?.discord) {
+      this.channels.push(createDiscordChannel(this.config.channels.discord));
+    }
 
-  return {
-    async stop() {
-      await Promise.all(channels.map((c) => c.stop()));
-    },
-  };
+    await Promise.all(this.channels.map((c) => c.start(deps)));
+  }
+
+  async stop(): Promise<void> {
+    await Promise.all(this.channels.map((c) => c.stop()));
+  }
 }

--- a/src/http/api-server.ts
+++ b/src/http/api-server.ts
@@ -14,6 +14,7 @@ export interface ApiServerDeps {
 
 export class ApiServer {
   private server: ServerType | undefined;
+  private running = false;
   private readonly deps: ApiServerDeps;
   private readonly port: number;
 
@@ -23,22 +24,28 @@ export class ApiServer {
   }
 
   async start(): Promise<void> {
+    if (this.running) return;
+
     const api = createApi(this.deps);
     return new Promise<void>((resolve) => {
       this.server = serve({ fetch: api.fetch, port: this.port, hostname: "127.0.0.1" }, () => {
         log.info("API server listening", { url: `http://127.0.0.1:${this.port}` });
+        this.running = true;
         resolve();
       });
     });
   }
 
   async stop(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      if (!this.server) {
+    if (!this.running) return;
+
+    return new Promise<void>((resolve) => {
+      this.server!.close((err) => {
+        if (err) log.warn("API server close error", { error: err });
+        this.server = undefined;
+        this.running = false;
         resolve();
-        return;
-      }
-      this.server.close((err) => (err ? reject(err) : resolve()));
+      });
     });
   }
 }

--- a/src/http/api-server.ts
+++ b/src/http/api-server.ts
@@ -1,0 +1,44 @@
+import { serve, type ServerType } from "@hono/node-server";
+import type { CronScheduler } from "../automation/cron-job.js";
+import type { Gateway } from "../gateway/index.js";
+import { createApi } from "./server.js";
+import { getApiPort } from "../utils/api-client.js";
+import { createLogger } from "../logging/logger.js";
+
+const log = createLogger("api-server");
+
+export interface ApiServerDeps {
+  cronScheduler: CronScheduler;
+  gateway: Gateway;
+}
+
+export class ApiServer {
+  private server: ServerType | undefined;
+  private readonly deps: ApiServerDeps;
+  private readonly port: number;
+
+  constructor(deps: ApiServerDeps) {
+    this.deps = deps;
+    this.port = getApiPort();
+  }
+
+  async start(): Promise<void> {
+    const api = createApi(this.deps);
+    return new Promise<void>((resolve) => {
+      this.server = serve({ fetch: api.fetch, port: this.port, hostname: "127.0.0.1" }, () => {
+        log.info("API server listening", { url: `http://127.0.0.1:${this.port}` });
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Replace `startChannels()` factory function with `ChannelManager` class (`new` → `.start()` → `.stop()`)
- Extract `startApiServer()` helper into `ApiServer` class in `src/http/api-server.ts`
- Update `app.ts` to use both new classes, making shutdown uniform (`await x.stop()` for all components)

Closes #844

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 508/508 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)