### PR TITLE
feat(tools): add message_send tool for Discord channels

### DIFF
--- a/src/agent/pi/session-factory.ts
+++ b/src/agent/pi/session-factory.ts
@@ -135,6 +135,7 @@ export async function createPiSession(
     runtime: deps.runtime,
     ...(agent.spawnableAgentIds ? { spawnableAgentIds: agent.spawnableAgentIds } : {}),
     ...(agent.channelContext ? { channelContext: agent.channelContext } : {}),
+    ...(agent.config.toolSettings?.message?.allowedChannels ? { allowedChannels: agent.config.toolSettings.message.allowedChannels } : {}),
     ...(agent.config.sandbox ? { agentSandboxConfig: agent.config.sandbox } : {}),
     ...(deps.sandboxExecutor ? { sandboxExecutor: deps.sandboxExecutor } : {}),
   });

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -4,6 +4,7 @@ import { HostExecutor, type Executor, type SandboxExecutor } from "../middleware
 import { type SandboxConfig } from "../middleware/sandbox-config.js";
 import { createWebFetchTool } from "./web.js";
 import { createReactTools } from "./react.js";
+import { createMessageTools } from "./message.js";
 import type { LazyChannelContext } from "../../channels/types.js";
 import { createExecTools } from "./exec.js";
 import type { AgentRuntime } from "../runtime.js";
@@ -20,6 +21,7 @@ export interface CreateAgentToolsOptions {
   runtime: AgentRuntime;
   spawnableAgentIds?: readonly string[];
   channelContext?: LazyChannelContext;
+  allowedChannels?: string[];
   agentSandboxConfig?: SandboxConfig;
   /** Required when agentSandboxConfig.enabled — provided by AgentRuntime. */
   sandboxExecutor?: SandboxExecutor;
@@ -58,6 +60,7 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
   ];
   if (opts.channelContext) {
     tools.push(...createReactTools(opts.channelContext));
+    tools.push(...createMessageTools(opts.channelContext, opts.allowedChannels));
   }
   return tools;
 }

--- a/src/agent/tools/message.test.ts
+++ b/src/agent/tools/message.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { createMessageSendTool } from "./message.js";
+import type { ChannelContext, ChannelActions } from "../../channels/types.js";
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+
+function mockContext(actions?: ChannelActions): ChannelContext {
+  return { getChannelActions: () => actions };
+}
+
+async function callTool(tool: AgentTool, args: unknown): Promise<unknown> {
+  const result: AgentToolResult<unknown> = await tool.execute("test-call", args as never);
+  const block = result.content.find((c) => c.type === "text") as { text: string } | undefined;
+  return JSON.parse(block?.text ?? "{}");
+}
+
+describe("message_send tool", () => {
+  it("sends a message and returns the message id", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ id: "msg-123" });
+    const tool = createMessageSendTool(mockContext({ sendMessage }));
+    const result = await callTool(tool, { channel_id: "ch-1", content: "hello" });
+    expect(result).toEqual({ success: true, messageId: "msg-123" });
+    expect(sendMessage).toHaveBeenCalledWith("ch-1", "hello");
+  });
+
+  it("rejects channels not in the allowlist", async () => {
+    const sendMessage = vi.fn();
+    const tool = createMessageSendTool(mockContext({ sendMessage }), ["ch-allowed"]);
+    const result = await callTool(tool, { channel_id: "ch-other", content: "hello" });
+    expect(result).toEqual({ error: "Channel ch-other is not in the allowed channels list" });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("allows channels in the allowlist", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ id: "msg-456" });
+    const tool = createMessageSendTool(mockContext({ sendMessage }), ["ch-allowed"]);
+    const result = await callTool(tool, { channel_id: "ch-allowed", content: "hi" });
+    expect(result).toEqual({ success: true, messageId: "msg-456" });
+  });
+
+  it("returns error when channel actions are unavailable", async () => {
+    const tool = createMessageSendTool(mockContext(undefined));
+    const result = await callTool(tool, { channel_id: "ch-1", content: "hello" });
+    expect(result).toEqual({ error: "Channel not available" });
+  });
+
+  it("returns error when sendMessage is not supported", async () => {
+    const tool = createMessageSendTool(mockContext({}));
+    const result = await callTool(tool, { channel_id: "ch-1", content: "hello" });
+    expect(result).toEqual({ error: "Channel does not support sending messages" });
+  });
+
+  it("returns error for empty channel_id", async () => {
+    const tool = createMessageSendTool(mockContext({ sendMessage: vi.fn() }));
+    const result = await callTool(tool, { channel_id: "", content: "hello" });
+    expect(result).toEqual({ error: "channel_id must not be empty" });
+  });
+
+  it("returns error for empty content", async () => {
+    const tool = createMessageSendTool(mockContext({ sendMessage: vi.fn() }));
+    const result = await callTool(tool, { channel_id: "ch-1", content: "" });
+    expect(result).toEqual({ error: "content must not be empty" });
+  });
+
+  it("no allowlist means all channels are allowed", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ id: "msg-789" });
+    const tool = createMessageSendTool(mockContext({ sendMessage }));
+    const result = await callTool(tool, { channel_id: "any-channel", content: "hi" });
+    expect(result).toEqual({ success: true, messageId: "msg-789" });
+  });
+});

