### PR TITLE
refactor(tools): delegate exec to pi's bash tool

### DIFF
--- a/src/agent/tools/exec.test.ts
+++ b/src/agent/tools/exec.test.ts
@@ -1,106 +1,39 @@
 import { describe, it, expect, vi } from "vitest";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
-
-async function callTool(tool: AgentTool, args: unknown): Promise<string> {
-  const result: AgentToolResult<unknown> = await tool.execute("test-call", args as never);
-  const block = result.content.find((c) => c.type === "text") as { text: string } | undefined;
-  return block?.text ?? "";
-}
-
-vi.mock("../logging/logger.js", () => ({
-  createLogger: () => ({
-    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
-  }),
-}));
-
 import { createExecTool, createExecTools } from "./exec.js";
 import { HostExecutor } from "../middleware/executor.js";
 import type { Executor } from "../middleware/executor.js";
 
-function makeMockExecutor(overrides?: Partial<Executor>): Executor {
+function makeMockExecutor(): Executor {
   return {
-    execute: vi.fn(async () => ({
-      exitCode: 0,
-      stdout: Buffer.from("mocked-out"),
-      stderr: Buffer.alloc(0),
-    })),
+    execute: vi.fn(async () => ({ exitCode: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) })),
     buildExecArgv: vi.fn(async (argv: string[]) => argv),
-    ...overrides,
   };
 }
 
 describe("createExecTool", () => {
-  it("returns a tool with correct schema", () => {
+  it("returns pi's bash tool", () => {
     const tool = createExecTool({ executor: makeMockExecutor() });
-    expect(tool.name).toBe("exec");
+    expect(tool.name).toBe("bash");
     expect(tool.parameters).toBeDefined();
   });
 
-  it("wraps command in sh -c and delegates to executor.execute", async () => {
-    const executor = makeMockExecutor();
-    const tool = createExecTool({ cwd: "/ws", executor });
-    const result = JSON.parse(await callTool(tool, { command: "echo hi" }));
-
-    expect(executor.execute).toHaveBeenCalledWith(
-      ["sh", "-c", "echo hi"],
-      { workspacePath: "/ws", timeout: expect.any(Number) },
-    );
-    expect(result.stdout).toBe("mocked-out");
-    expect(result.exit_code).toBe(0);
+  it("runs a real host command end-to-end", async () => {
+    const tool = createExecTool({ executor: new HostExecutor() });
+    const result = await tool.execute("test-call", { command: "echo hello" } as never);
+    const block = result.content.find((c) => c.type === "text") as { text: string } | undefined;
+    expect(block?.text).toMatch(/hello/);
   });
 
-  it("returns error for empty command", async () => {
-    const tool = createExecTool({ executor: makeMockExecutor() });
-    const result = JSON.parse(await callTool(tool, { command: "" }));
-    expect(result.error).toContain("must not be empty");
-  });
-
-  it("returns timeout JSON when executor reports timed out", async () => {
-    const executor = makeMockExecutor({
-      execute: vi.fn(async () => { throw new Error("Sandbox execution timed out after 1000ms"); }),
-    });
-    const tool = createExecTool({ cwd: "/ws", executor });
-    const result = JSON.parse(await callTool(tool, { command: "sleep 9999", timeout: 1 }));
-    expect(result.exit_code).toBe(124);
-    expect(result.error).toMatch(/timed out/);
-  });
-
-  it("returns exec-error JSON when executor throws", async () => {
-    const executor = makeMockExecutor({
-      execute: vi.fn(async () => { throw new Error("docker daemon not running"); }),
-    });
-    const tool = createExecTool({ cwd: "/ws", executor });
-    const result = JSON.parse(await callTool(tool, { command: "ls" }));
-    expect(result.exit_code).toBe(1);
-    expect(result.stderr).toMatch(/exec error/);
+  it("rejects on non-zero exit (pi convention)", async () => {
+    const tool = createExecTool({ executor: new HostExecutor() });
+    await expect(tool.execute("test-call", { command: "exit 7" } as never))
+      .rejects.toThrow(/exited with code 7/);
   });
 });
 
 describe("createExecTools", () => {
-  it("returns just the exec tool", () => {
+  it("returns just the bash tool", () => {
     const tools = createExecTools({ executor: makeMockExecutor() });
-    expect(tools.map((t) => t.name)).toEqual(["exec"]);
-  });
-});
-
-describe("HostExecutor + createExecTool integration", () => {
-  it("runs a real command end-to-end", async () => {
-    const tool = createExecTool({ executor: new HostExecutor() });
-    const result = JSON.parse(await callTool(tool, { command: "echo hello" }));
-    expect(result.stdout.trim()).toBe("hello");
-    expect(result.exit_code).toBe(0);
-  });
-
-  it("captures stderr", async () => {
-    const tool = createExecTool({ executor: new HostExecutor() });
-    const result = JSON.parse(await callTool(tool, { command: "echo err >&2" }));
-    expect(result.stderr.trim()).toBe("err");
-    expect(result.exit_code).toBe(0);
-  });
-
-  it("reports non-zero exit code", async () => {
-    const tool = createExecTool({ executor: new HostExecutor() });
-    const result = JSON.parse(await callTool(tool, { command: "exit 42" }));
-    expect(result.exit_code).toBe(42);
+    expect(tools.map((t) => t.name)).toEqual(["bash"]);
   });
 });

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -1,72 +1,78 @@
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
-import { Type, type Static } from "typebox";
-import type { Executor } from "../middleware/executor.js";
-
-const DEFAULT_TIMEOUT_SEC = 1800;
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { createBashTool, createLocalBashOperations, type BashOperations } from "@mariozechner/pi-coding-agent";
+import { spawn } from "node:child_process";
+import type { Executor, SandboxExecutor } from "../middleware/executor.js";
 
 export interface ExecToolOptions {
-  /** Working directory (host or container). */
   cwd?: string;
-  /** Per-agent executor. Required. */
+  /** Used to detect sandboxed agents (and to build `docker exec` argv). */
   executor: Executor;
+  /** Required for sandbox agents — undefined means host mode. */
+  sandboxExecutor?: SandboxExecutor;
+  agentId?: string;
 }
 
-function jsonResult(value: unknown): AgentToolResult<undefined> {
-  return { content: [{ type: "text", text: JSON.stringify(value) }], details: undefined };
-}
-
-const execSchema = Type.Object({
-  command: Type.String({ description: "The shell command to execute" }),
-  timeout: Type.Optional(Type.Number({
-    description: "Timeout in seconds (default 1800 = 30 min). No upper limit — pass higher values for known-long tasks.",
-  })),
-});
-
-export function createExecTool(options: ExecToolOptions): AgentTool<typeof execSchema> {
+export function createExecTool(options: ExecToolOptions): AgentTool {
   const cwd = options.cwd ?? process.cwd();
-  const { executor } = options;
-
-  return {
-    name: "exec",
-    label: "exec",
-    description:
-      "Execute a shell command. Returns stdout, stderr, and exit_code. " +
-      "Default timeout: 30 min, no upper limit. " +
-      "For long-running commands, use shell backgrounding (`cmd > /tmp/log 2>&1 &`) and `kill <pid>` to manage them.",
-    parameters: execSchema,
-    execute: async (_id, params: Static<typeof execSchema>) => {
-      const { command, timeout: timeoutSec } = params;
-      if (!command || command.trim().length === 0) {
-        return jsonResult({ error: "Command must not be empty" });
-      }
-
-      const argv = ["sh", "-c", command];
-      const timeoutMs = (timeoutSec ?? DEFAULT_TIMEOUT_SEC) * 1000;
-
-      try {
-        const result = await executor.execute(argv, { workspacePath: cwd, timeout: timeoutMs });
-        return jsonResult({
-          stdout: result.stdout.toString("utf8"),
-          stderr: result.stderr.toString("utf8"),
-          exit_code: result.exitCode,
-        });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("timed out")) {
-          return jsonResult({
-            stdout: "", stderr: "", exit_code: 124,
-            error: `Command timed out after ${timeoutMs / 1000}s`,
-          });
-        }
-        return jsonResult({
-          stdout: "", stderr: `[exec error] ${msg}`, exit_code: 1,
-          error: `Exec failed: ${msg}`,
-        });
-      }
-    },
-  };
+  const operations = options.sandboxExecutor && options.agentId
+    ? createSandboxBashOperations(options.sandboxExecutor, options.agentId)
+    : createLocalBashOperations();
+  return createBashTool(cwd, { operations });
 }
 
 export function createExecTools(options: ExecToolOptions): AgentTool[] {
   return [createExecTool(options)];
+}
+
+/**
+ * Routes pi's bash tool through SandboxExecutor — the command runs inside the
+ * agent's docker container instead of the host. We rebuild `docker exec -i <ctr> sh -c <cmd>`
+ * via `buildExecArgv` so we still get a real ChildProcess for stream + abort + timeout.
+ */
+function createSandboxBashOperations(executor: SandboxExecutor, agentId: string): BashOperations {
+  return {
+    exec(command, cwd, { onData, signal, timeout, env }) {
+      return new Promise((resolve) => {
+        let settled = false;
+        const settle = (exitCode: number | null): void => {
+          if (settled) return;
+          settled = true;
+          if (timer) clearTimeout(timer);
+          resolve({ exitCode });
+        };
+
+        executor
+          .buildExecArgv(agentId, ["sh", "-c", command], { workspacePath: cwd })
+          .then((argv) => {
+            const child = spawn(argv[0], argv.slice(1), {
+              stdio: ["ignore", "pipe", "pipe"],
+              ...(env ? { env } : {}),
+            });
+            child.stdout?.on("data", onData);
+            child.stderr?.on("data", onData);
+            child.on("error", (err) => {
+              onData(Buffer.from(`[sandbox exec error] ${err.message}\n`));
+              settle(1);
+            });
+            child.on("close", (code) => settle(code));
+
+            signal?.addEventListener("abort", () => {
+              if (!child.killed) child.kill("SIGTERM");
+            });
+          })
+          .catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            onData(Buffer.from(`[sandbox setup error] ${msg}\n`));
+            settle(1);
+          });
+
+        const timer = timeout
+          ? setTimeout(() => {
+              onData(Buffer.from(`\n[command timed out after ${timeout}ms]\n`));
+              settle(124);
+            }, timeout)
+          : undefined;
+      });
+    },
+  };
 }

--- a/src/agent/tools/exec.ts
+++ b/src/agent/tools/exec.ts
@@ -1,21 +1,23 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { createBashTool, createLocalBashOperations, type BashOperations } from "@mariozechner/pi-coding-agent";
 import { spawn } from "node:child_process";
-import type { Executor, SandboxExecutor } from "../middleware/executor.js";
+import type { Executor } from "../middleware/executor.js";
 
 export interface ExecToolOptions {
   cwd?: string;
-  /** Used to detect sandboxed agents (and to build `docker exec` argv). */
   executor: Executor;
-  /** Required for sandbox agents — undefined means host mode. */
-  sandboxExecutor?: SandboxExecutor;
-  agentId?: string;
+  /**
+   * Sandbox mode: route pi's bash tool through `executor.buildExecArgv` + self-spawn
+   * so the command runs inside the agent's docker container.
+   * Host mode: use pi's `createLocalBashOperations` for cross-platform shell resolution.
+   */
+  isSandboxed?: boolean;
 }
 
 export function createExecTool(options: ExecToolOptions): AgentTool {
   const cwd = options.cwd ?? process.cwd();
-  const operations = options.sandboxExecutor && options.agentId
-    ? createSandboxBashOperations(options.sandboxExecutor, options.agentId)
+  const operations = options.isSandboxed
+    ? createSandboxBashOperations(options.executor)
     : createLocalBashOperations();
   return createBashTool(cwd, { operations });
 }
@@ -25,11 +27,11 @@ export function createExecTools(options: ExecToolOptions): AgentTool[] {
 }
 
 /**
- * Routes pi's bash tool through SandboxExecutor — the command runs inside the
- * agent's docker container instead of the host. We rebuild `docker exec -i <ctr> sh -c <cmd>`
- * via `buildExecArgv` so we still get a real ChildProcess for stream + abort + timeout.
+ * Adapt pi's BashOperations to any Executor — we ask the executor for the
+ * argv it would spawn (e.g. `docker exec -i <ctr> sh -c <cmd>`) and spawn it
+ * ourselves so we control stream / abort / timeout.
  */
-function createSandboxBashOperations(executor: SandboxExecutor, agentId: string): BashOperations {
+function createSandboxBashOperations(executor: Executor): BashOperations {
   return {
     exec(command, cwd, { onData, signal, timeout, env }) {
       return new Promise((resolve) => {
@@ -42,7 +44,7 @@ function createSandboxBashOperations(executor: SandboxExecutor, agentId: string)
         };
 
         executor
-          .buildExecArgv(agentId, ["sh", "-c", command], { workspacePath: cwd })
+          .buildExecArgv(["sh", "-c", command], { workspacePath: cwd })
           .then((argv) => {
             const child = spawn(argv[0], argv.slice(1), {
               stdio: ["ignore", "pipe", "pipe"],

--- a/src/agent/tools/index.test.ts
+++ b/src/agent/tools/index.test.ts
@@ -42,7 +42,7 @@ describe("createAgentTools", () => {
     runtime: new AgentRuntime(),
   });
 
-  it("registers fs tools + time + exec + spawn_agent by default", () => {
+  it("registers fs tools + time + bash + spawn_agent by default", () => {
     const tools = createAgentTools(baseOpts());
     const names = tools.map((t) => t.name);
     expect(names).toContain("read");
@@ -50,7 +50,7 @@ describe("createAgentTools", () => {
     expect(names).toContain("edit");
     expect(names).toContain("ls");
     expect(names).toContain("get_current_time");
-    expect(names).toContain("exec");
+    expect(names).toContain("bash");
     expect(names).toContain("spawn_agent");
   });
 

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -46,7 +46,11 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
   const tools: AgentTool[] = [
     ...createFsTools(opts.workspacePath, fs),
     createTimeTool(),
-    ...createExecTools({ cwd: opts.workspacePath, executor }),
+    ...createExecTools({
+      cwd: opts.workspacePath,
+      executor,
+      ...(isSandboxed ? { sandboxExecutor: opts.sandboxExecutor!, agentId: opts.agentId } : {}),
+    }),
     createWebFetchTool(executor),
     createSpawnAgentTool({
       runtime: opts.runtime,

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -46,11 +46,7 @@ export function createAgentTools(opts: CreateAgentToolsOptions): AgentTool[] {
   const tools: AgentTool[] = [
     ...createFsTools(opts.workspacePath, fs),
     createTimeTool(),
-    ...createExecTools({
-      cwd: opts.workspacePath,
-      executor,
-      ...(isSandboxed ? { sandboxExecutor: opts.sandboxExecutor!, agentId: opts.agentId } : {}),
-    }),
+    ...createExecTools({ cwd: opts.workspacePath, executor, isSandboxed }),
     createWebFetchTool(executor),
     createSpawnAgentTool({
       runtime: opts.runtime,

--- a/tests/e2e-smoke.test.ts
+++ b/tests/e2e-smoke.test.ts
@@ -71,18 +71,18 @@ describe("edit tool (SDK)", () => {
   });
 });
 
-describe("exec tool", () => {
+describe("bash tool", () => {
   it("runs a shell command and returns stdout", async () => {
     const tools = createExecTools({ cwd: tmpDir, executor: new HostExecutor() });
-    const result = JSON.parse(await callTool(findTool(tools, "exec"), { command: "echo hello" }));
-    expect(result.exit_code).toBe(0);
-    expect(result.stdout.trim()).toBe("hello");
+    const result = await callTool(findTool(tools, "bash"), { command: "echo hello" });
+    expect(result).toMatch(/hello/);
   });
 
   it("reports non-zero exit codes", async () => {
     const tools = createExecTools({ cwd: tmpDir, executor: new HostExecutor() });
-    const result = JSON.parse(await callTool(findTool(tools, "exec"), { command: "exit 42" }));
-    expect(result.exit_code).not.toBe(0);
+    await expect(
+      (async () => callTool(findTool(tools, "bash"), { command: "exit 42" }))(),
+    ).rejects.toThrow(/exited with code 42/);
   });
 });
 
@@ -115,7 +115,7 @@ describe("full tool wiring", () => {
     expect(names.has("write")).toBe(true);
     expect(names.has("edit")).toBe(true);
     expect(names.has("ls")).toBe(true);
-    expect(names.has("exec")).toBe(true);
+    expect(names.has("bash")).toBe(true);
     expect(names.has("web_fetch")).toBe(true);
     expect(names.has("get_current_time")).toBe(true);
 
@@ -123,7 +123,7 @@ describe("full tool wiring", () => {
     const readResult = await callTool(findTool(all, "read"), { path: "SOUL.md" });
     expect(readResult).toContain("# Test Agent");
 
-    const execResult = JSON.parse(await callTool(findTool(all, "exec"), { command: "echo smoke" }));
-    expect(execResult.stdout.trim()).toBe("smoke");
+    const execResult = await callTool(findTool(all, "bash"), { command: "echo smoke" });
+    expect(execResult).toMatch(/smoke/);
   });
 });


### PR DESCRIPTION
## Summary
- Replace hand-rolled exec tool with `createBashTool` from `@mariozechner/pi-coding-agent`
- Fixes Windows `spawn sh ENOENT` — pi's `getShellConfig()` finds Git Bash / bash.exe automatically
- Sandbox agents get a thin `BashOperations` adapter that routes through `SandboxExecutor.buildExecArgv()`, preserving docker isolation

## Behavior changes
- Tool name: `exec` → `bash`
- Result shape: pi's text format instead of `{stdout, stderr, exit_code}` JSON; non-zero exit rejects (agent loop converts to tool error)
- Output truncation, temp-file spill, abort/timeout handling are now pi's

## Test plan
- [x] `pnpm run ci` (lint + typecheck + 514 tests passing)
- [ ] Manual test on Windows agent (delete BOOTSTRAP.md path that originally surfaced the bug)
- [ ] Manual test on a sandboxed agent (verify docker exec still works end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)