### PR TITLE
fix(discord): coalesce concurrent inbound on same session to one subscriber

### DIFF
--- a/src/channels/discord/inbound.test.ts
+++ b/src/channels/discord/inbound.test.ts
@@ -70,6 +70,7 @@ function makeGateway(): Gateway & { dispatch: ReturnType<typeof vi.fn> } {
 describe("handleInbound", () => {
   let gateway: ReturnType<typeof makeGateway>;
   let buildSubscriber: ReturnType<typeof vi.fn>;
+  let inflight: Map<string, { onEvent: ReturnType<typeof vi.fn>; done: Promise<void> }>;
 
   beforeEach(() => {
     gateway = makeGateway();
@@ -79,9 +80,10 @@ describe("handleInbound", () => {
       onEvent: vi.fn(),
       done: Promise.resolve(),
     });
+    inflight = new Map();
   });
 
-  const ctx = () => ({ botId: BOT_ID, buildSubscriber });
+  const ctx = () => ({ botId: BOT_ID, buildSubscriber, inflight });
   const sessionKeyFor = (msg: DiscordMessage, botId = BOT_ID): string => {
     const ch = msg.channel as { isThread?: () => boolean };
     if (ch?.isThread?.()) return `discord:${botId}:thread:${msg.channelId}`;
@@ -231,6 +233,68 @@ describe("handleInbound", () => {
     resolveDone();
     await p;
     expect(resolved).toBe(true);
+  });
+
+  // Regression #865: concurrent messages on the same session must share one
+  // outbound subscriber; otherwise gateway's fan-out emits each text_delta
+  // N times and assistant text appears duplicated N× on Discord.
+  it("coalesces concurrent inbound messages on same session to one subscriber", async () => {
+    let resolveDone!: () => void;
+    const done = new Promise<void>((r) => { resolveDone = r; });
+    const onEvent = vi.fn();
+    buildSubscriber = vi.fn().mockReturnValue({ onEvent, done });
+
+    const msg1 = fakeMsg({ id: "m-1", mentionedIds: [BOT_ID], content: `<@${BOT_ID}> first` });
+    const msg2 = fakeMsg({ id: "m-2", mentionedIds: [BOT_ID], content: `<@${BOT_ID}> second` });
+    const msg3 = fakeMsg({ id: "m-3", mentionedIds: [BOT_ID], content: `<@${BOT_ID}> third` });
+
+    const sharedCtx = ctx();
+    const p1 = handleInbound(msg1, route(msg1), { gateway }, sharedCtx);
+    // Let msg1 register the subscriber before msg2/msg3 arrive.
+    await vi.waitFor(() => expect(buildSubscriber).toHaveBeenCalledTimes(1));
+    const p2 = handleInbound(msg2, route(msg2), { gateway }, sharedCtx);
+    const p3 = handleInbound(msg3, route(msg3), { gateway }, sharedCtx);
+
+    await vi.waitFor(() => expect(gateway.dispatch).toHaveBeenCalledTimes(3));
+
+    // Only ONE subscriber was built and subscribed despite 3 inbound messages.
+    expect(buildSubscriber).toHaveBeenCalledTimes(1);
+    expect(gateway.subscribe).toHaveBeenCalledTimes(1);
+
+    // All three inbound messages were dispatched (so the model sees all of them).
+    expect(gateway.dispatch.mock.calls[0][0].content).toContain("first");
+    expect(gateway.dispatch.mock.calls[1][0].content).toContain("second");
+    expect(gateway.dispatch.mock.calls[2][0].content).toContain("third");
+
+    resolveDone();
+    await Promise.all([p1, p2, p3]);
+    // Inflight cleared after the shared subscriber resolves.
+    expect(sharedCtx.inflight.size).toBe(0);
+  });
+
+  it("rebuilds subscriber for the next inbound after the first run completes", async () => {
+    // First batch: one message, resolves to done.
+    let resolveDone1!: () => void;
+    const done1 = new Promise<void>((r) => { resolveDone1 = r; });
+    buildSubscriber = vi
+      .fn()
+      .mockReturnValueOnce({ onEvent: vi.fn(), done: done1 })
+      .mockReturnValueOnce({ onEvent: vi.fn(), done: Promise.resolve() });
+
+    const sharedCtx = ctx();
+    const msg1 = fakeMsg({ id: "m-1", mentionedIds: [BOT_ID], content: `<@${BOT_ID}> first` });
+    const p1 = handleInbound(msg1, route(msg1), { gateway }, sharedCtx);
+    await vi.waitFor(() => expect(buildSubscriber).toHaveBeenCalledTimes(1));
+    resolveDone1();
+    await p1;
+    expect(sharedCtx.inflight.size).toBe(0);
+
+    // Second batch: a new message after the first run finished should build
+    // a fresh subscriber, not reuse the disposed one.
+    const msg2 = fakeMsg({ id: "m-2", mentionedIds: [BOT_ID], content: `<@${BOT_ID}> second` });
+    await handleInbound(msg2, route(msg2), { gateway }, sharedCtx);
+    expect(buildSubscriber).toHaveBeenCalledTimes(2);
+    expect(gateway.subscribe).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -124,6 +124,11 @@ export interface InboundSubscriber {
 interface InboundContext {
   botId: string;
   buildSubscriber: (msg: DiscordMessage) => InboundSubscriber;
+  /** Per-session subscriber registry shared across inbound calls.
+   * First message for a session builds & subscribes; concurrent messages
+   * that hit the same in-flight session reuse the existing subscriber so
+   * the outbound stream is emitted exactly once. See #865. */
+  inflight: Map<string, InboundSubscriber>;
 }
 
 export async function handleInbound(
@@ -179,6 +184,22 @@ export async function handleInbound(
 
   await deps.gateway.createOrResumeSession(routing.agentId, routing.sessionKey);
 
+  // Coalesce concurrent inbound messages on the same session onto one
+  // subscriber. Without this, every message subscribes its own outbound
+  // buffer to the same sessionId; gateway emits each text_delta to all
+  // listeners, so the assistant reply is duplicated N× (#865).
+  const inflightKey = `${routing.agentId}::${routing.sessionKey}`;
+  const existing = ctx.inflight.get(inflightKey);
+  if (existing) {
+    try {
+      await deps.gateway.dispatch(message);
+      await existing.done;
+    } catch (err) {
+      log.warn("Dispatch (steered) failed", { agentId: routing.agentId, sessionKey: routing.sessionKey, error: err instanceof Error ? err.message : String(err) });
+    }
+    return;
+  }
+
   const subscriber = ctx.buildSubscriber(msg);
   const unsubscribe = await deps.gateway.subscribe(
     routing.agentId,
@@ -190,10 +211,12 @@ export async function handleInbound(
     return;
   }
 
+  ctx.inflight.set(inflightKey, subscriber);
   try {
     await deps.gateway.dispatch(message);
     await subscriber.done;
   } finally {
+    ctx.inflight.delete(inflightKey);
     unsubscribe();
   }
 }

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -124,10 +124,7 @@ export interface InboundSubscriber {
 interface InboundContext {
   botId: string;
   buildSubscriber: (msg: DiscordMessage) => InboundSubscriber;
-  /** Per-session subscriber registry shared across inbound calls.
-   * First message for a session builds & subscribes; concurrent messages
-   * that hit the same in-flight session reuse the existing subscriber so
-   * the outbound stream is emitted exactly once. See #865. */
+  /** In-flight subscribers keyed `${agentId}::${sessionKey}` (#865). */
   inflight: Map<string, InboundSubscriber>;
 }
 
@@ -184,10 +181,9 @@ export async function handleInbound(
 
   await deps.gateway.createOrResumeSession(routing.agentId, routing.sessionKey);
 
-  // Coalesce concurrent inbound messages on the same session onto one
-  // subscriber. Without this, every message subscribes its own outbound
-  // buffer to the same sessionId; gateway emits each text_delta to all
-  // listeners, so the assistant reply is duplicated N× (#865).
+  // If another inbound on this session is already subscribed, reuse it —
+  // otherwise gateway fans out each text_delta to N listeners and the reply
+  // dupes N× (#865).
   const inflightKey = `${routing.agentId}::${routing.sessionKey}`;
   const existing = ctx.inflight.get(inflightKey);
   if (existing) {

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -10,7 +10,7 @@ import type { Gateway } from "../../gateway/index.js";
 
 import { DedupeCache } from "./dedupe.js";
 import { ChannelHistoryBuffer, formatHistory } from "./channel-history.js";
-import { handleInbound, passesAllowlist, handleStopCommand } from "./inbound.js";
+import { handleInbound, passesAllowlist, handleStopCommand, type InboundSubscriber } from "./inbound.js";
 import { createDiscordSubscriber } from "./outbound.js";
 import { react } from "./react.js";
 import { resolveToken } from "./config.js";
@@ -65,6 +65,10 @@ export function createDiscordChannel(
   const clients = new Map<string, ClientLike>();
   const dedupes = new Map<string, DedupeCache>();
   const histories = new Map<string, ChannelHistoryBuffer>();
+  // accountId → "{agentId}::{sessionKey}" → in-flight subscriber.
+  // Coalesces concurrent inbound messages on the same session onto one
+  // outbound subscriber to prevent duplicated assistant replies (#865).
+  const inflightSubscribers = new Map<string, Map<string, InboundSubscriber>>();
   // threadId → sub-run sessionId — populated by spawn_agent's A2A sink, used
   // to route /stop posted in a sub-run thread to the right cancel target.
   const a2aThreads = new Map<string, string>();
@@ -94,6 +98,7 @@ export function createDiscordChannel(
             clients,
             dedupes,
             histories,
+            inflightSubscribers,
             a2aThreads,
           }),
         ),
@@ -126,6 +131,7 @@ export function createDiscordChannel(
       dedupes.clear();
       for (const h of histories.values()) h.clear();
       histories.clear();
+      inflightSubscribers.clear();
     },
 
     async send(target, content) {
@@ -185,11 +191,12 @@ interface StartAccountArgs {
   clients: Map<string, ClientLike>;
   dedupes: Map<string, DedupeCache>;
   histories: Map<string, ChannelHistoryBuffer>;
+  inflightSubscribers: Map<string, Map<string, InboundSubscriber>>;
   a2aThreads: Map<string, string>;
 }
 
 async function startAccount(args: StartAccountArgs): Promise<void> {
-  const { accountId, account, gateway, clientFactory, clients, dedupes, histories, a2aThreads } = args;
+  const { accountId, account, gateway, clientFactory, clients, dedupes, histories, inflightSubscribers, a2aThreads } = args;
 
   const token = resolveToken(account);
   if (!token) {
@@ -203,6 +210,8 @@ async function startAccount(args: StartAccountArgs): Promise<void> {
   dedupes.set(accountId, dedupe);
   const history = new ChannelHistoryBuffer();
   histories.set(accountId, history);
+  const inflight = new Map<string, InboundSubscriber>();
+  inflightSubscribers.set(accountId, inflight);
 
   client.on("error", () => {});
 
@@ -215,6 +224,7 @@ async function startAccount(args: StartAccountArgs): Promise<void> {
       gateway,
       dedupe,
       history,
+      inflight,
       a2aThreads,
     });
   });
@@ -250,6 +260,7 @@ async function startAccount(args: StartAccountArgs): Promise<void> {
           gateway,
           dedupe,
           history,
+          inflight,
           a2aThreads,
         });
       } catch { /* ignore */ }
@@ -266,11 +277,12 @@ interface InboundArgs {
   gateway: Gateway;
   dedupe: DedupeCache;
   history: ChannelHistoryBuffer;
+  inflight: Map<string, InboundSubscriber>;
   a2aThreads: Map<string, string>;
 }
 
 async function dispatchInbound(args: InboundArgs): Promise<void> {
-  const { msg, account, client, gateway, dedupe, history, a2aThreads } = args;
+  const { msg, account, client, gateway, dedupe, history, inflight, a2aThreads } = args;
   const botId = client.user?.id;
   if (!botId) return;
 
@@ -325,6 +337,7 @@ async function dispatchInbound(args: InboundArgs): Promise<void> {
           channel: triggerMsg.channel as SendableChannels,
           triggerMessageId: triggerMsg.id,
         }),
+      inflight,
     },
   ));
 }

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -65,9 +65,7 @@ export function createDiscordChannel(
   const clients = new Map<string, ClientLike>();
   const dedupes = new Map<string, DedupeCache>();
   const histories = new Map<string, ChannelHistoryBuffer>();
-  // accountId → "{agentId}::{sessionKey}" → in-flight subscriber.
-  // Coalesces concurrent inbound messages on the same session onto one
-  // outbound subscriber to prevent duplicated assistant replies (#865).
+  // accountId → inflight key → subscriber. See inbound.ts (#865).
   const inflightSubscribers = new Map<string, Map<string, InboundSubscriber>>();
   // threadId → sub-run sessionId — populated by spawn_agent's A2A sink, used
   // to route /stop posted in a sub-run thread to the right cancel target.


### PR DESCRIPTION
## Summary
- Track per-session in-flight subscribers in the Discord channel adapter so concurrent inbound messages on the same `(agentId, sessionKey)` share one outbound subscriber instead of each attaching its own.
- First inbound builds and subscribes; later ones dispatch (gateway routes them as `steered`) and await the existing subscriber's `done`.
- Eliminates the N× assistant-text duplication seen on Discord when the user sends multiple messages while a run is in flight.

## Root cause (from #865)

Each call to `handleInbound` was doing `subscribe → dispatch → await done → unsubscribe`. When messages 2..N arrived during an in-flight run, `dispatch` returned `state: "steered"` (no new run), but each message had already attached its own `SegmentedStreamBuffer` to the same `sessionId`. Gateway's `emit` fans out to every listener, so each `text_delta` was sent to Discord once per concurrent inbound — producing the same paragraph repeated N times.

## Fix

`InboundContext` now requires an `inflight: Map<string, InboundSubscriber>` keyed by `"{agentId}::{sessionKey}"`. In `handleInbound`:
- if an entry exists, dispatch the message (so the model still sees it) and await the shared `done`;
- otherwise build the subscriber, register it, and clear the entry in the `finally` after the run ends.

The channel adapter owns one such map per Discord account and threads it through `dispatchInbound`.

## Test plan
- [x] `pnpm test` — 416/417 pass. The one failure is `tests/e2e-smoke.test.ts` web_fetch hitting httpbin 503, unrelated to this change.
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] New regression test: 3 concurrent `handleInbound` calls on the same session ⇒ `buildSubscriber` called **once**, `gateway.subscribe` called **once**, all 3 dispatches still flow through.
- [x] New test: after the first run resolves, the next inbound builds a fresh subscriber (registry is cleared correctly).
- [ ] Manual Discord smoke: send 3+ messages in quick succession on `major`; verify the assistant reply appears once, not N times.

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)