### PR TITLE
fix(discord): coalesce per-session inbound + add in-turn steer

### DIFF
--- a/src/agent/pi/runner.ts
+++ b/src/agent/pi/runner.ts
@@ -1,8 +1,12 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import { randomUUID } from "node:crypto";
+import { createLogger } from "../../logging/logger.js";
+import type { SyncSteer } from "../runtime.js";
 import type { RegisteredAgent, RunRequest } from "../types.js";
 import { createPiSession, type PiSessionDeps } from "./session-factory.js";
+
+const log = createLogger("pi-runner");
 
 export interface PiRunnerOptions {
   agent: RegisteredAgent;
@@ -41,8 +45,9 @@ export class PiRunner {
     sessionId: string;
     abort: AbortSignal;
     onSession?: (session: AgentSession) => void;
+    registerSteer?: (steer: SyncSteer) => void;
   }): AsyncGenerator<AgentEvent> {
-    const { request, sessionId, abort, onSession } = opts;
+    const { request, sessionId, abort, onSession, registerSteer } = opts;
     const session = await createPiSession(this.opts.piDeps, {
       agent: this.opts.agent,
       sessionId,
@@ -50,6 +55,7 @@ export class PiRunner {
       ...(request.extraSystemPrompt ? { extraSystemPrompt: request.extraSystemPrompt } : {}),
     });
     onSession?.(session);
+    registerSteer?.(buildSyncSteer(session));
     const content = request.cwd && request.from
       ? `[Caller working directory: ${request.cwd}]\n\n${request.content}`
       : request.content;
@@ -59,6 +65,36 @@ export class PiRunner {
       session.dispose();
     }
   }
+}
+
+/** Build a sync in-turn steer fn around an AgentSession.
+ *  Returns true iff the agent is currently streaming (so the steeringQueue
+ *  will be drained at the next turn boundary). When false, the caller falls
+ *  back to enqueueing a new run.
+ *
+ *  The check + enqueue are synchronous and therefore atomic relative to the
+ *  JS event loop: the agent-loop cannot interleave between the isStreaming
+ *  read and the agent.steer call. This is what closes the race window where
+ *  a message could be enqueued just as the agent decides to stop and is
+ *  never drained. See openclaw's queueEmbeddedPiMessage for the same pattern. */
+function buildSyncSteer(session: AgentSession): SyncSteer {
+  return (content: string): boolean => {
+    if (!session.agent.state.isStreaming) return false;
+    try {
+      // Bypass AgentSession.steer's async expansion path — for inbound channel
+      // messages we don't want skill/template expansion. Go straight to the
+      // underlying pi-agent steering queue.
+      session.agent.steer({
+        role: "user",
+        content: [{ type: "text", text: content }],
+        timestamp: Date.now(),
+      });
+      return true;
+    } catch (err) {
+      log.warn("Sync steer failed", { error: err instanceof Error ? err.message : String(err) });
+      return false;
+    }
+  };
 }
 
 async function* streamPiSession(

--- a/src/agent/pi/runner.ts
+++ b/src/agent/pi/runner.ts
@@ -67,23 +67,17 @@ export class PiRunner {
   }
 }
 