--- a/src/agent/tools/message.ts
+++ b/src/agent/tools/message.ts
@@ -1,0 +1,47 @@
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type } from "typebox";
+import type { ChannelContext } from "../../channels/types.js";
+
+function jsonResult(value: unknown): AgentToolResult<undefined> {
+  return { content: [{ type: "text", text: JSON.stringify(value) }], details: undefined };
+}
+
+const messageSendSchema = Type.Object({
+  channel_id: Type.String({ description: "ID of the channel to send the message to" }),
+  content: Type.String({ description: "Message content to send" }),
+});
+
+export function createMessageSendTool(
+  ctx: ChannelContext,
+  allowedChannels?: string[],
+): AgentTool<typeof messageSendSchema> {
+  return {
+    name: "message_send",
+    label: "message_send",
+    description:
+      "Send a message to a specific channel by its ID. " +
+      "Use this to post results, notifications, or updates to a channel.",
+    parameters: messageSendSchema,
+    execute: async (_id, { channel_id, content }) => {
+      if (!channel_id || !channel_id.trim()) return jsonResult({ error: "channel_id must not be empty" });
+      if (!content || !content.trim()) return jsonResult({ error: "content must not be empty" });
+      if (allowedChannels && allowedChannels.length > 0 && !allowedChannels.includes(channel_id)) {
+        return jsonResult({ error: `Channel ${channel_id} is not in the allowed channels list` });
+      }
+      const actions = ctx.getChannelActions();
+      if (!actions) return jsonResult({ error: "Channel not available" });
+      if (!actions.sendMessage) return jsonResult({ error: "Channel does not support sending messages" });
+      try {
+        const result = await actions.sendMessage(channel_id, content);
+        return jsonResult({ success: true, messageId: result.id });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult({ error: message });
+      }
+    },
+  };
+}
+
+export function createMessageTools(ctx: ChannelContext, allowedChannels?: string[]): AgentTool[] {
+  return [createMessageSendTool(ctx, allowedChannels)];
+}

--- a/src/agent/tools/types.ts
+++ b/src/agent/tools/types.ts
@@ -3,4 +3,5 @@
 export interface AgentToolSettings {
   allow?: string[];
   deny?: string[];
+  message?: { allowedChannels?: string[] };
 }

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -97,6 +97,15 @@ export function createDiscordChannel(
               if (!client) throw new Error(`No bot serves agent "${agentId}" in channel ${channelId}`);
               return react(client, messageId, emoji, channelId);
             },
+            sendMessage: async (channelId, content) => {
+              const client = clientForAgentInChannel(agentId, channelId, accounts, clients);
+              if (!client) throw new Error(`No bot serves agent "${agentId}" in channel ${channelId}`);
+              const ch = (await client.channels.fetch(channelId)) as
+                | { send?: (c: string) => Promise<{ id: string }> }
+                | null;
+              if (!ch?.send) throw new Error(`Channel ${channelId} is not sendable`);
+              return ch.send(content);
+            },
           };
           ctx.setChannelActions(actions);
         }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -14,6 +14,7 @@ export interface ChannelDeps {
 /** Actions an agent tool can perform on the channel (via LazyChannelContext). */
 export interface ChannelActions {
   react?(messageId: string, emoji: string, channelId: string): Promise<void>;
+  sendMessage?(channelId: string, content: string): Promise<{ id: string }>;
 }
 
 export type ChannelsConfig = Record<string, unknown>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,7 @@ export interface AgentToolsConfigFile {
   allow?: string[];
   /** Always blocked. Wins over allow. */
   deny?: string[];
+  message?: { allowedChannels?: string[] };
 }
 
 export interface SandboxDockerConfigFile {
@@ -97,6 +98,7 @@ export function resolveToolSettings(
   return {
     allow: agentTools?.allow ?? defaultTools?.allow,
     deny: agentTools?.deny ?? defaultTools?.deny,
+    message: agentTools?.message ?? defaultTools?.message,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `message_send` agent tool that lets agents post messages to specific Discord channels by ID
- Add per-agent `allowedChannels` config to restrict which channels the tool can target
- Wire `sendMessage` through the existing `ChannelActions` interface so the Discord adapter provides the implementation

Closes #846

## Config example
```yaml
agents:
  main:
    tools:
      message:
        allowedChannels:
          - "123456789"
```

## Test plan
- [x] Unit tests for message_send tool (8 tests: success, allowlist block/pass, empty params, missing actions)
- [x] `pnpm ci` passes (lint + typecheck + 516 tests)
- [ ] Manual: configure a cron job prompt instructing the agent to send results to a channel ID, verify message appears in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)