### PR TITLE
fix(copilot): tool names, error events, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,13 @@ pnpm test:integration
 - `types.ts` — `RegisteredAgent`, `RunRequest`, `RunInfo`, `AgentConfig`, `ProviderConfig`, `RunValidationError`, plus session types (`Session`, `SessionStore`, `SessionMetadata`, `TranscriptUpdate`).
 - `pi/` — Pi backbone (default agent runtime, not a swappable adapter). Wraps `@mariozechner/pi-agent-core` + `@mariozechner/pi-coding-agent`: `runner.ts`, `session-factory.ts`, `session-store.ts`, `messages.ts`, `system-prompt-override.ts`, `tool-result-truncation.ts`. Other isotopes modules (transports, HTTP, gateway) are allowed to depend on these directly — pi is the host, not a guest.
 - `adapters/claude/` — Third-party adapter for the Claude Agent SDK. Implements the same `Runner` interface but lives under `adapters/` to signal "alternative entry point, not the backbone".
+- `adapters/copilot/` — Third-party adapter for the GitHub Copilot CLI SDK. Same shape as `adapters/claude/`. Requires `gh auth login` + Copilot access.
 - `tools/` — Built-in agent tools (`web` for `web_fetch`, `react` for channel reactions) and the registry (`index.ts`) that assembles per-agent tool sets.
 - `workspace/` — Loads `SOUL.md` / `TOOLS.md` / `MEMORY.md` / `BOOTSTRAP.md` into system prompts; manages workspace state and template files.
 
 ### Key patterns
 
-- **Pluggable runner**: `AgentRuntime` dispatches to a runner per agent (`pi` default, `claude` alternative). Swap runners without touching gateway or transport code.
+- **Pluggable runner**: `AgentRuntime` dispatches to a runner per agent (`pi` default, `claude` and `copilot` alternatives). Swap runners without touching gateway or transport code.
 - **Tool registry**: Tools are `(schema, handler)` pairs assembled per-agent in `agent/tools/index.ts`; tool guards (CLI, FS) are enforced at registration and injected into system prompts.
 - **Extensions (pi-native)**: User-authored extensions in `~/.isotopes/extensions/pi/*.ts` are loaded via pi-coding-agent's `DefaultResourceLoader` and shared across all agents (loader is cached per-agentId in `session-factory.ts`). Per-agent capability scoping is via `tools.allow` / `tools.deny`, not separate extension sets.
 - **Event streaming**: `AgentRuntime.run()` returns `AsyncIterable<AgentEvent>` — discriminated union of turn_start, text_delta, tool_call, tool_result, turn_end, agent_end, error. Gateway's `ingestRunnerEvents` translates these into `SessionEvent` for consumers.

--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -21,7 +21,7 @@ provider:
 agents:
   - id: main
     # runner: pi                            # pi (default) | claude | copilot
-    #                                       # claude: uses Claude Agent SDK (requires `claude login`)
+    #                                       # claude: uses Claude Agent SDK (requires `claude login` or ~/.claude/settings.json)
     #                                       # copilot: uses GitHub Copilot CLI (requires `gh auth login` + Copilot access)
     # enabled: true                         # set false to skip loading this agent
     # spawnable: false                      # set true to let other agents spawn this one

--- a/isotopes.example.yaml
+++ b/isotopes.example.yaml
@@ -20,7 +20,9 @@ provider:
 # =============================================================================
 agents:
   - id: main
-    # runner: pi                            # pi (default) | claude
+    # runner: pi                            # pi (default) | claude | copilot
+    #                                       # claude: uses Claude Agent SDK (requires `claude login`)
+    #                                       # copilot: uses GitHub Copilot CLI (requires `gh auth login` + Copilot access)
     # enabled: true                         # set false to skip loading this agent
     # spawnable: false                      # set true to let other agents spawn this one
     # sessionPolicy: parent-reuse           # parent-reuse (default) | always-new

--- a/src/agent/adapters/copilot/runner.ts
+++ b/src/agent/adapters/copilot/runner.ts
@@ -90,6 +90,12 @@ export class CopilotRunner {
         queue.end();
       });
 
+      session.on("session.error", (event) => {
+        stopReason = "error";
+        errorMessage = `[${event.data.errorType}] ${event.data.message}`;
+        queue.end();
+      });
+
       await session.send({ prompt: request.content });
 
       for await (const ev of queue) {

--- a/src/agent/adapters/copilot/runner.ts
+++ b/src/agent/adapters/copilot/runner.ts
@@ -33,6 +33,7 @@ export class CopilotRunner {
     });
 
     const queue = new EventQueue<Translated>();
+    const toolNameById = new Map<string, string>();
     let assistantText = "";
     let costUsd: number | undefined;
     let errorMessage: string | undefined;
@@ -60,6 +61,7 @@ export class CopilotRunner {
       });
 
       session.on("tool.execution_start", (event) => {
+        toolNameById.set(event.data.toolCallId, event.data.toolName);
         queue.push({
           kind: "tool_call",
           id: event.data.toolCallId,
@@ -72,7 +74,7 @@ export class CopilotRunner {
         queue.push({
           kind: "tool_result",
           id: event.data.toolCallId,
-          name: toolNameFromComplete(event),
+          name: toolNameById.get(event.data.toolCallId) ?? event.data.toolCallId,
           result: event.data.result,
           isError: !event.data.success,
         });
@@ -113,10 +115,6 @@ export class CopilotRunner {
 
     yield buildAgentEnd(assistantText, stopReason, errorMessage, costUsd);
   }
-}
-
-function toolNameFromComplete(event: { data: { toolCallId: string }; type: string }): string {
-  return (event as unknown as { data: { toolName?: string } }).data.toolName ?? event.data.toolCallId;
 }
 
 type Translated =


### PR DESCRIPTION
Addresses review feedback from PR #858 (merged) — three small fixes plus docs.

## Changes

### 1. Tool names now resolve correctly (fix #2)
\`tool.execution_complete\` payload doesn't carry \`toolName\` (confirmed by grepping the SDK \`.d.ts\`), only \`toolCallId\`. The old \`toolNameFromComplete\` helper read a non-existent field and always fell back to UUID. Mirror Claude's \`toolNameById\` Map: record name on \`tool.execution_start\`, look up on complete. Downstream now sees \"bash\" instead of \"abc-uuid-123\".

### 2. Bridge session error events (fix #7)
Subscribe to \`session.error\` (rate_limit, quota, context_limit, etc.) → set \`stopReason=\"error\"\`, format \`[errorType] message\`, end the queue. Previously these silently hung until the outer abort/timeout fired.

### 3. Docs (fix #3)
- \`isotopes.example.yaml\`: \`runner\` comment lists copilot + auth prereq (\`gh auth login\` + Copilot access)
- \`CLAUDE.md\`: add \`adapters/copilot/\` entry; update \"Pluggable runner\" pattern to mention all three

## Verified
- SDK event grep confirmed: \`session.error\` exists with \`{ errorType, message, errorCode?, ... }\`
- \`tool.execution_complete\` confirmed to NOT have \`toolName\` (only \`toolCallId\`)
- \`pnpm run ci\` — lint + typecheck + 415 tests passing

## Deferred (follow-up issues, per review)
- #1 \`assistant.message\` accumulation semantics — needs multi-turn smoke to confirm any real issue
- #4 streaming via \`assistant.message_delta\`
- #5 sessionId resume rejection comment
- #6 lift EventQueue to utils/
- #8 test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)