-/** Build a sync in-turn steer fn around an AgentSession.
- *  Returns true iff the agent is currently streaming (so the steeringQueue
- *  will be drained at the next turn boundary). When false, the caller falls
- *  back to enqueueing a new run.
- *
- *  The check + enqueue are synchronous and therefore atomic relative to the
- *  JS event loop: the agent-loop cannot interleave between the isStreaming
- *  read and the agent.steer call. This is what closes the race window where
- *  a message could be enqueued just as the agent decides to stop and is
- *  never drained. See openclaw's queueEmbeddedPiMessage for the same pattern. */
+/** Sync in-turn steer for an AgentSession.
+ *  Returns false when the agent isn't streaming — caller falls back to a new
+ *  run. The isStreaming check + agent.steer enqueue are one synchronous
+ *  expression, so the agent-loop can't end between them (closes the race
+ *  where a message could be enqueued just as the agent decides to stop). */
 function buildSyncSteer(session: AgentSession): SyncSteer {
   return (content: string): boolean => {
     if (!session.agent.state.isStreaming) return false;
     try {
-      // Bypass AgentSession.steer's async expansion path — for inbound channel
-      // messages we don't want skill/template expansion. Go straight to the
-      // underlying pi-agent steering queue.
+      // Bypass AgentSession.steer's async expansion — inbound channel
+      // messages don't need skill/template processing.
       session.agent.steer({
         role: "user",
         content: [{ type: "text", text: content }],

--- a/src/agent/runtime.test.ts
+++ b/src/agent/runtime.test.ts
@@ -363,10 +363,10 @@ describe("runtime.run — abort on consumer early-return", () => {
   });
 });
 
-describe("runtime.steer — wires onSession into RunHandle", () => {
-  it("steer reaches the runner's session via onSession callback", async () => {
+describe("runtime.trySteer — wires registerSteer into RunHandle", () => {
+  it("trySteer forwards to the runner's registered sync steer fn", async () => {
     const rt = new AgentRuntime();
-    const steerSpy = vi.fn();
+    const steerSpy = vi.fn().mockReturnValue(true);
     let pendingResolve: () => void = () => {};
     const pending = new Promise<void>((r) => { pendingResolve = r; });
     let runStarted: () => void = () => {};
@@ -374,7 +374,7 @@ describe("runtime.steer — wires onSession into RunHandle", () => {
 
     rt.registerRunner("main", stubRunner({
       async *run(opts) {
-        opts.onSession?.({ steer: steerSpy } as never);
+        opts.registerSteer?.(steerSpy);
         runStarted();
         opts.abort.addEventListener("abort", pendingResolve, { once: true });
         await pending;
@@ -391,14 +391,19 @@ describe("runtime.steer — wires onSession into RunHandle", () => {
     const drain = (async () => { for await (const _ev of stream) { void _ev; } })();
 
     await started;
-    await rt.steer("steer-1", "interject");
+    expect(rt.trySteer("steer-1", "interject")).toBe(true);
     expect(steerSpy).toHaveBeenCalledWith("interject");
 
     rt.cancel("steer-1");
     await drain;
   });
 
-  it("steer throws when runner did not call onSession", async () => {
+  it("trySteer returns false when no run is active for the sessionId", () => {
+    const rt = new AgentRuntime();
+    expect(rt.trySteer("nonexistent", "x")).toBe(false);
+  });
+
+  it("trySteer returns false when the runner did not register a steer fn", async () => {
     const rt = new AgentRuntime();
     let pendingResolve: () => void = () => {};
     const pending = new Promise<void>((r) => { pendingResolve = r; });
@@ -423,9 +428,44 @@ describe("runtime.steer — wires onSession into RunHandle", () => {
     const drain = (async () => { for await (const _ev of stream) { void _ev; } })();
 
     await started;
-    await expect(rt.steer("steer-2", "x")).rejects.toThrow(/No active session/);
+    expect(rt.trySteer("steer-2", "x")).toBe(false);
 
     rt.cancel("steer-2");
+    await drain;
+  });
+
+  it("trySteer reflects the runner's runtime decision (returns false when not streamable)", async () => {
+    const rt = new AgentRuntime();
+    let allowSteer = true;
+    let pendingResolve: () => void = () => {};
+    const pending = new Promise<void>((r) => { pendingResolve = r; });
+    let runStarted: () => void = () => {};
+    const started = new Promise<void>((r) => { runStarted = r; });
+
+    rt.registerRunner("conditional", stubRunner({
+      async *run(opts) {
+        opts.registerSteer?.(() => allowSteer);
+        runStarted();
+        opts.abort.addEventListener("abort", pendingResolve, { once: true });
+        await pending;
+        yield buildAgentEnd("done");
+      },
+      agent: fakeAgent("conditional"),
+    }));
+
+    const stream = rt.run({
+      to: "conditional",
+      sessionId: "cond-1",
+      content: "hi",
+    });
+    const drain = (async () => { for await (const _ev of stream) { void _ev; } })();
+    await started;
+
+    expect(rt.trySteer("cond-1", "x")).toBe(true);
+    allowSteer = false;
+    expect(rt.trySteer("cond-1", "y")).toBe(false);
+
+    rt.cancel("cond-1");
     await drain;
   });
 });

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -51,16 +51,14 @@ interface RunHandle {
   abort: AbortController;
   parentSessionId?: string;
   session?: AgentSession;
-  /** Sync in-turn steer registered by the runner. Returns false if the run
-   *  is no longer accepting steer. Discord channel calls runtime.trySteer
-   *  via this on every inbound — see gateway.trySteer. */
+  /** Set by runners that support in-turn steer (currently pi only). */
   steer?: SyncSteer;
   cancelReason?: string;
 }
 
-/** Synchronous in-turn steer fn. Returns true iff the message was queued into
- *  the active turn; false otherwise (run already ended, disposed, etc.).
- *  Must be synchronous so the caller can decide leader-vs-steer atomically. */
+/** Sync in-turn steer. Must be sync so callers can decide leader-vs-steer
+ *  atomically without an await window where the run could end. Returns true
+ *  iff the message was queued into the active turn. */
 export type SyncSteer = (content: string) => boolean;
 
 export interface AgentRuntimeOptions {
@@ -97,10 +95,7 @@ export interface Runner {
     abort: AbortSignal;
     /** Steerable session hook; ClaudeRunner doesn't call it. */
     onSession?: (session: AgentSession) => void;
-    /** Register a synchronous in-turn steer function. Called once per run by
-     *  runners that support steering (pi). The function returns true if the
-     *  message was queued into the in-flight turn, false if the run is no
-     *  longer accepting steer (already stopped, disposed, etc.). */
+    /** Runners that support in-turn steer call this once at startup. */
     registerSteer?: (steer: SyncSteer) => void;
   }): AsyncGenerator<AgentEvent>;
 }
@@ -374,9 +369,7 @@ export class AgentRuntime {
     return this.runs.size;
   }
 
-  /** Synchronous in-turn steer. Returns true if the message was queued into
-   *  the active run's current turn, false if no such run exists, the runner
-   *  doesn't support steer, or the run is no longer accepting steer. */
+  /** Sync in-turn steer; see SyncSteer. */
   trySteer(sessionId: string, content: string): boolean {
     return this.runs.get(sessionId)?.steer?.(content) ?? false;
   }

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -51,8 +51,17 @@ interface RunHandle {
   abort: AbortController;
   parentSessionId?: string;
   session?: AgentSession;
+  /** Sync in-turn steer registered by the runner. Returns false if the run
+   *  is no longer accepting steer. Discord channel calls runtime.trySteer
+   *  via this on every inbound — see gateway.trySteer. */
+  steer?: SyncSteer;
   cancelReason?: string;
 }
+
+/** Synchronous in-turn steer fn. Returns true iff the message was queued into
+ *  the active turn; false otherwise (run already ended, disposed, etc.).
+ *  Must be synchronous so the caller can decide leader-vs-steer atomically. */
+export type SyncSteer = (content: string) => boolean;
 
 export interface AgentRuntimeOptions {
   /** Default LLM provider. */
@@ -88,6 +97,11 @@ export interface Runner {
     abort: AbortSignal;
     /** Steerable session hook; ClaudeRunner doesn't call it. */
     onSession?: (session: AgentSession) => void;
+    /** Register a synchronous in-turn steer function. Called once per run by
+     *  runners that support steering (pi). The function returns true if the
+     *  message was queued into the in-flight turn, false if the run is no
+     *  longer accepting steer (already stopped, disposed, etc.). */
+    registerSteer?: (steer: SyncSteer) => void;
   }): AsyncGenerator<AgentEvent>;
 }
 
@@ -322,6 +336,7 @@ export class AgentRuntime {
         sessionId,
         abort: abort.signal,
         onSession: (session) => { handle.session = session; },
+        registerSteer: (steerFn) => { handle.steer = steerFn; },
       })) {
         if (event.type === "tool_execution_start") {
           log.debug("Tool call", { runId, agentId: req.to, toolName: event.toolName, toolCallId: event.toolCallId });
@@ -359,11 +374,11 @@ export class AgentRuntime {
     return this.runs.size;
   }
 
-  /** Push-model steer — inject a user message into an in-flight run mid-turn. */
-  async steer(sessionId: string, message: string): Promise<void> {
-    const handle = this.runs.get(sessionId);
-    if (!handle?.session) throw new Error(`No active session for "${sessionId}"`);
-    await handle.session.steer(message);
+  /** Synchronous in-turn steer. Returns true if the message was queued into
+   *  the active run's current turn, false if no such run exists, the runner
+   *  doesn't support steer, or the run is no longer accepting steer. */
+  trySteer(sessionId: string, content: string): boolean {
+    return this.runs.get(sessionId)?.steer?.(content) ?? false;
   }
 
   getRunBySession(sessionId: string): RunInfo | undefined {

--- a/src/channels/discord/inbound.test.ts
+++ b/src/channels/discord/inbound.test.ts
@@ -52,7 +52,8 @@ function fakeMsg(opts: FakeMsgOpts = {}): DiscordMessage {
 
 function makeGateway(): Gateway & { dispatch: ReturnType<typeof vi.fn> } {
   return {
-    dispatch: vi.fn().mockResolvedValue({ sessionId: "s", state: "new_run" }),
+    dispatch: vi.fn().mockResolvedValue({ sessionId: "s" }),
+    trySteer: vi.fn().mockReturnValue(false),
     dispatchAndWait: vi.fn().mockResolvedValue({ responseText: "", errorMessage: null }),
     abort: vi.fn().mockResolvedValue(undefined),
     abortByKey: vi.fn().mockResolvedValue(false),
@@ -216,21 +217,6 @@ describe("handleInbound", () => {
     resolveDone();
     await promise;
     expect(settled).toBe(true);
-  });
-
-  it("awaits subscriber.done even when dispatch returns steered", async () => {
-    gateway.dispatch.mockResolvedValueOnce({ sessionId: "s", state: "steered" });
-    let resolveDone!: () => void;
-    const done = new Promise<void>((r) => { resolveDone = r; });
-    buildSubscriber = vi.fn().mockReturnValue({ onEvent: vi.fn(), done });
-    const msg = fakeMsg({ mentionedIds: [BOT_ID], content: `<@${BOT_ID}> hi` });
-    let resolved = false;
-    const p = handleInbound(msg, route(msg), { gateway }, ctx()).then(() => { resolved = true; });
-    await vi.waitFor(() => expect(gateway.dispatch).toHaveBeenCalled());
-    expect(resolved).toBe(false);
-    resolveDone();
-    await p;
-    expect(resolved).toBe(true);
   });
 });
 

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -126,6 +126,29 @@ interface InboundContext {
   buildSubscriber: (msg: DiscordMessage) => InboundSubscriber;
 }
 
+/** Inbound filter shared by the fast-path (trySteer) and slow-path
+ *  (handleInbound). Returns true iff the message should be delivered to the
+ *  agent at all. Lives here so both paths can't drift — fast-path must apply
+ *  the same gating or it would steer messages that the slow path would
+ *  silently drop (own bot echoes, unmentioned chatter in groups, etc.). */
+export function shouldDispatchInbound(
+  msg: DiscordMessage,
+  params: { botId: string; guilds?: Record<string, GuildConfig>; allowBots?: boolean },
+): boolean {
+  if (msg.author.id === params.botId) return false;
+  if (msg.author.bot && params.allowBots === false) return false;
+  if (
+    msg.guild
+    && isThreadMessage(msg)
+    && params.guilds?.[msg.guild.id]?.respondInThreads === false
+  ) return false;
+  if (msg.guild) {
+    const requireMention = params.guilds?.[msg.guild.id]?.requireMention ?? true;
+    if (requireMention && !msg.mentions?.has?.(params.botId)) return false;
+  }
+  return true;
+}
+
 export async function handleInbound(
   msg: DiscordMessage,
   routing: { agentId: string; sessionKey: string },
@@ -134,27 +157,9 @@ export async function handleInbound(
 ): Promise<void> {
   log.debug("Message received", { author: msg.author.username, channelId: msg.channelId, guildId: msg.guild?.id });
 
-  if (msg.author.id === ctx.botId) {
-    log.debug("Filtered: own message", { authorId: msg.author.id });
+  if (!shouldDispatchInbound(msg, { botId: ctx.botId, guilds: deps.guilds, allowBots: deps.allowBots })) {
+    log.debug("Filtered (handleInbound)", { msgId: msg.id, author: msg.author.username });
     return;
-  }
-
-  if (msg.author.bot && deps.allowBots === false) {
-    log.debug("Filtered: bot message", { author: msg.author.username });
-    return;
-  }
-
-  if (msg.guild && isThreadMessage(msg) && deps.guilds?.[msg.guild.id]?.respondInThreads === false) {
-    log.debug("Filtered: thread message", { channelId: msg.channelId });
-    return;
-  }
-
-  if (msg.guild) {
-    const requireMention = deps.guilds?.[msg.guild.id]?.requireMention ?? true;
-    if (requireMention && !msg.mentions?.has?.(ctx.botId)) {
-      log.debug("Filtered: not mentioned", { msgId: msg.id });
-      return;
-    }
   }
 
   const cleanedText = msg.content.replace(/<@!?\d+>/g, "").trim();

--- a/src/channels/discord/inbound.ts
+++ b/src/channels/discord/inbound.ts
@@ -126,11 +126,8 @@ interface InboundContext {
   buildSubscriber: (msg: DiscordMessage) => InboundSubscriber;
 }
 
-/** Inbound filter shared by the fast-path (trySteer) and slow-path
- *  (handleInbound). Returns true iff the message should be delivered to the
- *  agent at all. Lives here so both paths can't drift — fast-path must apply
- *  the same gating or it would steer messages that the slow path would
- *  silently drop (own bot echoes, unmentioned chatter in groups, etc.). */
+/** Shared by fast-path (trySteer) and slow-path (handleInbound) so both
+ *  apply identical gating. */
 export function shouldDispatchInbound(
   msg: DiscordMessage,
   params: { botId: string; guilds?: Record<string, GuildConfig>; allowBots?: boolean },

--- a/src/channels/discord/index.test.ts
+++ b/src/channels/discord/index.test.ts
@@ -38,12 +38,14 @@ function makeFakeClient(botId: string): FakeClient {
 
 function makeGateway(): Gateway & {
   dispatch: ReturnType<typeof vi.fn>;
+  trySteer: ReturnType<typeof vi.fn>;
   abort: ReturnType<typeof vi.fn>;
   abortByKey: ReturnType<typeof vi.fn>;
   subscribe: ReturnType<typeof vi.fn>;
 } {
   return {
-    dispatch: vi.fn().mockResolvedValue({ sessionId: "s", state: "new_run" }),
+    dispatch: vi.fn().mockResolvedValue({ sessionId: "s" }),
+    trySteer: vi.fn().mockReturnValue(false),
     dispatchAndWait: vi.fn().mockResolvedValue({ responseText: "", errorMessage: null }),
     abort: vi.fn().mockResolvedValue(undefined),
     abortByKey: vi.fn().mockResolvedValue(false),
@@ -57,6 +59,7 @@ function makeGateway(): Gateway & {
     deleteSession: vi.fn().mockResolvedValue(false),
   } as unknown as Gateway & {
     dispatch: ReturnType<typeof vi.fn>;
+    trySteer: ReturnType<typeof vi.fn>;
     abort: ReturnType<typeof vi.fn>;
     abortByKey: ReturnType<typeof vi.fn>;
     subscribe: ReturnType<typeof vi.fn>;
@@ -344,6 +347,151 @@ describe("createDiscordChannel — inbound wiring", () => {
     const channelSend = (msg.channel as unknown as { send: ReturnType<typeof vi.fn> }).send;
     expect(channelSend).toHaveBeenCalled();
     expect(channelSend.mock.calls[0][0]).toContain("hello world.");
+  });
+});
+
+// #865 regression: concurrent inbound on the same session must not stack up
+// subscribers on the same gateway sessionId — that's what fans out text_delta
+// N× to Discord.
+describe("createDiscordChannel — per-session inbound serialization (#865)", () => {
+  it("serializes concurrent inbound on the same session — only one subscribe is live at a time", async () => {
+    const client = makeFakeClient("bot-A");
+    const gateway = makeGateway();
+
+    const listeners: Array<(event: unknown) => void> = [];
+    let live = 0;
+    let peak = 0;
+    gateway.subscribe.mockImplementation(async (_a, _k, listener) => {
+      listeners.push(listener as (event: unknown) => void);
+      live += 1;
+      if (live > peak) peak = live;
+      return () => { live -= 1; };
+    });
+
+    const adapter = createDiscordChannel(
+      {
+        accounts: {
+          alpha: { token: "tok", defaultAgentId: "main", groupAccess: { policy: "open" } },
+        },
+      },
+      { clientFactory: () => client },
+    );
+    await adapter.start({ gateway });
+
+    const msg1 = fakeMsg({ id: "m1", mentionedIds: ["bot-A"], content: "<@bot-A> first" });
+    const msg2 = fakeMsg({ id: "m2", mentionedIds: ["bot-A"], content: "<@bot-A> second" });
+    const msg3 = fakeMsg({ id: "m3", mentionedIds: ["bot-A"], content: "<@bot-A> third" });
+    client.emit("messageCreate", msg1);
+    client.emit("messageCreate", msg2);
+    client.emit("messageCreate", msg3);
+
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+    expect(live).toBe(1);
+    expect(listeners.length).toBe(1);
+
+    listeners[0]({ type: "agent_end", stopReason: "end" });
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+    expect(live).toBe(1);
+    expect(listeners.length).toBe(2);
+
+    listeners[1]({ type: "agent_end", stopReason: "end" });
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+    expect(live).toBe(1);
+    expect(listeners.length).toBe(3);
+
+    listeners[2]({ type: "agent_end", stopReason: "end" });
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+    expect(live).toBe(0);
+
+    expect(peak).toBe(1);
+    expect(gateway.dispatch).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not serialize across different sessions — two channels run in parallel", async () => {
+    const client = makeFakeClient("bot-A");
+    const gateway = makeGateway();
+    let live = 0;
+    let peak = 0;
+    const listeners: Array<(event: unknown) => void> = [];
+    gateway.subscribe.mockImplementation(async (_a, _k, listener) => {
+      listeners.push(listener as (event: unknown) => void);
+      live += 1;
+      if (live > peak) peak = live;
+      return () => { live -= 1; };
+    });
+
+    const adapter = createDiscordChannel(
+      {
+        accounts: {
+          alpha: { token: "tok", defaultAgentId: "main", groupAccess: { policy: "open" } },
+        },
+      },
+      { clientFactory: () => client },
+    );
+    await adapter.start({ gateway });
+
+    client.emit("messageCreate", fakeMsg({ id: "m1", channelId: "c-1", mentionedIds: ["bot-A"] }));
+    client.emit("messageCreate", fakeMsg({ id: "m2", channelId: "c-2", mentionedIds: ["bot-A"] }));
+
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+
+    expect(peak).toBe(2);
+    expect(listeners.length).toBe(2);
+
+    listeners[0]({ type: "agent_end", stopReason: "end" });
+    listeners[1]({ type: "agent_end", stopReason: "end" });
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+    expect(live).toBe(0);
+  });
+});
+
+describe("createDiscordChannel — in-turn steer (fast-path)", () => {
+  it("calls gateway.trySteer first; when it succeeds, does NOT subscribe/dispatch", async () => {
+    const client = makeFakeClient("bot-A");
+    const gateway = makeGateway();
+    // trySteer returns true → fast-path success, slow path must not run.
+    gateway.trySteer.mockReturnValue(true);
+
+    const adapter = createDiscordChannel(
+      {
+        accounts: {
+          alpha: { token: "tok", defaultAgentId: "main", groupAccess: { policy: "open" } },
+        },
+      },
+      { clientFactory: () => client },
+    );
+    await adapter.start({ gateway });
+
+    client.emit("messageCreate", fakeMsg({ mentionedIds: ["bot-A"], content: "<@bot-A> hi" }));
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+
+    expect(gateway.trySteer).toHaveBeenCalledTimes(1);
+    // Slow path skipped:
+    expect(gateway.subscribe).not.toHaveBeenCalled();
+    expect(gateway.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to dispatch+subscribe when trySteer returns false", async () => {
+    const client = makeFakeClient("bot-A");
+    const gateway = makeGateway();
+    gateway.trySteer.mockReturnValue(false);
+
+    const adapter = createDiscordChannel(
+      {
+        accounts: {
+          alpha: { token: "tok", defaultAgentId: "main", groupAccess: { policy: "open" } },
+        },
+      },
+      { clientFactory: () => client },
+    );
+    await adapter.start({ gateway });
+
+    client.emit("messageCreate", fakeMsg({ mentionedIds: ["bot-A"], content: "<@bot-A> hi" }));
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+
+    expect(gateway.trySteer).toHaveBeenCalledTimes(1);
+    expect(gateway.subscribe).toHaveBeenCalledTimes(1);
+    expect(gateway.dispatch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/channels/discord/index.test.ts
+++ b/src/channels/discord/index.test.ts
@@ -493,6 +493,68 @@ describe("createDiscordChannel — in-turn steer (fast-path)", () => {
     expect(gateway.subscribe).toHaveBeenCalledTimes(1);
     expect(gateway.dispatch).toHaveBeenCalledTimes(1);
   });
+
+  // Fast-path must apply the same inbound filters as the slow path; otherwise
+  // it would inject unfiltered messages directly into the active turn — bot
+  // echo loops, unmentioned chatter in groups treated as user input, etc.
+  it("does NOT trySteer when guild message lacks @mention (requireMention default true)", async () => {
+    const client = makeFakeClient("bot-A");
+    const gateway = makeGateway();
+    gateway.trySteer.mockReturnValue(true); // would succeed if called — must not be called
+    const adapter = createDiscordChannel(
+      { accounts: { alpha: { token: "tok", defaultAgentId: "main", groupAccess: { policy: "open" } } } },
+      { clientFactory: () => client },
+    );
+    await adapter.start({ gateway });
+
+    // Guild message, no mention of bot-A.
+    client.emit("messageCreate", fakeMsg({ content: "casual chatter" }));
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+
+    expect(gateway.trySteer).not.toHaveBeenCalled();
+    expect(gateway.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trySteer when message author is the bot itself", async () => {
+    const client = makeFakeClient("bot-A");
+    const gateway = makeGateway();
+    gateway.trySteer.mockReturnValue(true);
+    const adapter = createDiscordChannel(
+      { accounts: { alpha: { token: "tok", defaultAgentId: "main", groupAccess: { policy: "open" } } } },
+      { clientFactory: () => client },
+    );
+    await adapter.start({ gateway });
+
+    // Bot's own message echoed back via messageCreate.
+    client.emit("messageCreate", fakeMsg({ authorId: "bot-A", mentionedIds: ["bot-A"], content: "<@bot-A> hi" }));
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+
+    expect(gateway.trySteer).not.toHaveBeenCalled();
+    expect(gateway.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trySteer for other bots when account.allowBots = false", async () => {
+    const client = makeFakeClient("bot-A");
+    const gateway = makeGateway();
+    gateway.trySteer.mockReturnValue(true);
+    const adapter = createDiscordChannel(
+      {
+        accounts: {
+          alpha: { token: "tok", defaultAgentId: "main", allowBots: false, groupAccess: { policy: "open" } },
+        },
+      },
+      { clientFactory: () => client },
+    );
+    await adapter.start({ gateway });
+
+    // Another bot mentions us — would normally be allowed (we are mentioned),
+    // but allowBots=false must drop it before any dispatch/steer.
+    client.emit("messageCreate", fakeMsg({ authorBot: true, mentionedIds: ["bot-A"], content: "<@bot-A> hello fellow bot" }));
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+
+    expect(gateway.trySteer).not.toHaveBeenCalled();
+    expect(gateway.dispatch).not.toHaveBeenCalled();
+  });
 });
 
 describe("createDiscordChannel — message metadata enrichment", () => {

--- a/src/channels/discord/index.test.ts
+++ b/src/channels/discord/index.test.ts
@@ -350,9 +350,8 @@ describe("createDiscordChannel — inbound wiring", () => {
   });
 });
 
-// #865 regression: concurrent inbound on the same session must not stack up
-// subscribers on the same gateway sessionId — that's what fans out text_delta
-// N× to Discord.
+// #865 regression: concurrent inbound on the same session must not stack
+// subscribers on the same gateway sessionId (causes N× fan-out of text_delta).
 describe("createDiscordChannel — per-session inbound serialization (#865)", () => {
   it("serializes concurrent inbound on the same session — only one subscribe is live at a time", async () => {
     const client = makeFakeClient("bot-A");
@@ -449,7 +448,6 @@ describe("createDiscordChannel — in-turn steer (fast-path)", () => {
   it("calls gateway.trySteer first; when it succeeds, does NOT subscribe/dispatch", async () => {
     const client = makeFakeClient("bot-A");
     const gateway = makeGateway();
-    // trySteer returns true → fast-path success, slow path must not run.
     gateway.trySteer.mockReturnValue(true);
 
     const adapter = createDiscordChannel(
@@ -466,7 +464,6 @@ describe("createDiscordChannel — in-turn steer (fast-path)", () => {
     for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
 
     expect(gateway.trySteer).toHaveBeenCalledTimes(1);
-    // Slow path skipped:
     expect(gateway.subscribe).not.toHaveBeenCalled();
     expect(gateway.dispatch).not.toHaveBeenCalled();
   });
@@ -494,9 +491,7 @@ describe("createDiscordChannel — in-turn steer (fast-path)", () => {
     expect(gateway.dispatch).toHaveBeenCalledTimes(1);
   });
 
-  // Fast-path must apply the same inbound filters as the slow path; otherwise
-  // it would inject unfiltered messages directly into the active turn — bot
-  // echo loops, unmentioned chatter in groups treated as user input, etc.
+  // Fast-path must apply the same inbound filters as the slow path.
   it("does NOT trySteer when guild message lacks @mention (requireMention default true)", async () => {
     const client = makeFakeClient("bot-A");
     const gateway = makeGateway();
@@ -507,7 +502,6 @@ describe("createDiscordChannel — in-turn steer (fast-path)", () => {
     );
     await adapter.start({ gateway });
 
-    // Guild message, no mention of bot-A.
     client.emit("messageCreate", fakeMsg({ content: "casual chatter" }));
     for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
 
@@ -525,7 +519,6 @@ describe("createDiscordChannel — in-turn steer (fast-path)", () => {
     );
     await adapter.start({ gateway });
 
-    // Bot's own message echoed back via messageCreate.
     client.emit("messageCreate", fakeMsg({ authorId: "bot-A", mentionedIds: ["bot-A"], content: "<@bot-A> hi" }));
     for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
 
@@ -547,8 +540,7 @@ describe("createDiscordChannel — in-turn steer (fast-path)", () => {
     );
     await adapter.start({ gateway });
 
-    // Another bot mentions us — would normally be allowed (we are mentioned),
-    // but allowBots=false must drop it before any dispatch/steer.
+    // Bot author + mention would normally be allowed; allowBots=false blocks it.
     client.emit("messageCreate", fakeMsg({ authorBot: true, mentionedIds: ["bot-A"], content: "<@bot-A> hello fellow bot" }));
     for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
 

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -10,7 +10,7 @@ import type { Gateway } from "../../gateway/index.js";
 
 import { DedupeCache } from "./dedupe.js";
 import { ChannelHistoryBuffer, formatHistory } from "./channel-history.js";
-import { handleInbound, passesAllowlist, handleStopCommand } from "./inbound.js";
+import { handleInbound, passesAllowlist, handleStopCommand, shouldDispatchInbound } from "./inbound.js";
 import { createDiscordSubscriber } from "./outbound.js";
 import { react } from "./react.js";
 import { resolveToken } from "./config.js";
@@ -320,9 +320,30 @@ async function dispatchInbound(args: InboundArgs): Promise<void> {
   // Skipped when the message has attachments — image extraction is async and
   // would force us past the atomic window. Also skipped when the trimmed
   // text is empty; the slow path filters those out.
+  //
+  // Must apply the same inbound filters as the slow path before steering —
+  // otherwise unmentioned chatter in a group, the bot's own message echoed
+  // back, or messages from disallowed bots would be injected as user input
+  // into the active turn instead of being dropped.
+  //
+  // The framed content here is meta + cleanedText only — no channel history
+  // block and no REPLY_PROMPT extraSystemPrompt. The history block exists to
+  // bootstrap context at the start of a new turn; when we're steering an
+  // in-flight turn the agent is already inside the session's streaming
+  // context (the prior reply tag instructions are already in the message
+  // history), so re-prepending them is noise. The buffered group history
+  // stays in the buffer and will be consumed by the next slow-path message.
   const cleanedText = msg.content.replace(/<@!?\d+>/g, "").trim();
   const hasAttachments = msg.attachments && msg.attachments.size > 0;
-  if (cleanedText && !hasAttachments) {
+  if (
+    cleanedText
+    && !hasAttachments
+    && shouldDispatchInbound(msg, {
+      botId,
+      ...(account.guilds ? { guilds: account.guilds } : {}),
+      ...(account.allowBots !== undefined ? { allowBots: account.allowBots } : {}),
+    })
+  ) {
     const meta = extractDiscordMetadata(msg);
     const chatType = msg.guild ? "group" : "direct";
     const framedContent = `${formatInboundMeta(meta, chatType)}\n\n${cleanedText}`;

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -315,24 +315,12 @@ async function dispatchInbound(args: InboundArgs): Promise<void> {
     });
   }
 
-  // Fast-path: if an agent run is currently streaming for this session, try
-  // to queue this message into its in-turn steering queue (atomic sync op).
-  // Skipped when the message has attachments — image extraction is async and
-  // would force us past the atomic window. Also skipped when the trimmed
-  // text is empty; the slow path filters those out.
-  //
-  // Must apply the same inbound filters as the slow path before steering —
-  // otherwise unmentioned chatter in a group, the bot's own message echoed
-  // back, or messages from disallowed bots would be injected as user input
-  // into the active turn instead of being dropped.
-  //
-  // The framed content here is meta + cleanedText only — no channel history
-  // block and no REPLY_PROMPT extraSystemPrompt. The history block exists to
-  // bootstrap context at the start of a new turn; when we're steering an
-  // in-flight turn the agent is already inside the session's streaming
-  // context (the prior reply tag instructions are already in the message
-  // history), so re-prepending them is noise. The buffered group history
-  // stays in the buffer and will be consumed by the next slow-path message.
+  // Fast-path: sync-inject into an in-flight turn if the agent is streaming.
+  // Skipped on attachments (extraction is async, breaks the sync atomicity)
+  // and on filtered messages (own echoes, unmentioned chatter, etc.).
+  // Framing omits the channel-history block and REPLY_PROMPT — the active
+  // turn already has them in scope; the buffered history is left for the
+  // next slow-path message to consume.
   const cleanedText = msg.content.replace(/<@!?\d+>/g, "").trim();
   const hasAttachments = msg.attachments && msg.attachments.size > 0;
   if (

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -66,9 +66,7 @@ export function createDiscordChannel(
   const clients = new Map<string, ClientLike>();
   const dedupes = new Map<string, DedupeCache>();
   const histories = new Map<string, ChannelHistoryBuffer>();
-  // FIFO per sessionKey within an account. Inbound messages that miss the
-  // trySteer fast-path fall back to this queue, so a single channel never
-  // has two concurrent runs racing the same gateway sessionId (#865).
+  // FIFO per sessionKey — fallback when trySteer misses; serializes runs (#865).
   const inboundQueues = new Map<string, KeyedAsyncQueue>();
   // threadId → sub-run sessionId — populated by spawn_agent's A2A sink, used
   // to route /stop posted in a sub-run thread to the right cancel target.
@@ -341,8 +339,6 @@ async function dispatchInbound(args: InboundArgs): Promise<void> {
     }
   }
 
-  // Slow path: serialize per session so a single channel never has two
-  // concurrent agent runs racing the same gateway sessionId (#865).
   const sinkFactory = buildSinkFactory(client, msg.channelId, a2aThreads);
   await inboundQueue.enqueue(`${agentId}::${sessionKey}`, () =>
     runWithA2A(sinkFactory, () => handleInbound(

--- a/src/channels/discord/index.ts
+++ b/src/channels/discord/index.ts
@@ -18,6 +18,7 @@ import { extractDiscordMetadata, formatInboundMeta } from "./message-metadata.js
 import { createLogger } from "../../logging/logger.js";
 import { DiscordA2ASink, type DiscordA2ASinkDeps } from "./a2a-sink.js";
 import { type A2ASinkFactory, runWithA2A } from "../../agent/a2a-sink.js";
+import { KeyedAsyncQueue } from "../../utils/keyed-async-queue.js";
 import type {
   DiscordAccountConfig,
   DiscordChannelsConfig,
@@ -65,6 +66,10 @@ export function createDiscordChannel(
   const clients = new Map<string, ClientLike>();
   const dedupes = new Map<string, DedupeCache>();
   const histories = new Map<string, ChannelHistoryBuffer>();
+  // FIFO per sessionKey within an account. Inbound messages that miss the
+  // trySteer fast-path fall back to this queue, so a single channel never
+  // has two concurrent runs racing the same gateway sessionId (#865).
+  const inboundQueues = new Map<string, KeyedAsyncQueue>();
   // threadId → sub-run sessionId — populated by spawn_agent's A2A sink, used
   // to route /stop posted in a sub-run thread to the right cancel target.
   const a2aThreads = new Map<string, string>();
@@ -94,6 +99,7 @@ export function createDiscordChannel(
             clients,
             dedupes,
             histories,
+            inboundQueues,
             a2aThreads,
           }),
         ),
@@ -126,6 +132,8 @@ export function createDiscordChannel(
       dedupes.clear();
       for (const h of histories.values()) h.clear();
       histories.clear();
+      for (const q of inboundQueues.values()) q.clear();
+      inboundQueues.clear();
     },
 
     async send(target, content) {
@@ -185,11 +193,12 @@ interface StartAccountArgs {
   clients: Map<string, ClientLike>;
   dedupes: Map<string, DedupeCache>;
   histories: Map<string, ChannelHistoryBuffer>;
+  inboundQueues: Map<string, KeyedAsyncQueue>;
   a2aThreads: Map<string, string>;
 }
 
 async function startAccount(args: StartAccountArgs): Promise<void> {
-  const { accountId, account, gateway, clientFactory, clients, dedupes, histories, a2aThreads } = args;
+  const { accountId, account, gateway, clientFactory, clients, dedupes, histories, inboundQueues, a2aThreads } = args;
 
   const token = resolveToken(account);
   if (!token) {
@@ -203,6 +212,8 @@ async function startAccount(args: StartAccountArgs): Promise<void> {
   dedupes.set(accountId, dedupe);
   const history = new ChannelHistoryBuffer();
   histories.set(accountId, history);
+  const inboundQueue = new KeyedAsyncQueue();
+  inboundQueues.set(accountId, inboundQueue);
 
   client.on("error", () => {});
 
@@ -215,6 +226,7 @@ async function startAccount(args: StartAccountArgs): Promise<void> {
       gateway,
       dedupe,
       history,
+      inboundQueue,
       a2aThreads,
     });
   });
@@ -250,6 +262,7 @@ async function startAccount(args: StartAccountArgs): Promise<void> {
           gateway,
           dedupe,
           history,
+          inboundQueue,
           a2aThreads,
         });
       } catch { /* ignore */ }
@@ -266,11 +279,12 @@ interface InboundArgs {
   gateway: Gateway;
   dedupe: DedupeCache;
   history: ChannelHistoryBuffer;
+  inboundQueue: KeyedAsyncQueue;
   a2aThreads: Map<string, string>;
 }
 
 async function dispatchInbound(args: InboundArgs): Promise<void> {
-  const { msg, account, client, gateway, dedupe, history, a2aThreads } = args;
+  const { msg, account, client, gateway, dedupe, history, inboundQueue, a2aThreads } = args;
   const botId = client.user?.id;
   if (!botId) return;
 
@@ -286,8 +300,9 @@ async function dispatchInbound(args: InboundArgs): Promise<void> {
   const sessionKey = resolveSessionKey(msg, botId);
 
   // /stop runs before history.append so the command never leaks into channel
-  // history (or any LLM session). Every bot consumes /stop; only the
-  // addressed bot actually aborts.
+  // history (or any LLM session). It also runs before any queue/steer path —
+  // queueing /stop would make it wait for the run it's meant to abort. Every
+  // bot consumes /stop; only the addressed bot actually aborts.
   const isStopCommand = await handleStopCommand(msg, botId, gateway, agentId, sessionKey, a2aThreads);
   if (isStopCommand) return;
 
@@ -300,33 +315,54 @@ async function dispatchInbound(args: InboundArgs): Promise<void> {
     });
   }
 
+  // Fast-path: if an agent run is currently streaming for this session, try
+  // to queue this message into its in-turn steering queue (atomic sync op).
+  // Skipped when the message has attachments — image extraction is async and
+  // would force us past the atomic window. Also skipped when the trimmed
+  // text is empty; the slow path filters those out.
+  const cleanedText = msg.content.replace(/<@!?\d+>/g, "").trim();
+  const hasAttachments = msg.attachments && msg.attachments.size > 0;
+  if (cleanedText && !hasAttachments) {
+    const meta = extractDiscordMetadata(msg);
+    const chatType = msg.guild ? "group" : "direct";
+    const framedContent = `${formatInboundMeta(meta, chatType)}\n\n${cleanedText}`;
+    if (gateway.trySteer(agentId, sessionKey, framedContent)) {
+      log.debug("Steered into active run", { agentId, sessionKey });
+      return;
+    }
+  }
+
+  // Slow path: serialize per session so a single channel never has two
+  // concurrent agent runs racing the same gateway sessionId (#865).
   const sinkFactory = buildSinkFactory(client, msg.channelId, a2aThreads);
-  await runWithA2A(sinkFactory, () => handleInbound(
-    msg,
-    { agentId, sessionKey },
-    {
-      gateway,
-      ...(account.guilds ? { guilds: account.guilds } : {}),
-      ...(account.allowBots !== undefined ? { allowBots: account.allowBots } : {}),
-      transformContent: (content, triggerMsg) => {
-        const meta = extractDiscordMetadata(triggerMsg);
-        const chatType = triggerMsg.guild ? "group" : "direct";
-        const historyBlock = triggerMsg.guild
-          ? formatHistory(history.consumeExcluding(triggerMsg.channelId, triggerMsg.id))
-          : "";
-        const prefix = historyBlock ? `${historyBlock}\n\n${formatInboundMeta(meta, chatType)}` : formatInboundMeta(meta, chatType);
-        return `${prefix}\n\n${content}`;
+  await inboundQueue.enqueue(`${agentId}::${sessionKey}`, () =>
+    runWithA2A(sinkFactory, () => handleInbound(
+      msg,
+      { agentId, sessionKey },
+      {
+        gateway,
+        ...(account.guilds ? { guilds: account.guilds } : {}),
+        ...(account.allowBots !== undefined ? { allowBots: account.allowBots } : {}),
+        transformContent: (content, triggerMsg) => {
+          const meta = extractDiscordMetadata(triggerMsg);
+          const chatType = triggerMsg.guild ? "group" : "direct";
+          const historyBlock = triggerMsg.guild
+            ? formatHistory(history.consumeExcluding(triggerMsg.channelId, triggerMsg.id))
+            : "";
+          const prefix = historyBlock ? `${historyBlock}\n\n${formatInboundMeta(meta, chatType)}` : formatInboundMeta(meta, chatType);
+          return `${prefix}\n\n${content}`;
+        },
       },
-    },
-    {
-      botId,
-      buildSubscriber: (triggerMsg) =>
-        createDiscordSubscriber({
-          channel: triggerMsg.channel as SendableChannels,
-          triggerMessageId: triggerMsg.id,
-        }),
-    },
-  ));
+      {
+        botId,
+        buildSubscriber: (triggerMsg) =>
+          createDiscordSubscriber({
+            channel: triggerMsg.channel as SendableChannels,
+            triggerMessageId: triggerMsg.id,
+          }),
+      },
+    )),
+  );
 }
 
 /** Find the unique account whose effective agent for this channel matches. */

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createGateway } from "./gateway.js";
 import { AgentRuntime, type Runner } from "../agent/runtime.js";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
@@ -103,7 +103,7 @@ const baseMsg: Message = { agentId: "main", content: "hi", source: "tui" };
 async function dispatchAndCollect(
   gateway: ReturnType<typeof createGateway>,
   msg: Message,
-): Promise<{ sessionId: string; state: string; events: SessionEvent[] }> {
+): Promise<{ sessionId: string; events: SessionEvent[] }> {
   const events: SessionEvent[] = [];
   const { sessionKey } = await gateway.createOrResumeSession(msg.agentId, msg.sessionKey);
   const ready = new Promise<void>((resolve) => {
@@ -115,7 +115,7 @@ async function dispatchAndCollect(
   await gateway.dispatch({ ...msg, sessionKey });
   await ready;
   const session = await gateway.getSession(msg.agentId, sessionKey);
-  return { sessionId: session?.id ?? "", state: "new_run", events };
+  return { sessionId: session?.id ?? "", events };
 }
 
 describe("gateway.dispatchAndWait", () => {
@@ -137,13 +137,12 @@ describe("gateway.dispatchAndWait", () => {
   });
 });
 
-describe("gateway.dispatch (new_run)", () => {
-  it("returns new_run state and surfaces text_delta + agent_end on subscribers", async () => {
+describe("gateway.dispatch (new run)", () => {
+  it("surfaces text_delta + agent_end on subscribers", async () => {
     const runtime = buildRuntime(fastRunner(["a", "b"]));
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
-    const { events, state } = await dispatchAndCollect(gateway, { ...baseMsg, sessionKey: "k1" });
-    expect(state).toBe("new_run");
+    const { events } = await dispatchAndCollect(gateway, { ...baseMsg, sessionKey: "k1" });
     const textDeltas = events.filter((e): e is Extract<SessionEvent, { type: "text_delta" }> => e.type === "text_delta");
     expect(textDeltas.map((e) => e.delta)).toEqual(["a", "b"]);
     expect(events.at(-1)?.type).toBe("agent_end");
@@ -163,8 +162,8 @@ describe("gateway.dispatch (new_run)", () => {
   });
 });
 
-describe("gateway.dispatch (steered)", () => {
-  it("forwards to runtime.steer when session is busy", async () => {
+describe("gateway.dispatch (in-flight collision)", () => {
+  it("throws when a run for the session is already in flight", async () => {
     const longRunner: Runner = {
       resolveSessionId: (req) => req.sessionId ?? "stub",
       async *run({ abort }) {
@@ -174,22 +173,19 @@ describe("gateway.dispatch (steered)", () => {
       },
     };
     const runtime = buildRuntime(longRunner);
-    const steerSpy = vi.spyOn(runtime, "steer").mockResolvedValue();
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     await gateway.createOrResumeSession("main", "shared");
-    const first = gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "first" });
-    await first; // dispatch resolves early on handle.ready
-    const second = await gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "second" });
-    expect(second.state).toBe("steered");
-    expect(steerSpy).toHaveBeenCalledWith(second.sessionId, "second");
+    const first = await gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "first" });
+    await expect(
+      gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "second" }),
+    ).rejects.toThrow(/already has an in-flight run/);
 
-    await gateway.abort(second.sessionId);
+    await gateway.abort(first.sessionId);
   });
 
-  it("falls through to a fresh run if the prior run ended between observe and steer", async () => {
+  it("starts a fresh run if the prior run has already ended", async () => {
     const runtime = buildRuntime(fastRunner(["one"]));
-    const steerSpy = vi.spyOn(runtime, "steer");
     const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
 
     const first = await gateway.dispatchAndWait({ ...baseMsg, sessionKey: "ended", content: "first" });
@@ -197,7 +193,44 @@ describe("gateway.dispatch (steered)", () => {
 
     const second = await gateway.dispatchAndWait({ ...baseMsg, sessionKey: "ended", content: "second" });
     expect(second.responseText).toBe("one");
-    expect(steerSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("gateway.trySteer", () => {
+  it("returns false when no active run exists for the session", () => {
+    const runtime = buildRuntime(fastRunner(["x"]));
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
+    expect(gateway.trySteer("main", "nonexistent", "hi")).toBe(false);
+  });
+
+  it("forwards to runtime.trySteer for an active run; reflects its boolean", async () => {
+    let steered = "";
+    const longRunner: Runner = {
+      resolveSessionId: (req) => req.sessionId ?? "stub",
+      async *run({ abort, registerSteer }) {
+        registerSteer?.((content) => { steered = content; return true; });
+        yield textDelta("running");
+        await new Promise((r) => abort.addEventListener("abort", r, { once: true }));
+        yield agentEnd();
+      },
+    };
+    const runtime = buildRuntime(longRunner);
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
+
+    await gateway.createOrResumeSession("main", "shared");
+    const first = await gateway.dispatch({ ...baseMsg, sessionKey: "shared", content: "first" });
+
+    expect(gateway.trySteer("main", "shared", "interject")).toBe(true);
+    expect(steered).toBe("interject");
+
+    await gateway.abort(first.sessionId);
+  });
+
+  it("returns false again after the run ends (active map cleaned up)", async () => {
+    const runtime = buildRuntime(fastRunner(["one"]));
+    const gateway = createGateway({ agentRuntime: runtime, sessionStoreManager: makeStores() });
+    await gateway.dispatchAndWait({ ...baseMsg, sessionKey: "ended-trysteer", content: "first" });
+    expect(gateway.trySteer("main", "ended-trysteer", "x")).toBe(false);
   });
 });
 

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -23,15 +23,22 @@ export interface GatewayDeps {
   sessionStoreManager: SessionStoreManager;
 }
 
-// `ready` resolves once the underlying runner has registered the run
-// (i.e. the first event has arrived) so steer can safely target it.
+// `ready` resolves once the runner has emitted its first event, so dispatch's
+// caller is guaranteed any post-return subscribe() call still sees the run.
 interface ActiveHandle {
   ready: Promise<void>;
   resolveReady: () => void;
+  /** Composite key `${agentId}::${sessionKey}` — used to clean the secondary
+   *  index in triggerRun's finally without re-deriving from msg. */
+  keyIndex: string;
 }
 
 export function createGateway(deps: GatewayDeps): Gateway {
   const active = new Map<string, ActiveHandle>();
+  // Secondary index: `${agentId}::${sessionKey}` → sessionId. Lets trySteer()
+  // be fully synchronous (no async store lookup). Kept in lock-step with
+  // `active`: written in dispatch, deleted in triggerRun's finally.
+  const activeByKey = new Map<string, string>();
   // sessionId -> external subscribers (fan-out targets for emit()).
   const listeners = new Map<string, Set<SessionEventListener>>();
 
@@ -116,6 +123,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
       log.error("Run error", { sessionId, error: errorMessage });
     } finally {
       active.delete(sessionId);
+      activeByKey.delete(handle.keyIndex);
       if (!readyResolved) handle.resolveReady();
       emit(sessionId, errorMessage
         ? { type: "agent_end", stopReason: "error", errorMessage }
@@ -140,33 +148,31 @@ export function createGateway(deps: GatewayDeps): Gateway {
 
   async function dispatch(msg: Message): Promise<DispatchResult> {
     const sessionId = await resolveSessionId(msg);
-
-    while (true) {
-      const existing = active.get(sessionId);
-      if (existing) {
-        await existing.ready;
-        // The run may have ended while we awaited ready (finally also resolves
-        // ready). If `active` no longer holds our handle, retry as a fresh run.
-        if (active.get(sessionId) !== existing) continue;
-        try {
-          await deps.agentRuntime.steer(sessionId, msg.content);
-        } catch (err) {
-          if (!active.has(sessionId)) continue;
-          log.warn("Steer failed", { sessionId, error: err instanceof Error ? err.message : String(err) });
-        }
-        log.info("Dispatched", { agentId: msg.agentId, sessionId, state: "steered" });
-        return { sessionId, state: "steered" };
-      }
-
-      let resolveReady!: () => void;
-      const ready = new Promise<void>((r) => { resolveReady = r; });
-      const handle: ActiveHandle = { ready, resolveReady };
-      active.set(sessionId, handle);
-      void triggerRun(sessionId, msg, handle);
-      await handle.ready;
-      log.info("Dispatched", { agentId: msg.agentId, sessionId, state: "new_run" });
-      return { sessionId, state: "new_run" };
+    if (active.has(sessionId)) {
+      throw new Error(`Session ${sessionId} already has an in-flight run; use trySteer or serialize via a queue`);
     }
+    const keyIndex = `${msg.agentId}::${msg.sessionKey}`;
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((r) => { resolveReady = r; });
+    const handle: ActiveHandle = { ready, resolveReady, keyIndex };
+    active.set(sessionId, handle);
+    activeByKey.set(keyIndex, sessionId);
+    void triggerRun(sessionId, msg, handle);
+    await handle.ready;
+    log.info("Dispatched", { agentId: msg.agentId, sessionId });
+    return { sessionId };
+  }
+
+  /** Synchronous in-turn steer. Returns true iff the message was queued into
+   *  an active run's current turn; false if no active run, the runner doesn't
+   *  support steer, or the run isn't currently streaming.
+   *
+   *  Synchronous by design: callers must be able to atomically decide
+   *  "leader-vs-steer" without an await window where the run could end. */
+  function trySteer(agentId: string, sessionKey: string, content: string): boolean {
+    const sessionId = activeByKey.get(`${agentId}::${sessionKey}`);
+    if (!sessionId) return false;
+    return deps.agentRuntime.trySteer(sessionId, content);
   }
 
   async function dispatchAndWait(msg: Message): Promise<AwaitResult> {
@@ -268,6 +274,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
 
   return {
     dispatch,
+    trySteer,
     dispatchAndWait,
     abort,
     abortByKey,

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -23,21 +23,18 @@ export interface GatewayDeps {
   sessionStoreManager: SessionStoreManager;
 }
 
-// `ready` resolves once the runner has emitted its first event, so dispatch's
-// caller is guaranteed any post-return subscribe() call still sees the run.
+// `ready` resolves on the run's first event so dispatch's caller can safely
+// subscribe() after return without missing the early stream.
 interface ActiveHandle {
   ready: Promise<void>;
   resolveReady: () => void;
-  /** Composite key `${agentId}::${sessionKey}` — used to clean the secondary
-   *  index in triggerRun's finally without re-deriving from msg. */
+  /** `${agentId}::${sessionKey}` — for cleaning activeByKey in finally. */
   keyIndex: string;
 }
 
 export function createGateway(deps: GatewayDeps): Gateway {
   const active = new Map<string, ActiveHandle>();
-  // Secondary index: `${agentId}::${sessionKey}` → sessionId. Lets trySteer()
-  // be fully synchronous (no async store lookup). Kept in lock-step with
-  // `active`: written in dispatch, deleted in triggerRun's finally.
+  // `${agentId}::${sessionKey}` → sessionId. Lets trySteer be fully sync.
   const activeByKey = new Map<string, string>();
   // sessionId -> external subscribers (fan-out targets for emit()).
   const listeners = new Map<string, Set<SessionEventListener>>();
@@ -163,12 +160,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
     return { sessionId };
   }
 
-  /** Synchronous in-turn steer. Returns true iff the message was queued into
-   *  an active run's current turn; false if no active run, the runner doesn't
-   *  support steer, or the run isn't currently streaming.
-   *
-   *  Synchronous by design: callers must be able to atomically decide
-   *  "leader-vs-steer" without an await window where the run could end. */
+  /** Sync in-turn steer; see Gateway.trySteer. */
   function trySteer(agentId: string, sessionKey: string, content: string): boolean {
     const sessionId = activeByKey.get(`${agentId}::${sessionKey}`);
     if (!sessionId) return false;

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -23,7 +23,6 @@ export interface Message {
 
 export interface DispatchResult {
   sessionId: string;
-  state: "new_run" | "steered";
 }
 
 export interface CreateSessionResult {
@@ -50,9 +49,18 @@ export interface AwaitResult {
 }
 
 export interface Gateway {
-  /** Fire-and-forget. Resolves once Gateway knows new_run vs steered.
-   *  Events flow exclusively through subscribe(). */
+  /** Fire-and-forget. Resolves once the run is registered and emitting.
+   *  Throws if a run is already in flight for the same session — callers
+   *  must serialize (e.g. KeyedAsyncQueue per session) or use trySteer
+   *  first. Events flow exclusively through subscribe(). */
   dispatch(msg: Message): Promise<DispatchResult>;
+
+  /** Synchronous in-turn steer. Returns true iff the content was queued
+   *  into an active run's current turn (so the existing subscriber will
+   *  deliver the reply). Returns false if no active run, or the runner
+   *  doesn't support steer, or the run isn't currently streaming —
+   *  callers should then fall back to enqueueing a new dispatch. */
+  trySteer(agentId: string, sessionKey: string, content: string): boolean;
 
   /** Convenience: dispatch + subscribe + wait for agent_end, returns final text. */
   dispatchAndWait(msg: Message): Promise<AwaitResult>;

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -50,16 +50,13 @@ export interface AwaitResult {
 
 export interface Gateway {
   /** Fire-and-forget. Resolves once the run is registered and emitting.
-   *  Throws if a run is already in flight for the same session — callers
-   *  must serialize (e.g. KeyedAsyncQueue per session) or use trySteer
-   *  first. Events flow exclusively through subscribe(). */
+   *  Throws if the same session already has a run in flight — callers must
+   *  serialize (e.g. KeyedAsyncQueue) or steer via trySteer first. */
   dispatch(msg: Message): Promise<DispatchResult>;
 
-  /** Synchronous in-turn steer. Returns true iff the content was queued
-   *  into an active run's current turn (so the existing subscriber will
-   *  deliver the reply). Returns false if no active run, or the runner
-   *  doesn't support steer, or the run isn't currently streaming —
-   *  callers should then fall back to enqueueing a new dispatch. */
+  /** Sync in-turn steer. Returns true iff the content was queued into the
+   *  active turn; false if no active run or it's not currently streaming.
+   *  On false, fall back to dispatch. */
   trySteer(agentId: string, sessionKey: string, content: string): boolean;
 
   /** Convenience: dispatch + subscribe + wait for agent_end, returns final text. */

--- a/src/http/sessions.ts
+++ b/src/http/sessions.ts
@@ -89,7 +89,7 @@ export function registerSessionRoutes(app: Hono, deps: ApiDeps): void {
       content: body.message,
       source: "tui",
     });
-    return c.json({ sessionId: result.sessionId, state: result.state });
+    return c.json({ sessionId: result.sessionId });
   });
 
   app.post("/api/sessions/:agentId/:key/abort", async (c) => {

--- a/src/http/test-helpers.ts
+++ b/src/http/test-helpers.ts
@@ -9,6 +9,7 @@ export function createStubGateway(overrides: Partial<Gateway> = {}): Gateway {
   };
   return {
     dispatch: notImpl("dispatch") as Gateway["dispatch"],
+    trySteer: () => false,
     dispatchAndWait: notImpl("dispatchAndWait") as Gateway["dispatchAndWait"],
     abort: async () => {},
     abortByKey: async () => false,

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -30,7 +30,6 @@ export interface SessionInfo {
 
 export interface DispatchResult {
   sessionId: string;
-  state: "new_run" | "steered";
 }
 
 export type Screen = "chat" | "status" | "sessions";

--- a/src/utils/keyed-async-queue.test.ts
+++ b/src/utils/keyed-async-queue.test.ts
@@ -29,7 +29,6 @@ describe("KeyedAsyncQueue", () => {
       order.push("t2:end");
     });
 
-    // t2 must not start until t1 finishes.
     await new Promise((r) => setTimeout(r, 5));
     expect(order).toEqual(["t1:start"]);
 
@@ -62,7 +61,6 @@ describe("KeyedAsyncQueue", () => {
     });
 
     await new Promise((r) => setTimeout(r, 5));
-    // Both started without waiting on each other.
     expect(order).toEqual(["a:start", "b:start"]);
 
     dB.resolve();
@@ -85,7 +83,6 @@ describe("KeyedAsyncQueue", () => {
     });
     await expect(p1).rejects.toThrow("boom");
 
-    // Next task on the same key still runs.
     const p2 = q.enqueue("k", async () => "ok");
     expect(await p2).toBe("ok");
   });

--- a/src/utils/keyed-async-queue.test.ts
+++ b/src/utils/keyed-async-queue.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { KeyedAsyncQueue } from "./keyed-async-queue.js";
+
+function deferred<T = void>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("KeyedAsyncQueue", () => {
+  it("serializes tasks for the same key", async () => {
+    const q = new KeyedAsyncQueue();
+    const order: string[] = [];
+    const d1 = deferred();
+    const d2 = deferred();
+
+    const p1 = q.enqueue("k", async () => {
+      order.push("t1:start");
+      await d1.promise;
+      order.push("t1:end");
+    });
+    const p2 = q.enqueue("k", async () => {
+      order.push("t2:start");
+      await d2.promise;
+      order.push("t2:end");
+    });
+
+    // t2 must not start until t1 finishes.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(order).toEqual(["t1:start"]);
+
+    d1.resolve();
+    await p1;
+    // Yield once so t2's chained .then(task) fires and t2 enters its body.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(order).toEqual(["t1:start", "t1:end", "t2:start"]);
+
+    d2.resolve();
+    await p2;
+    expect(order).toEqual(["t1:start", "t1:end", "t2:start", "t2:end"]);
+  });
+
+  it("runs different keys concurrently", async () => {
+    const q = new KeyedAsyncQueue();
+    const order: string[] = [];
+    const dA = deferred();
+    const dB = deferred();
+
+    const pA = q.enqueue("a", async () => {
+      order.push("a:start");
+      await dA.promise;
+      order.push("a:end");
+    });
+    const pB = q.enqueue("b", async () => {
+      order.push("b:start");
+      await dB.promise;
+      order.push("b:end");
+    });
+
+    await new Promise((r) => setTimeout(r, 5));
+    // Both started without waiting on each other.
+    expect(order).toEqual(["a:start", "b:start"]);
+
+    dB.resolve();
+    await pB;
+    dA.resolve();
+    await pA;
+    expect(order.sort()).toEqual(["a:end", "a:start", "b:end", "b:start"]);
+  });
+
+  it("returns the task's resolved value", async () => {
+    const q = new KeyedAsyncQueue();
+    const value = await q.enqueue("k", async () => 42);
+    expect(value).toBe(42);
+  });
+
+  it("propagates a task error to its caller without breaking the queue", async () => {
+    const q = new KeyedAsyncQueue();
+    const p1 = q.enqueue("k", async () => {
+      throw new Error("boom");
+    });
+    await expect(p1).rejects.toThrow("boom");
+
+    // Next task on the same key still runs.
+    const p2 = q.enqueue("k", async () => "ok");
+    expect(await p2).toBe("ok");
+  });
+
+  it("cleans up the tail map when a key's chain drains", async () => {
+    const q = new KeyedAsyncQueue();
+    await q.enqueue("k", async () => undefined);
+    // Allow the cleanup .then callback to fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(q.has("k")).toBe(false);
+  });
+});

--- a/src/utils/keyed-async-queue.ts
+++ b/src/utils/keyed-async-queue.ts
@@ -1,0 +1,28 @@
+/** FIFO per key; different keys run concurrently. */
+export class KeyedAsyncQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  enqueue<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    const current = previous.then(task);
+    const tail = current.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(key, tail);
+    const cleanup = () => {
+      if (this.tails.get(key) === tail) this.tails.delete(key);
+    };
+    tail.then(cleanup, cleanup);
+    return current;
+  }
+
+  has(key: string): boolean {
+    return this.tails.has(key);
+  }
+
+  /** Drop bookkeeping; in-flight tasks keep running. */
+  clear(): void {
+    this.tails.clear();
+  }
+}


### PR DESCRIPTION
Closes #865 (duplicated assistant replies on concurrent Discord messages) and adds first-class in-turn steering for active runs.

## Background

When two Discord messages arrived concurrently for the same session, the inbound pipeline subscribed two listeners to the same gateway sessionId. Gateway's fan-out then emitted every \`text_delta\` to both listeners, so the assistant reply was sent to Discord twice.

Previous attempts at fixing this (PR #865 and successor) hit two structural problems:

1. **Race window** in protocol-based approaches: any \`get(inflight) / build / subscribe / set(inflight)\` sequence has multiple \`await\` points between the check and the registration. Concurrent inbound observed the dedupe Map as empty and both went on to subscribe.
2. **Async \`runtime.steer\`** had a race with pi's agent-loop: \`Agent.steer()\` is fire-and-forget. If you called it after pi decided to stop but before \`active.delete\`, the message was silently dropped — the queue would never be drained.

## Design

Modeled on openclaw's approach. Two layers:

### 1) Sync in-turn steer (best path)

When an active run is currently streaming the same session, route the new message into pi's steering queue via a **synchronous** fast path. The active run's existing subscriber delivers the reply, so no new subscriber is created and no fan-out occurs.

\`\`\`
PiRunner.run() registers a sync closure:
  steer = (content) => {
    if (!session.agent.state.isStreaming) return false
    session.agent.steer({ ... })   // sync enqueue
    return true
  }

runtime.trySteer(sessionId, content): boolean
  = runs.get(sessionId)?.steer?.(content) ?? false

gateway.trySteer(agentId, sessionKey, content): boolean
  = sessionId = activeByKey.get(\`\${agentId}::\${sessionKey}\`)
    return runtime.trySteer(sessionId, content)
\`\`\`

The whole \`isStreaming\` check + \`agent.steer\` call is one synchronous expression — JS single-thread guarantees the agent-loop can't interleave between them. This closes the race window that plagued \`async runtime.steer\`.

### 2) Per-session FIFO queue (fallback)

When fast path returns \`false\` (no active run, run not streaming, message has attachments, etc.), the inbound falls back to a \`KeyedAsyncQueue\` keyed by \`\${agentId}::\${sessionKey}\`. This serializes concurrent inbound on the same session, so a single channel never has two subscribers racing the same gateway sessionId.

\`\`\`
dispatchInbound(msg):
  preflight (dedupe, /stop, history.append)
  
  // Fast path
  if (cleanedText && !hasAttachments) {
    framedContent = inbound_meta + cleanedText
    if (gateway.trySteer(agentId, sessionKey, framedContent)) return
  }
  
  // Slow path
  await inboundQueue.enqueue(\`\${agentId}::\${sessionKey}\`, () =>
    handleInbound(...)
  )
\`\`\`

## Cleanup along the way

- \`gateway.dispatch\` is now always-new_run; throws on concurrent dispatch for the same session (callers must serialize via \`trySteer\` + queue).
- \`DispatchResult.state\` dropped — there's only one outcome now.
- \`runtime.steer()\` (the async version) removed; \`trySteer\` is the API.
- \`handleInbound\` no longer takes a steered/new_run-aware code path.
- \`heartbeat.ts\` comment about \"gateway's steer absorbs the next tick\" — no longer accurate; updated to describe the \`isRunning\` gate.

## Race analysis

The remaining race surface, by path:

| Scenario | Outcome |
|---|---|
| msg2 during active streaming, fast-path hit | Steered into in-turn queue ✅ |
| msg2 during \`agent-loop\` stop decision (~5ms window) | \`isStreaming\` is false → fast-path returns false → enqueued → runs as next turn ✅ |
| msg2 concurrent with msg1 leader, both pre-streaming | Both observe \`activeByKey\` empty → fast-path returns false for both → both go to queue, run serially ✅ |
| msg2 with attachments | Skips fast-path → queue ✅ |

No silent drops. Either steers cleanly or falls back to the queue.

## Test plan

- [x] \`pnpm run typecheck\` — passes
- [x] \`pnpm run lint\` — passes  
- [x] \`pnpm run test\` — 427/428 passes (1 unrelated network failure in \`tests/e2e-smoke.test.ts > web_fetch tool\` hitting httpbin.org)
- [x] \`KeyedAsyncQueue\`: 5 unit tests
- [x] \`runtime.trySteer\`: 4 unit tests
- [x] \`gateway\`: throws on concurrent dispatch; \`trySteer\` boolean paths; \`trySteer\` returns false after run ends
- [x] Discord channel: 
  - #865 regression: 3 concurrent messages → peak listener count = 1, all 3 dispatched. Verified the test fails if \`queue.enqueue\` is bypassed (peak = 3, reproducing the original bug).
  - Different sessions parallel: peak = 2
  - Fast-path success: no subscribe, no dispatch
  - Fast-path miss: subscribe + dispatch

## What this is not

- Not openclaw's \`steer-backlog\` mode (double-delivery via followup queue as a backup). That's a separate product decision — this PR's fast path is sync-atomic so it doesn't need it.
- Not configurable mode (steer / collect / interrupt). Just one behavior: try sync steer, otherwise queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)