### PR TITLE
feat(copilot): add CopilotRunner adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.9",
+    "@github/copilot-sdk": "1.0.0-beta.9",
     "@hono/node-server": "^2.0.2",
     "@mariozechner/pi-agent-core": "^0.70.6",
     "@mariozechner/pi-ai": "^0.70.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.1.9
         version: 0.1.77(zod@4.3.6)
+      '@github/copilot-sdk':
+        specifier: 1.0.0-beta.9
+        version: 1.0.0-beta.9
       '@hono/node-server':
         specifier: ^2.0.2
         version: 2.0.2(hono@4.12.18)
@@ -517,6 +520,62 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@github/copilot-darwin-arm64@1.0.56':
+    resolution: {integrity: sha512-vCittEfa/Qys86TxhI5rgxy8L8WTQoooIjEj8kZe7mq62TOOrFGnWJjqaR6mgljmPTxKRFmT6achUxKRVZil9g==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-darwin-x64@1.0.56':
+    resolution: {integrity: sha512-yO7OvFysG/98s9T8k5cEXzBz++mki7ufkH2S8/jqC7YIKhlj64rh+/vIBU5DQ9RLXbPKm6OjGjJn8iDWXzzuJQ==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-linux-arm64@1.0.56':
+    resolution: {integrity: sha512-ukOwSwFOqgpQQs5Nw3GAFRGIn6LqA8KfI6hD+tUeqoWkB0OlXxwQER7sKEfSQZu1vcNnW1+YIM/qT5W5RWdmhA==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-linux-x64@1.0.56':
+    resolution: {integrity: sha512-C84nduDAeHCTEfjs+mYfIjbBjGRx2huy8XZBu0ETAD08uUBuQpUHn2PYhaaHb1yKoG6LMceKt10PTrqNdOE9IQ==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-linuxmusl-arm64@1.0.56':
+    resolution: {integrity: sha512-EuDmGVl4fEk7Q+AVhkQkpiRlXpjGGQ5GzfBzMEOWgrvfdCLcT62p1uEaz+AT2UdkJiViruLyVf3pZFUyQwyvjA==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-linuxmusl-x64@1.0.56':
+    resolution: {integrity: sha512-qRXub9+1J7mNIzweAaw0tGgztS6XK+ZlwhUjOcFTusbqnED33zw4HzExUNUTTDue/BOUwkYzvXqMqn5N6juIJg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-sdk@1.0.0-beta.9':
+    resolution: {integrity: sha512-D4yiGL4/faFCjL7bozhX7bgxt/x1wp2LZ2p9Tw+xrA5hbcLh5Be5kPen+bFA8NbVfgt1G2djDYFZlrZjXXmcBw==}
+    engines: {node: '>=20.0.0'}
+
+  '@github/copilot-win32-arm64@1.0.56':
+    resolution: {integrity: sha512-/lj/zEezNoewCxvVORLN0JFvvi9WmQTYvtIyyg8kVlA9HZeg0vpRTBM5hdoni2D8mKb7g/8w8VF2Ecy9D3+NpA==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot-win32-x64@1.0.56':
+    resolution: {integrity: sha512-062C3lp4nvVl+vkkteYOrYpgnqZ/SAi54NuTQ4k45V2TNmLIpmMybmM0tCluxOfiTY+8EuS72H9RS8NUj1CzhQ==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot@1.0.56':
+    resolution: {integrity: sha512-epJ9yRqK1QjU73FDAlxPqZKh+CxkA1TIYbhTvXblturw5wWUhCSRhI2XoamNERohPznY10Wg3tbZC3jUAmQdJw==}
+    hasBin: true
 
   '@google/genai@1.48.0':
     resolution: {integrity: sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==}
@@ -1469,6 +1528,10 @@ packages:
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -2578,6 +2641,10 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+    engines: {node: '>=14.0.0'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3304,6 +3371,49 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
+
+  '@github/copilot-darwin-arm64@1.0.56':
+    optional: true
+
+  '@github/copilot-darwin-x64@1.0.56':
+    optional: true
+
+  '@github/copilot-linux-arm64@1.0.56':
+    optional: true
+
+  '@github/copilot-linux-x64@1.0.56':
+    optional: true
+
+  '@github/copilot-linuxmusl-arm64@1.0.56':
+    optional: true
+
+  '@github/copilot-linuxmusl-x64@1.0.56':
+    optional: true
+
+  '@github/copilot-sdk@1.0.0-beta.9':
+    dependencies:
+      '@github/copilot': 1.0.56
+      vscode-jsonrpc: 8.2.1
+      zod: 4.3.6
+
+  '@github/copilot-win32-arm64@1.0.56':
+    optional: true
+
+  '@github/copilot-win32-x64@1.0.56':
+    optional: true
+
+  '@github/copilot@1.0.56':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@github/copilot-darwin-arm64': 1.0.56
+      '@github/copilot-darwin-x64': 1.0.56
+      '@github/copilot-linux-arm64': 1.0.56
+      '@github/copilot-linux-x64': 1.0.56
+      '@github/copilot-linuxmusl-arm64': 1.0.56
+      '@github/copilot-linuxmusl-x64': 1.0.56
+      '@github/copilot-win32-arm64': 1.0.56
+      '@github/copilot-win32-x64': 1.0.56
 
   '@google/genai@1.48.0':
     dependencies:
@@ -4344,6 +4454,8 @@ snapshots:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
+
+  detect-libc@2.1.2: {}
 
   diff@8.0.4: {}
 
@@ -5530,6 +5642,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vscode-jsonrpc@8.2.1: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/src/agent/adapters/copilot/runner.ts
+++ b/src/agent/adapters/copilot/runner.ts
@@ -55,8 +55,8 @@ export class CopilotRunner {
         return;
       }
 
-      session.on("assistant.message_delta", (event) => {
-        queue.push({ kind: "text", text: event.data.deltaContent });
+      session.on("assistant.message", (event) => {
+        queue.push({ kind: "text", text: event.data.content });
       });
 
       session.on("tool.execution_start", (event) => {

--- a/src/agent/adapters/copilot/runner.ts
+++ b/src/agent/adapters/copilot/runner.ts
@@ -1,0 +1,213 @@
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+import { randomUUID } from "node:crypto";
+import type { RunRequest } from "../../types.js";
+import { RunValidationError } from "../../types.js";
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage, AssistantMessageEvent } from "@mariozechner/pi-ai";
+import { createLogger } from "../../../logging/logger.js";
+
+const log = createLogger("copilot-runner");
+
+export class CopilotRunner {
+  resolveSessionId(req: RunRequest): string {
+    return req.sessionId ?? `copilot:${randomUUID()}`;
+  }
+
+  validateRequest(req: RunRequest): void {
+    if (!req.cwd) throw new RunValidationError("copilot: cwd is required");
+    if (req.sessionId) throw new RunValidationError("copilot: sessions are not resumable; omit sessionId");
+  }
+
+  async *run(opts: {
+    request: RunRequest;
+    sessionId: string;
+    abort: AbortSignal;
+  }): AsyncGenerator<AgentEvent> {
+    const { request, abort } = opts;
+
+    const client = new CopilotClient({
+      mode: "copilot-cli",
+      workingDirectory: request.cwd,
+      useLoggedInUser: true,
+    });
+
+    const queue = new EventQueue<Translated>();
+    let assistantText = "";
+    let costUsd: number | undefined;
+    let errorMessage: string | undefined;
+    let stopReason: string = "end";
+
+    try {
+      await client.start();
+
+      const session = await client.createSession({
+        onPermissionRequest: approveAll,
+      });
+
+      const onAbort = async () => {
+        try { await session.abort(); } catch { /* ignore */ }
+        queue.end();
+      };
+      abort.addEventListener("abort", onAbort, { once: true });
+      if (abort.aborted) {
+        await onAbort();
+        return;
+      }
+
+      session.on("assistant.message_delta", (event) => {
+        queue.push({ kind: "text", text: event.data.deltaContent });
+      });
+
+      session.on("tool.execution_start", (event) => {
+        queue.push({
+          kind: "tool_call",
+          id: event.data.toolCallId,
+          name: event.data.toolName,
+          input: event.data.arguments,
+        });
+      });
+
+      session.on("tool.execution_complete", (event) => {
+        queue.push({
+          kind: "tool_result",
+          id: event.data.toolCallId,
+          name: toolNameFromComplete(event),
+          result: event.data.result,
+          isError: !event.data.success,
+        });
+      });
+
+      session.on("assistant.usage", (event) => {
+        if (event.data.cost !== undefined) {
+          costUsd = (costUsd ?? 0) + event.data.cost;
+        }
+      });
+
+      session.on("session.idle", () => {
+        queue.end();
+      });
+
+      await session.send({ prompt: request.content });
+
+      for await (const ev of queue) {
+        if (ev.kind === "text") {
+          assistantText += ev.text;
+          yield buildMessageUpdate(ev.text);
+        } else if (ev.kind === "tool_call") {
+          yield buildToolStart(ev.id, ev.name, ev.input);
+        } else if (ev.kind === "tool_result") {
+          yield buildToolEnd(ev.id, ev.name, ev.result, ev.isError);
+        }
+      }
+
+      abort.removeEventListener("abort", onAbort);
+      await session.disconnect();
+    } catch (err) {
+      stopReason = "error";
+      errorMessage = err instanceof Error ? err.message : String(err);
+      log.warn("Copilot run failed", { error: errorMessage });
+    } finally {
+      try { await client.stop(); } catch { /* ignore */ }
+    }
+
+    yield buildAgentEnd(assistantText, stopReason, errorMessage, costUsd);
+  }
+}
+
+function toolNameFromComplete(event: { data: { toolCallId: string }; type: string }): string {
+  return (event as unknown as { data: { toolName?: string } }).data.toolName ?? event.data.toolCallId;
+}
+
+type Translated =
+  | { kind: "text"; text: string }
+  | { kind: "tool_call"; id: string; name: string; input: unknown }
+  | { kind: "tool_result"; id: string; name: string; result: unknown; isError: boolean };
+
+class EventQueue<T> implements AsyncIterable<T> {
+  private queue: T[] = [];
+  private waiting: ((value: IteratorResult<T>) => void) | undefined;
+  private finished = false;
+  private rejected: Error | undefined;
+
+  push(item: T): void {
+    if (this.finished) return;
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = undefined;
+      resolve({ value: item, done: false });
+    } else {
+      this.queue.push(item);
+    }
+  }
+
+  end(): void {
+    this.finished = true;
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = undefined;
+      resolve({ value: undefined as unknown as T, done: true });
+    }
+  }
+
+  error(err: Error): void {
+    this.rejected = err;
+    this.end();
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return { next: () => this.next() };
+  }
+
+  private next(): Promise<IteratorResult<T>> {
+    if (this.rejected) return Promise.reject(this.rejected);
+    if (this.queue.length > 0) {
+      return Promise.resolve({ value: this.queue.shift()!, done: false });
+    }
+    if (this.finished) {
+      return Promise.resolve({ value: undefined as unknown as T, done: true });
+    }
+    return new Promise((resolve) => {
+      this.waiting = resolve;
+    });
+  }
+}
+
+function buildAssistantMessage(text: string, extras: { stopReason?: string; errorMessage?: string } = {}): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    stopReason: extras.stopReason ?? "end",
+    ...(extras.errorMessage ? { errorMessage: extras.errorMessage } : {}),
+  } as unknown as AgentMessage;
+}
+
+function buildMessageUpdate(delta: string): AgentEvent {
+  const partial = buildAssistantMessage(delta) as unknown as AssistantMessage;
+  const ame: AssistantMessageEvent = {
+    type: "text_delta",
+    contentIndex: 0,
+    delta,
+    partial,
+  } as AssistantMessageEvent;
+  return {
+    type: "message_update",
+    message: partial as unknown as AgentMessage,
+    assistantMessageEvent: ame,
+  };
+}
+
+function buildToolStart(toolCallId: string, toolName: string, args: unknown): AgentEvent {
+  return { type: "tool_execution_start", toolCallId, toolName, args };
+}
+
+function buildToolEnd(toolCallId: string, toolName: string, result: unknown, isError: boolean): AgentEvent {
+  return { type: "tool_execution_end", toolCallId, toolName, result, isError };
+}
+
+function buildAgentEnd(text: string, stopReason: string, errorMessage: string | undefined, _costUsd: number | undefined): AgentEvent {
+  return {
+    type: "agent_end",
+    messages: [buildAssistantMessage(text, { stopReason, ...(errorMessage ? { errorMessage } : {}) })],
+  };
+}

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -13,6 +13,7 @@ import { RunValidationError } from "./types.js";
 import type { PiSessionDeps } from "./pi/session-factory.js";
 import { PiRunner } from "./pi/runner.js";
 import { ClaudeRunner } from "./adapters/claude/runner.js";
+import { CopilotRunner } from "./adapters/copilot/runner.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import {
   type AgentSession,
@@ -181,9 +182,9 @@ export class AgentRuntime {
   async register(opts: AddAgentOptions): Promise<AddAgentResult> {
     const { agentFile, provider, globalTools } = opts;
     const agentConfig = toAgentConfig(agentFile, provider, globalTools);
-    return agentConfig.runner === "claude"
-      ? this.registerClaude(agentConfig)
-      : this.registerPi(agentConfig, opts);
+    if (agentConfig.runner === "claude") return this.registerClaude(agentConfig);
+    if (agentConfig.runner === "copilot") return this.registerCopilot(agentConfig);
+    return this.registerPi(agentConfig, opts);
   }
 
   private registerClaude(agentConfig: AgentConfig): AddAgentResult {
@@ -193,6 +194,16 @@ export class AgentRuntime {
       ...(agentConfig.sessionPolicy ? { sessionPolicy: agentConfig.sessionPolicy } : {}),
     };
     this.registerRunner(agentConfig.id, new ClaudeRunner(), { spawnable: agentConfig.spawnable === true });
+    return { agent, workspacePath: null };
+  }
+
+  private registerCopilot(agentConfig: AgentConfig): AddAgentResult {
+    const agent: RegisteredAgent = {
+      id: agentConfig.id,
+      config: agentConfig,
+      ...(agentConfig.sessionPolicy ? { sessionPolicy: agentConfig.sessionPolicy } : {}),
+    };
+    this.registerRunner(agentConfig.id, new CopilotRunner(), { spawnable: agentConfig.spawnable === true });
     return { agent, workspacePath: null };
   }
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -14,7 +14,7 @@ export interface ProviderConfig {
 
 export interface AgentConfig {
   id: string;
-  runner?: "pi" | "claude";
+  runner?: "pi" | "claude" | "copilot";
   /** Defaults to ${ISOTOPES_HOME}/workspace-${id}. */
   workspace?: string;
   toolSettings?: AgentToolSettings;

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ export interface HeartbeatConfigFile {
 
 export interface AgentConfigFile {
   id: string;
-  runner?: "pi" | "claude";
+  runner?: "pi" | "claude" | "copilot";
   enabled?: boolean;
   /** Absolute or ISOTOPES_HOME-relative. */
   workspace?: string;


### PR DESCRIPTION
## Summary
Adds GitHub Copilot CLI as a third runner option alongside \`pi\` and \`claude\`. Mirrors the same shape as \`adapters/claude/runner.ts\` — no isotopes tools, no SOUL.md/MEMORY.md injection. The agent is a pure copilot session driven via \`@github/copilot-sdk\`'s \`copilot-cli\` mode using the logged-in GitHub user.

## Changes
- \`src/agent/adapters/copilot/runner.ts\` (+215) — new CopilotRunner
- \`src/agent/runtime.ts\` — register copilot when \`runner: \"copilot\"\`
- \`src/agent/types.ts\` / \`src/config.ts\` — runner enum gains \"copilot\"
- \`package.json\` / \`pnpm-lock.yaml\` — add \`@github/copilot-sdk@1.0.0-beta.9\`

## Feature parity with ClaudeRunner
| | Claude | Copilot |
|---|---|---|
| Runner interface | ✅ | ✅ |
| Event stream translation | ✅ | ✅ |
| Abort signal bridging | ✅ | ✅ |
| \`cwd\` required, \`sessionId\` rejected | ✅ | ✅ |
| Cost tracking collected | ✅ (discarded) | ✅ (discarded) |
| Tests | ❌ | ❌ (intentional — matches Claude) |

## Test plan
- [x] \`pnpm run ci\` (lint + typecheck + 415 tests)
- [ ] Manual smoke: configure a copilot agent and dispatch a prompt (see PR thread for steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)