### PR TITLE
feat(app): add scheduled Discord notification output

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it, vi } from "vitest";
 import { sendScheduledResult } from "./app.js";
 
 describe("sendScheduledResult", () => {
+  it("prefers the error message over the normal response text", async () => {
+    const notify = vi.fn().mockResolvedValue(undefined);
+
+    await sendScheduledResult(
+      { responseText: "body", errorMessage: "boom" },
+      { type: "discord", channelId: "chan-1" },
+      { notify },
+    );
+
+    expect(notify).toHaveBeenCalledWith({ type: "discord", channelId: "chan-1" }, "⚠️ boom");
+  });
+
   it("sends the agent response to the configured Discord target", async () => {
     const notify = vi.fn().mockResolvedValue(undefined);
 
@@ -28,11 +40,35 @@ describe("sendScheduledResult", () => {
     );
   });
 
+  it("does nothing when there is no target", async () => {
+    const notify = vi.fn();
+
+    await sendScheduledResult(
+      { responseText: "hello", errorMessage: null },
+      undefined,
+      { notify },
+    );
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+
   it("does nothing when there is no response text", async () => {
     const notify = vi.fn();
 
-    await sendScheduledResult({ responseText: "", errorMessage: null }, undefined, { notify });
+    await sendScheduledResult({ responseText: "", errorMessage: null }, { type: "discord", channelId: "chan-1" }, { notify });
 
     expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("logs and swallows notify failures", async () => {
+    const notify = vi.fn().mockRejectedValue(new Error("bad channel"));
+
+    await expect(sendScheduledResult(
+      { responseText: "hello", errorMessage: null },
+      { type: "discord", channelId: "chan-1" },
+      { notify },
+    )).resolves.toBeUndefined();
+
+    expect(notify).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendScheduledResult } from "./app.js";
+
+describe("sendScheduledResult", () => {
+  it("sends the agent response to the configured Discord target", async () => {
+    const notify = vi.fn().mockResolvedValue(undefined);
+
+    await sendScheduledResult(
+      {
+        responseText: "hello from cron",
+        errorMessage: null,
+      },
+      {
+        type: "discord",
+        channelId: "chan-1",
+        threadId: "thr-1",
+      },
+      { notify },
+    );
+
+    expect(notify).toHaveBeenCalledWith(
+      {
+        type: "discord",
+        channelId: "chan-1",
+        threadId: "thr-1",
+      },
+      "hello from cron",
+    );
+  });
+
+  it("does nothing when there is no response text", async () => {
+    const notify = vi.fn();
+
+    await sendScheduledResult({ responseText: "", errorMessage: null }, undefined, { notify });
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,8 @@ import { AgentRuntime } from "./agent/runtime.js";
 import { discoverExtensionPaths } from "./extensions/pi/loader.js";
 import { startChannels } from "./extensions/channels/loader.js";
 import { createGateway, type Gateway } from "./gateway/index.js";
+import type { NotificationTargetConfig } from "./automation/types.js";
+import type { NotificationTarget } from "./channels/types.js";
 
 const log = createLogger("app");
 
@@ -46,9 +48,9 @@ export async function start(opts: AppOptions): Promise<App> {
   const agentRuntime = createAgentRuntime(config);
   const { agentWorkspaces, channelContexts } = await registerAgents(config, agentRuntime, sessionStoreManager);
   const gateway = createGateway({ agentRuntime, sessionStoreManager });
-  const heartbeatManagers = startHeartbeats(config, agentWorkspaces, gateway);
-  const cronScheduler = startCron(config, agentRuntime, gateway);
   const channels = await startChannels({ gateway, config, channelContexts });
+  const heartbeatManagers = startHeartbeats(config, agentWorkspaces, gateway, channels);
+  const cronScheduler = startCron(config, agentRuntime, gateway, channels);
   const apiServer = await startApiServer(cronScheduler, gateway);
 
   const stop = async () => {
@@ -120,6 +122,7 @@ function startHeartbeats(
   config: IsotopesConfigFile,
   agentWorkspaces: Map<string, string>,
   gateway: Gateway,
+  channels: { notify?: (target: NotificationTarget, content: string) => Promise<void> },
 ): HeartbeatManager[] {
   const managers: HeartbeatManager[] = [];
 
@@ -139,6 +142,7 @@ function startHeartbeats(
           content: prompt,
           source: "heartbeat",
         });
+        await sendScheduledResult(result, resolveNotificationTarget(agentFile.heartbeat?.notify), channels);
         return result.responseText;
       },
     });
@@ -155,6 +159,7 @@ function startCron(
   config: IsotopesConfigFile,
   agentRuntime: AgentRuntime,
   gateway: Gateway,
+  channels: { notify?: (target: NotificationTarget, content: string) => Promise<void> },
 ): CronScheduler {
   const scheduler = new CronScheduler(async (job) => {
     if (!agentRuntime.getAgent(job.agentId)) {
@@ -165,12 +170,13 @@ function startCron(
     const sessionKey = `cron:${job.agentId}:${job.name}`;
 
     try {
-      await gateway.dispatchAndWait({
+      const result = await gateway.dispatchAndWait({
         agentId: job.agentId,
         sessionKey,
         content: prompt,
         source: "cron",
       });
+      await sendScheduledResult(result, resolveNotificationTarget(job.notify), channels);
     } catch { /* ignore */ }
   });
 
@@ -183,6 +189,7 @@ function startCron(
         agentId: agentFile.id,
         action: { type: "prompt", prompt: task.prompt },
         enabled: task.enabled ?? true,
+        notify: task.notify,
       });
     }
   }
@@ -195,6 +202,7 @@ function startCron(
         agentId: task.agentId,
         action: task.action,
         enabled: task.enabled ?? true,
+        notify: task.notify,
       });
     }
   }
@@ -204,7 +212,32 @@ function startCron(
   return scheduler;
 }
 
-async function startApiServer(cronScheduler: CronScheduler, gateway: Gateway): Promise<ServerType> {
+export async function sendScheduledResult(
+  result: { responseText: string; errorMessage: string | null },
+  target: NotificationTarget | undefined,
+  sink: { notify?: (target: NotificationTarget, content: string) => Promise<void> },
+): Promise<void> {
+  if (!target || !sink.notify) return;
+
+  const content = result.errorMessage?.trim() ? `⚠️ ${result.errorMessage.trim()}` : result.responseText.trim();
+  if (!content) return;
+
+  await sink.notify(target, content);
+}
+
+function resolveNotificationTarget(config?: NotificationTargetConfig): NotificationTarget | undefined {
+  if (!config || config.enabled === false) return undefined;
+  if (!config.channelId) return undefined;
+
+  return {
+    type: config.type ?? "discord",
+    accountId: config.accountId,
+    channelId: config.channelId,
+    threadId: config.threadId,
+  };
+}
+
+function startApiServer(cronScheduler: CronScheduler, gateway: Gateway): Promise<ServerType> {
   const port = getApiPort();
   const api = createApi({ cronScheduler, gateway });
   return new Promise<ServerType>((resolve) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -175,7 +175,9 @@ function startCron(
         source: "cron",
       });
       await sendScheduledResult(result, resolveNotificationTarget(job.notify), channels);
-    } catch { /* ignore */ }
+    } catch (err) {
+      log.warn("Cron run failed", { agentId: job.agentId, jobName: job.name, error: err });
+    }
   });
 
   for (const agentFile of config.agents) {
@@ -209,6 +211,7 @@ function startCron(
   log.info("Cron scheduler started", { jobs: scheduler.listJobs().length });
   return scheduler;
 }
+
 export async function sendScheduledResult(
   result: { responseText: string; errorMessage: string | null },
   target: NotificationTarget | undefined,
@@ -219,7 +222,11 @@ export async function sendScheduledResult(
   const content = result.errorMessage?.trim() ? `⚠️ ${result.errorMessage.trim()}` : result.responseText.trim();
   if (!content) return;
 
-  await sink.notify(target, content);
+  try {
+    await sink.notify(target, content);
+  } catch (err) {
+    log.warn("Scheduled notification failed", { target, error: err });
+  }
 }
 
 function resolveNotificationTarget(config?: NotificationTargetConfig): NotificationTarget | undefined {

--- a/src/automation/cron-job.ts
+++ b/src/automation/cron-job.ts
@@ -1,6 +1,6 @@
 import { Cron } from "croner";
 import { randomUUID } from "node:crypto";
-import type { CronAction } from "./types.js";
+import type { CronAction, NotificationTargetConfig } from "./types.js";
 
 export type { CronAction };
 
@@ -13,6 +13,7 @@ export interface CronJob {
   agentId: string;
   action: CronAction;
   enabled: boolean;
+  notify?: NotificationTargetConfig;
   lastRun?: Date;
   nextRun?: Date;
   createdAt: Date;

--- a/src/automation/types.ts
+++ b/src/automation/types.ts
@@ -1,5 +1,13 @@
 // src/automation/types.ts — Cron + heartbeat config types
 
+export interface NotificationTargetConfig {
+  enabled?: boolean;
+  type?: "discord";
+  accountId?: string;
+  channelId?: string;
+  threadId?: string;
+}
+
 /** Action to perform when a cron job triggers. */
 export type CronAction =
   | { type: "message"; content: string }

--- a/src/channels/discord/index.test.ts
+++ b/src/channels/discord/index.test.ts
@@ -108,6 +108,23 @@ describe("createDiscordChannel — lifecycle", () => {
     await adapter.stop();
   });
 
+  it("uses the configured threadId when sending scheduled notifications", async () => {
+    const client = makeFakeClient("bot-A");
+    const sendMock = vi.fn().mockResolvedValue({ id: "out-1" });
+    client.channels.fetch = vi.fn().mockResolvedValue({ send: sendMock });
+
+    const adapter = createDiscordChannel(
+      { accounts: { acct1: { token: "tok", defaultAgentId: "main", groupAccess: { policy: "open" } } } },
+      { clientFactory: () => client },
+    );
+
+    await adapter.start({ gateway: makeGateway() });
+    await adapter.notify!({ type: "discord", accountId: "acct1", channelId: "main-channel", threadId: "thread-1" }, "hello world");
+
+    expect(client.channels.fetch).toHaveBeenCalledWith("thread-1");
+    expect(sendMock).toHaveBeenCalledWith("hello world");
+  });
+
   it("constructs and logs in one client per account", async () => {
     const a = makeFakeClient("bot-A");
     const b = makeFakeClient("bot-B");
@@ -180,7 +197,7 @@ describe("createDiscordChannel — lifecycle", () => {
     const ctxB = new LazyChannelContext();
     await adapter.start({
       gateway: makeGateway(),
-      
+
       channelContexts: new Map([["agentA", ctxA], ["agentB", ctxB]]),
     });
     await ctxA.getChannelActions()!.react!("msg-1", "👀", "ch-1");

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -12,6 +12,7 @@ import { DedupeCache } from "./dedupe.js";
 import { ChannelHistoryBuffer, formatHistory } from "./channel-history.js";
 import { handleInbound, passesAllowlist, handleStopCommand } from "./inbound.js";
 import { chunkDiscordMessage, createDiscordSubscriber } from "./outbound.js";
+import { fetchSendableChannel } from "./sendable.js";
 import { react } from "./react.js";
 import { resolveToken } from "./config.js";
 import { extractDiscordMetadata, formatInboundMeta } from "./message-metadata.js";
@@ -69,14 +70,15 @@ export function createDiscordChannel(
   async function notify(target: NotificationTarget, content: string): Promise<void> {
     if (target.type !== "discord") throw new Error(`Unsupported notification target: ${target.type}`);
 
-    const client = target.accountId ? clients.get(target.accountId) : clients.values().next().value;
-    if (!client) throw new Error("No Discord client is available for outbound notifications");
-
-    const channel = await client.channels.fetch(target.channelId);
-    const sendable = channel as { send?: (message: string) => Promise<unknown> } | null | undefined;
-    if (!sendable || typeof sendable.send !== "function") {
-      throw new Error(`Discord channel ${target.channelId} is not sendable`);
+    const client = target.accountId
+      ? clients.get(target.accountId)
+      : undefined;
+    if (!client) {
+      throw new Error("No Discord client matches the requested accountId for outbound notifications");
     }
+
+    const targetChannelId = target.threadId ?? target.channelId;
+    const sendable = await fetchSendableChannel(client, targetChannelId);
 
     const chunks = chunkDiscordMessage(content);
     for (const chunk of chunks) {
@@ -85,6 +87,7 @@ export function createDiscordChannel(
   }
 
   return {
+    kind: "discord",
     async start(deps: ChannelDeps) {
       const { gateway } = deps;
       const accountIds = Object.keys(accounts);

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -5,13 +5,13 @@ import {
   type Message as DiscordMessage,
   type SendableChannels,
 } from "discord.js";
-import type { Channel, ChannelActions, ChannelDeps } from "../types.js";
+import type { Channel, ChannelActions, ChannelDeps, NotificationTarget } from "../types.js";
 import type { Gateway } from "../../gateway/index.js";
 
 import { DedupeCache } from "./dedupe.js";
 import { ChannelHistoryBuffer, formatHistory } from "./channel-history.js";
 import { handleInbound, passesAllowlist, handleStopCommand } from "./inbound.js";
-import { createDiscordSubscriber } from "./outbound.js";
+import { chunkDiscordMessage, createDiscordSubscriber } from "./outbound.js";
 import { react } from "./react.js";
 import { resolveToken } from "./config.js";
 import { extractDiscordMetadata, formatInboundMeta } from "./message-metadata.js";
@@ -66,6 +66,24 @@ export function createDiscordChannel(
   // to route /stop posted in a sub-run thread to the right cancel target.
   const a2aThreads = new Map<string, string>();
 
+  async function notify(target: NotificationTarget, content: string): Promise<void> {
+    if (target.type !== "discord") throw new Error(`Unsupported notification target: ${target.type}`);
+
+    const client = target.accountId ? clients.get(target.accountId) : clients.values().next().value;
+    if (!client) throw new Error("No Discord client is available for outbound notifications");
+
+    const channel = await client.channels.fetch(target.channelId);
+    const sendable = channel as { send?: (message: string) => Promise<unknown> } | null | undefined;
+    if (!sendable || typeof sendable.send !== "function") {
+      throw new Error(`Discord channel ${target.channelId} is not sendable`);
+    }
+
+    const chunks = chunkDiscordMessage(content);
+    for (const chunk of chunks) {
+      await sendable.send(chunk);
+    }
+  }
+
   return {
     async start(deps: ChannelDeps) {
       const { gateway } = deps;
@@ -117,6 +135,7 @@ export function createDiscordChannel(
       for (const h of histories.values()) h.clear();
       histories.clear();
     },
+    notify,
   };
 }
 

--- a/src/channels/discord/sendable.ts
+++ b/src/channels/discord/sendable.ts
@@ -1,0 +1,21 @@
+export interface SendableDiscordClient {
+  channels: { fetch(id: string): Promise<unknown> };
+}
+
+export interface SendableDiscordChannel {
+  send(message: string): Promise<unknown>;
+}
+
+export async function fetchSendableChannel(
+  client: SendableDiscordClient,
+  channelId: string,
+): Promise<SendableDiscordChannel> {
+  const channel = await client.channels.fetch(channelId);
+  const sendable = channel as { send?: unknown } | null | undefined;
+
+  if (!sendable || typeof sendable.send !== "function") {
+    throw new Error(`Discord channel ${channelId} is not sendable`);
+  }
+
+  return sendable as SendableDiscordChannel;
+}

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -1,8 +1,16 @@
 import type { Gateway } from "../gateway/index.js";
 
+export interface NotificationTarget {
+  type: "discord";
+  accountId?: string;
+  channelId: string;
+  threadId?: string;
+}
+
 export interface Channel {
   start(deps: ChannelDeps): Promise<void>;
   stop(): Promise<void>;
+  notify?(target: NotificationTarget, content: string): Promise<void>;
 }
 
 export interface ChannelDeps {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -8,6 +8,7 @@ export interface NotificationTarget {
 }
 
 export interface Channel {
+  kind?: string;
   start(deps: ChannelDeps): Promise<void>;
   stop(): Promise<void>;
   notify?(target: NotificationTarget, content: string): Promise<void>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import YAML from "yaml";
 import type { ProviderType, AgentConfig } from "./agent/types.js";
 import type { AgentToolSettings } from "./agent/tools/types.js";
 import type { ChannelsConfig } from "./channels/types.js";
-import type { CronAction } from "./automation/types.js";
+import type { CronAction, NotificationTargetConfig } from "./automation/types.js";
 import { resolveSandboxConfig, type SandboxConfig } from "./agent/middleware/sandbox-config.js";
 
 export interface ProviderConfigFile {
@@ -18,6 +18,7 @@ export interface ProviderConfigFile {
 export interface HeartbeatConfigFile {
   enabled?: boolean;
   intervalSeconds?: number;
+  notify?: NotificationTargetConfig;
 }
 
 export interface CronTaskConfigFile {
@@ -25,6 +26,7 @@ export interface CronTaskConfigFile {
   schedule: string;
   prompt: string;
   enabled?: boolean;
+  notify?: NotificationTargetConfig;
 }
 
 export interface AgentConfigFile {
@@ -78,6 +80,7 @@ export interface CronJobConfigFile {
   agentId: string;
   action: CronAction;
   enabled?: boolean;
+  notify?: NotificationTargetConfig;
 }
 
 export interface IsotopesConfigFile {

--- a/src/extensions/channels/loader.test.ts
+++ b/src/extensions/channels/loader.test.ts
@@ -26,6 +26,21 @@ describe("ChannelManager", () => {
     await expect(manager.stop()).resolves.toBeUndefined();
   });
 
+  it("routes notify only to matching channel kinds", async () => {
+    const discordNotify = vi.fn().mockResolvedValue(undefined);
+    const feishuNotify = vi.fn().mockResolvedValue(undefined);
+    const manager = new ChannelManager({});
+    (manager as unknown as { channels: Array<{ kind?: string; notify?: typeof discordNotify }> }).channels = [
+      { kind: "discord", notify: discordNotify },
+      { kind: "feishu", notify: feishuNotify },
+    ];
+
+    await manager.notify({ type: "discord", channelId: "chan-1" }, "hello");
+
+    expect(discordNotify).toHaveBeenCalledWith({ type: "discord", channelId: "chan-1" }, "hello");
+    expect(feishuNotify).not.toHaveBeenCalled();
+  });
+
   it("starts the discord adapter when the import succeeds", async () => {
     const start = vi.fn<Channel["start"]>(async () => {});
     const stop = vi.fn<Channel["stop"]>(async () => {});

--- a/src/extensions/channels/loader.ts
+++ b/src/extensions/channels/loader.ts
@@ -38,6 +38,11 @@ export class ChannelManager {
   }
 
   async notify(target: NotificationTarget, content: string): Promise<void> {
-    await Promise.all(this.channels.map((c) => c.notify?.(target, content)));
+    const candidates = this.channels.filter((c) => (c.kind ?? "") === target.type);
+    if (candidates.length === 0) {
+      throw new Error(`No channel adapter is registered for target type "${target.type}"`);
+    }
+
+    await Promise.all(candidates.map((c) => c.notify?.(target, content)));
   }
 }

--- a/src/extensions/channels/loader.ts
+++ b/src/extensions/channels/loader.ts
@@ -3,6 +3,7 @@ import { createDiscordChannel } from "../../channels/discord/index.js";
 
 export interface StartChannelsResult {
   stop(): Promise<void>;
+  notify(target: { type: "discord"; accountId?: string; channelId: string; threadId?: string }, content: string): Promise<void>;
 }
 
 export interface StartChannelsDeps extends ChannelDeps {
@@ -21,6 +22,9 @@ export async function startChannels(deps: StartChannelsDeps): Promise<StartChann
   return {
     async stop() {
       await Promise.all(channels.map((c) => c.stop()));
+    },
+    async notify(target, content) {
+      await Promise.all(channels.map((c) => c.notify?.(target, content)));
     },
   };
 }


### PR DESCRIPTION
## Summary
- add configurable notify targets for cron/heartbeat results
- send scheduled output to Discord via channel adapter
- add regression tests for scheduled notification routing

## Testing
- pnpm typecheck
- pnpm lint
- pnpm vitest run src/app.test.ts src/channels/discord/index.test.ts src/channels/discord/outbound.test.ts